### PR TITLE
Add systemd user service for daemon auto-start

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.18)
 project(GPUAudioUpsampler LANGUAGES CXX CUDA)
 
+# Standard install directories (bin, lib, etc.)
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CUDA_STANDARD 17)
@@ -149,5 +152,12 @@ if(NOT DEFINED SYSTEMD_USER_UNIT_DIR)
         set(SYSTEMD_USER_UNIT_DIR "${CMAKE_INSTALL_PREFIX}/lib/systemd/user")
     endif()
 endif()
-install(FILES systemd/gpu-upsampler@.service
+
+# Generate service file with correct install paths
+configure_file(
+    systemd/gpu-upsampler.service.in
+    ${CMAKE_BINARY_DIR}/gpu-upsampler.service
+    @ONLY
+)
+install(FILES ${CMAKE_BINARY_DIR}/gpu-upsampler.service
         DESTINATION "${SYSTEMD_USER_UNIT_DIR}")

--- a/systemd/gpu-upsampler.service.in
+++ b/systemd/gpu-upsampler.service.in
@@ -8,8 +8,7 @@ BindsTo=pipewire.service
 
 [Service]
 Type=simple
-WorkingDirectory=/home/%i/Working/gpu_os
-ExecStart=/home/%i/Working/gpu_os/build/gpu_upsampler_alsa
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/gpu_upsampler_alsa
 ExecReload=/bin/kill -HUP $MAINPID
 
 # Restart policy


### PR DESCRIPTION
## Summary
- systemdユーザーサービス `gpu-upsampler@.service` を追加
- PipeWireパターンに準拠（BindsTo, After, セキュリティハードニング）
- `cmake --install` でインストール可能

## Usage
```bash
cmake --install build
systemctl --user enable gpu-upsampler@$USER
systemctl --user start gpu-upsampler@$USER
journalctl --user -u gpu-upsampler@$USER -f  # ログ確認
```

## Test plan
- [ ] `cmake --install build` でサービスファイルがインストールされることを確認
- [ ] `systemctl --user enable/start` で起動することを確認
- [ ] PipeWire停止時に連動して停止することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)