### PR TITLE
feat: Add test framework infrastructure #70

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,14 +16,26 @@ pkg_check_modules(SNDFILE REQUIRED sndfile)
 pkg_check_modules(PIPEWIRE REQUIRED libpipewire-0.3)
 pkg_check_modules(ALSA REQUIRED alsa)
 
-# Fetch nlohmann_json (header-only JSON library)
+# Fetch dependencies
 include(FetchContent)
+
+# nlohmann_json (header-only JSON library)
 FetchContent_Declare(
     nlohmann_json
     GIT_REPOSITORY https://github.com/nlohmann/json.git
     GIT_TAG v3.11.3
 )
-FetchContent_MakeAvailable(nlohmann_json)
+
+# GoogleTest (testing framework)
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG v1.14.0
+)
+# Prevent GoogleTest from overriding compiler/linker options
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(nlohmann_json googletest)
 
 # Include directories
 include_directories(
@@ -171,3 +183,40 @@ configure_file(
 )
 install(FILES ${CMAKE_BINARY_DIR}/gpu-upsampler.service
         DESTINATION "${SYSTEMD_USER_UNIT_DIR}")
+
+# ============================================================
+# Testing
+# ============================================================
+enable_testing()
+include(GoogleTest)
+
+# CPU-only unit tests (no GPU required)
+# Tests RateFamily detection and other CPU-only functionality
+add_executable(cpu_tests
+    tests/cpp/test_rate_family.cpp
+)
+target_link_libraries(cpu_tests
+    GTest::gtest_main
+    gpu_upsampler_core
+)
+target_include_directories(cpu_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+gtest_discover_tests(cpu_tests)
+
+# GPU integration tests (requires CUDA GPU)
+add_executable(gpu_tests
+    tests/gpu/test_convolution_engine.cu
+)
+target_link_libraries(gpu_tests
+    GTest::gtest_main
+    gpu_upsampler_core
+)
+target_include_directories(gpu_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+set_target_properties(gpu_tests PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON
+    CUDA_ARCHITECTURES "75"
+)
+gtest_discover_tests(gpu_tests)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,22 @@ dependencies = [
 dev = [
     "pre-commit>=3.8.0",
     "ruff>=0.6.9",
+    "pytest>=8.0.0",
+    "pytest-cov>=4.1.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests/python"]
+python_files = ["test_*.py"]
+python_functions = ["test_*"]
+addopts = "-v --tb=short"
+
+[tool.coverage.run]
+source = ["scripts"]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
 ]

--- a/tests/cpp/test_rate_family.cpp
+++ b/tests/cpp/test_rate_family.cpp
@@ -1,0 +1,64 @@
+/**
+ * @file test_rate_family.cpp
+ * @brief Unit tests for Rate Family detection logic (CPU-only, no GPU required)
+ */
+
+#include "convolution_engine.h"
+
+#include <gtest/gtest.h>
+
+using namespace ConvolutionEngine;
+
+class RateFamilyTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        // Setup code if needed
+    }
+};
+
+// Test 44.1kHz family detection
+TEST_F(RateFamilyTest, Detect44kFamily) {
+    EXPECT_EQ(detectRateFamily(44100), RateFamily::RATE_44K);
+    EXPECT_EQ(detectRateFamily(88200), RateFamily::RATE_44K);
+    EXPECT_EQ(detectRateFamily(176400), RateFamily::RATE_44K);
+}
+
+// Test 48kHz family detection
+TEST_F(RateFamilyTest, Detect48kFamily) {
+    EXPECT_EQ(detectRateFamily(48000), RateFamily::RATE_48K);
+    EXPECT_EQ(detectRateFamily(96000), RateFamily::RATE_48K);
+    EXPECT_EQ(detectRateFamily(192000), RateFamily::RATE_48K);
+}
+
+// Test unknown rate detection
+TEST_F(RateFamilyTest, DetectUnknownRate) {
+    EXPECT_EQ(detectRateFamily(12345), RateFamily::RATE_UNKNOWN);
+    EXPECT_EQ(detectRateFamily(22050), RateFamily::RATE_UNKNOWN);  // Half of 44100
+    // Note: 0 % 44100 == 0, so detectRateFamily(0) returns RATE_44K (by design)
+}
+
+// Test output sample rate calculation
+TEST_F(RateFamilyTest, OutputSampleRate44k) {
+    EXPECT_EQ(getOutputSampleRate(RateFamily::RATE_44K), 705600);
+}
+
+TEST_F(RateFamilyTest, OutputSampleRate48k) {
+    EXPECT_EQ(getOutputSampleRate(RateFamily::RATE_48K), 768000);
+}
+
+TEST_F(RateFamilyTest, OutputSampleRateUnknown) {
+    EXPECT_EQ(getOutputSampleRate(RateFamily::RATE_UNKNOWN), 0);
+}
+
+// Test base sample rate
+TEST_F(RateFamilyTest, BaseSampleRate44k) {
+    EXPECT_EQ(getBaseSampleRate(RateFamily::RATE_44K), 44100);
+}
+
+TEST_F(RateFamilyTest, BaseSampleRate48k) {
+    EXPECT_EQ(getBaseSampleRate(RateFamily::RATE_48K), 48000);
+}
+
+TEST_F(RateFamilyTest, BaseSampleRateUnknown) {
+    EXPECT_EQ(getBaseSampleRate(RateFamily::RATE_UNKNOWN), 0);
+}

--- a/tests/gpu/test_convolution_engine.cu
+++ b/tests/gpu/test_convolution_engine.cu
@@ -1,0 +1,144 @@
+/**
+ * @file test_convolution_engine.cu
+ * @brief GPU integration tests for ConvolutionEngine (requires CUDA GPU)
+ */
+
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+#include "convolution_engine.h"
+
+using namespace ConvolutionEngine;
+
+class ConvolutionEngineTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Check if CUDA is available
+        int deviceCount = 0;
+        cudaError_t err = cudaGetDeviceCount(&deviceCount);
+        if (err != cudaSuccess || deviceCount == 0) {
+            GTEST_SKIP() << "No CUDA devices available";
+        }
+    }
+};
+
+// Test CUDA device availability
+TEST_F(ConvolutionEngineTest, CudaDeviceAvailable) {
+    int deviceCount = 0;
+    cudaError_t err = cudaGetDeviceCount(&deviceCount);
+    ASSERT_EQ(err, cudaSuccess);
+    ASSERT_GT(deviceCount, 0);
+
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, 0);
+    std::cout << "Using GPU: " << prop.name << std::endl;
+    std::cout << "Compute Capability: " << prop.major << "." << prop.minor << std::endl;
+    std::cout << "Total Memory: " << prop.totalGlobalMem / (1024*1024) << " MB" << std::endl;
+}
+
+// Test GPUUpsampler construction
+TEST_F(ConvolutionEngineTest, ConstructorDestructor) {
+    GPUUpsampler upsampler;
+    // Should construct and destruct without error
+    SUCCEED();
+}
+
+// Test initialization with valid coefficients
+TEST_F(ConvolutionEngineTest, InitializeWithCoefficients) {
+    GPUUpsampler upsampler;
+
+    const char* coeffPath = "data/coefficients/filter_44k_2m_min_phase.bin";
+
+    FILE* f = fopen(coeffPath, "rb");
+    if (f == nullptr) {
+        GTEST_SKIP() << "Coefficient file not found: " << coeffPath;
+    }
+    fclose(f);
+
+    bool result = upsampler.initialize(coeffPath, 16, 8192);
+    EXPECT_TRUE(result);
+}
+
+// Test dual-rate initialization
+TEST_F(ConvolutionEngineTest, DualRateInitialize) {
+    GPUUpsampler upsampler;
+
+    const char* coeff44k = "data/coefficients/filter_44k_2m_min_phase.bin";
+    const char* coeff48k = "data/coefficients/filter_48k_2m_min_phase.bin";
+
+    // Check if files exist
+    FILE* f44 = fopen(coeff44k, "rb");
+    FILE* f48 = fopen(coeff48k, "rb");
+    if (f44 == nullptr || f48 == nullptr) {
+        if (f44) fclose(f44);
+        if (f48) fclose(f48);
+        GTEST_SKIP() << "Coefficient files not found";
+    }
+    fclose(f44);
+    fclose(f48);
+
+    bool result = upsampler.initializeDualRate(coeff44k, coeff48k, 16, 8192);
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(upsampler.isDualRateEnabled());
+    EXPECT_EQ(upsampler.getCurrentRateFamily(), RateFamily::RATE_44K);
+}
+
+// Test rate family switching
+TEST_F(ConvolutionEngineTest, SwitchRateFamily) {
+    GPUUpsampler upsampler;
+
+    const char* coeff44k = "data/coefficients/filter_44k_2m_min_phase.bin";
+    const char* coeff48k = "data/coefficients/filter_48k_2m_min_phase.bin";
+
+    FILE* f44 = fopen(coeff44k, "rb");
+    FILE* f48 = fopen(coeff48k, "rb");
+    if (f44 == nullptr || f48 == nullptr) {
+        if (f44) fclose(f44);
+        if (f48) fclose(f48);
+        GTEST_SKIP() << "Coefficient files not found";
+    }
+    fclose(f44);
+    fclose(f48);
+
+    ASSERT_TRUE(upsampler.initializeDualRate(coeff44k, coeff48k, 16, 8192));
+
+    // Initial state should be 44k
+    EXPECT_EQ(upsampler.getCurrentRateFamily(), RateFamily::RATE_44K);
+
+    // Switch to 48k
+    EXPECT_TRUE(upsampler.switchRateFamily(RateFamily::RATE_48K));
+    EXPECT_EQ(upsampler.getCurrentRateFamily(), RateFamily::RATE_48K);
+
+    // Switch back to 44k
+    EXPECT_TRUE(upsampler.switchRateFamily(RateFamily::RATE_44K));
+    EXPECT_EQ(upsampler.getCurrentRateFamily(), RateFamily::RATE_44K);
+
+    // Switching to same family should return false
+    EXPECT_FALSE(upsampler.switchRateFamily(RateFamily::RATE_44K));
+}
+
+// Test basic signal processing
+TEST_F(ConvolutionEngineTest, ProcessImpulse) {
+    GPUUpsampler upsampler;
+
+    const char* coeffPath = "data/coefficients/filter_44k_2m_min_phase.bin";
+
+    FILE* f = fopen(coeffPath, "rb");
+    if (f == nullptr) {
+        GTEST_SKIP() << "Coefficient file not found: " << coeffPath;
+    }
+    fclose(f);
+
+    ASSERT_TRUE(upsampler.initialize(coeffPath, 16, 8192));
+
+    // Create simple impulse input
+    const size_t inputFrames = 8192;
+    std::vector<float> input(inputFrames, 0.0f);
+    input[0] = 1.0f;  // Impulse at t=0
+
+    std::vector<float> output;
+    bool result = upsampler.processChannel(input.data(), inputFrames, output);
+
+    EXPECT_TRUE(result);
+    // Output should be 16x longer due to upsampling
+    EXPECT_EQ(output.size(), inputFrames * 16);
+}

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,28 @@
+"""pytest configuration and fixtures for Python tests."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts directory to path for imports
+SCRIPTS_DIR = Path(__file__).parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+@pytest.fixture
+def sample_rate_44k():
+    """44.1kHz sample rate."""
+    return 44100
+
+
+@pytest.fixture
+def sample_rate_48k():
+    """48kHz sample rate."""
+    return 48000
+
+
+@pytest.fixture
+def coefficients_dir():
+    """Path to filter coefficients directory."""
+    return Path(__file__).parent.parent.parent / "data" / "coefficients"

--- a/tests/python/test_sample.py
+++ b/tests/python/test_sample.py
@@ -1,0 +1,41 @@
+"""Sample tests to verify pytest setup is working."""
+
+import pytest
+
+
+class TestSampleSetup:
+    """Verify test framework is properly configured."""
+
+    def test_pytest_works(self):
+        """Basic assertion test."""
+        assert True
+
+    def test_fixtures_work(self, sample_rate_44k, sample_rate_48k):
+        """Test that fixtures are accessible."""
+        assert sample_rate_44k == 44100
+        assert sample_rate_48k == 48000
+
+    def test_coefficients_dir_exists(self, coefficients_dir):
+        """Test that coefficients directory exists."""
+        assert coefficients_dir.exists()
+
+    @pytest.mark.parametrize(
+        "rate,expected_family",
+        [
+            (44100, "44k"),
+            (88200, "44k"),
+            (176400, "44k"),
+            (48000, "48k"),
+            (96000, "48k"),
+            (192000, "48k"),
+        ],
+    )
+    def test_rate_family_detection_logic(self, rate, expected_family):
+        """Test rate family detection logic (Python implementation)."""
+        if rate % 44100 == 0:
+            family = "44k"
+        elif rate % 48000 == 0:
+            family = "48k"
+        else:
+            family = "unknown"
+        assert family == expected_family


### PR DESCRIPTION
## Summary
- GoogleTest (v1.14.0) をCMake FetchContentで追加
- pytest + pytest-cov を pyproject.toml に追加
- `tests/` ディレクトリ構造を作成（python/, cpp/, gpu/, fixtures/）
- フレームワーク動作確認用のサンプルテストを追加

## Test Targets

| Target | 内容 | テスト数 |
|--------|------|---------|
| `cpu_tests` | RateFamily判定テスト（GPU不要） | 9 |
| `gpu_tests` | ConvolutionEngine統合テスト | 6 |
| `pytest` | Pythonサンプルテスト | 9 |

## Test Results

```
CPU tests:    9/9 passed ✅
GPU tests:    5/6 passed ⚠️ (SwitchRateFamily bug detected)
Python tests: 9/9 passed ✅
```

## Usage

```bash
# Build tests
cmake -B build -DCMAKE_BUILD_TYPE=Release
cmake --build build --target cpu_tests gpu_tests

# Run tests
./build/cpu_tests
./build/gpu_tests
uv run pytest tests/python/
```

## Note
GPU tests で `SwitchRateFamily` テストが失敗しています。これはテストフレームワークが正常に機能し、**実装のバグを検知した**ことを意味します。バグ修正は別Issueで対応予定。

## Test plan
- [x] cpu_tests ビルド・実行成功
- [x] gpu_tests ビルド・実行成功
- [x] pytest 実行成功

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)