### PR TITLE
Fix systemd service paths and install data files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,16 @@ install(TARGETS gpu_upsampler_alsa DESTINATION bin)
 install(TARGETS gpu_upsampler_core DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include/gpu_upsampler)
 
+# Install data files (filter coefficients and default config)
+# These are required at runtime and referenced by relative paths
+set(GPU_UPSAMPLER_DATADIR "${CMAKE_INSTALL_FULL_DATADIR}/gpu_upsampler")
+install(DIRECTORY data/coefficients
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/gpu_upsampler/data"
+        FILES_MATCHING PATTERN "*.bin" PATTERN "*.json")
+install(FILES config.json
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/gpu_upsampler"
+        OPTIONAL)  # Optional: user may not have config.json yet
+
 # Install systemd user service file
 # Default location: /usr/lib/systemd/user/ (system-wide for all users)
 # User can override with -DSYSTEMD_USER_UNIT_DIR=...

--- a/systemd/gpu-upsampler.service.in
+++ b/systemd/gpu-upsampler.service.in
@@ -8,6 +8,7 @@ BindsTo=pipewire.service
 
 [Service]
 Type=simple
+WorkingDirectory=@CMAKE_INSTALL_FULL_DATADIR@/gpu_upsampler
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/gpu_upsampler_alsa
 ExecReload=/bin/kill -HUP $MAINPID
 


### PR DESCRIPTION
## Summary
- Add `WorkingDirectory` to systemd service for relative path resolution
- Install `data/coefficients/` to `share/gpu_upsampler/data/`
- Install `config.json` to `share/gpu_upsampler/` (optional)

## Problem
The systemd service was starting with `/` as working directory, causing the daemon to fail when looking for:
- `config.json`
- `data/coefficients/filter_*.bin`

The daemon would exit with "Config error: Filter file not found" and enter a restart loop.

## Solution
1. Set `WorkingDirectory` in service file to the installed data location
2. Add CMake install rules for required runtime files

## Install structure
```
/usr/local/
├── bin/gpu_upsampler_alsa
├── share/gpu_upsampler/
│   ├── config.json (optional)
│   └── data/coefficients/*.bin
└── lib/systemd/user/gpu-upsampler.service
```

## Test plan
- [ ] `cmake --install build` installs data files
- [ ] `systemctl --user start gpu-upsampler` succeeds
- [ ] Daemon finds filter coefficients at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)