### PR TITLE
#72 Add C++ CPU unit tests for EQ and Config modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,13 +191,21 @@ enable_testing()
 include(GoogleTest)
 
 # CPU-only unit tests (no GPU required)
-# Tests RateFamily detection and other CPU-only functionality
+# Tests: RateFamily, EQ Parser, EQ to FIR, Config Loader
 add_executable(cpu_tests
     tests/cpp/test_rate_family.cpp
+    tests/cpp/test_eq_parser.cpp
+    tests/cpp/test_eq_to_fir.cpp
+    tests/cpp/test_config_loader.cpp
+    # Source files needed for tests (not in gpu_upsampler_core)
+    src/eq_parser.cpp
+    src/eq_to_fir.cpp
+    src/config_loader.cpp
 )
 target_link_libraries(cpu_tests
     GTest::gtest_main
     gpu_upsampler_core
+    nlohmann_json::nlohmann_json
 )
 target_include_directories(cpu_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/include

--- a/tests/cpp/test_config_loader.cpp
+++ b/tests/cpp/test_config_loader.cpp
@@ -1,0 +1,174 @@
+/**
+ * @file test_config_loader.cpp
+ * @brief Unit tests for config loader (JSON configuration)
+ */
+
+#include "config_loader.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+
+namespace fs = std::filesystem;
+
+class ConfigLoaderTest : public ::testing::Test {
+   protected:
+    fs::path tempDir;
+    fs::path testConfigPath;
+
+    void SetUp() override {
+        // Create temp directory for test files
+        tempDir = fs::temp_directory_path() / "gpu_upsampler_test";
+        fs::create_directories(tempDir);
+        testConfigPath = tempDir / "test_config.json";
+    }
+
+    void TearDown() override {
+        // Clean up temp files
+        fs::remove_all(tempDir);
+    }
+
+    void writeConfig(const std::string& content) {
+        std::ofstream file(testConfigPath);
+        file << content;
+        file.close();
+    }
+};
+
+// ============================================================
+// loadAppConfig tests
+// ============================================================
+
+TEST_F(ConfigLoaderTest, LoadNonExistentFileReturnsFalse) {
+    AppConfig config;
+    bool result = loadAppConfig("/nonexistent/path/config.json", config, false);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(ConfigLoaderTest, LoadNonExistentFileUsesDefaults) {
+    AppConfig config;
+    loadAppConfig("/nonexistent/path/config.json", config, false);
+
+    // Should have default values
+    EXPECT_EQ(config.alsaDevice, "hw:USB");
+    EXPECT_EQ(config.bufferSize, 262144);
+    EXPECT_EQ(config.periodSize, 32768);
+    EXPECT_EQ(config.upsampleRatio, 16);
+    EXPECT_EQ(config.blockSize, 4096);
+    EXPECT_FLOAT_EQ(config.gain, 16.0f);
+    EXPECT_EQ(config.inputSampleRate, 44100);
+    EXPECT_FALSE(config.eqEnabled);
+    EXPECT_EQ(config.eqProfilePath, "");
+}
+
+TEST_F(ConfigLoaderTest, LoadEmptyJsonReturnsTrue) {
+    writeConfig("{}");
+
+    AppConfig config;
+    bool result = loadAppConfig(testConfigPath, config, false);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(ConfigLoaderTest, LoadFullConfig) {
+    writeConfig(R"({
+        "alsaDevice": "hw:Audio",
+        "bufferSize": 131072,
+        "periodSize": 16384,
+        "upsampleRatio": 8,
+        "blockSize": 8192,
+        "gain": 8.0,
+        "filterPath": "custom/filter.bin",
+        "inputSampleRate": 48000,
+        "eqEnabled": true,
+        "eqProfilePath": "data/EQ/custom.txt"
+    })");
+
+    AppConfig config;
+    bool result = loadAppConfig(testConfigPath, config, false);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(config.alsaDevice, "hw:Audio");
+    EXPECT_EQ(config.bufferSize, 131072);
+    EXPECT_EQ(config.periodSize, 16384);
+    EXPECT_EQ(config.upsampleRatio, 8);
+    EXPECT_EQ(config.blockSize, 8192);
+    EXPECT_FLOAT_EQ(config.gain, 8.0f);
+    EXPECT_EQ(config.filterPath, "custom/filter.bin");
+    EXPECT_EQ(config.inputSampleRate, 48000);
+    EXPECT_TRUE(config.eqEnabled);
+    EXPECT_EQ(config.eqProfilePath, "data/EQ/custom.txt");
+}
+
+TEST_F(ConfigLoaderTest, LoadPartialConfigKeepsDefaults) {
+    writeConfig(R"({
+        "alsaDevice": "hw:Custom",
+        "upsampleRatio": 4
+    })");
+
+    AppConfig config;
+    loadAppConfig(testConfigPath, config, false);
+
+    // Specified values
+    EXPECT_EQ(config.alsaDevice, "hw:Custom");
+    EXPECT_EQ(config.upsampleRatio, 4);
+
+    // Default values for unspecified fields
+    EXPECT_EQ(config.bufferSize, 262144);
+    EXPECT_EQ(config.periodSize, 32768);
+    EXPECT_EQ(config.blockSize, 4096);
+    EXPECT_FLOAT_EQ(config.gain, 16.0f);
+    EXPECT_EQ(config.inputSampleRate, 44100);
+}
+
+TEST_F(ConfigLoaderTest, LoadInvalidJsonReturnsFalse) {
+    writeConfig("{ invalid json }");
+
+    AppConfig config;
+    bool result = loadAppConfig(testConfigPath, config, false);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(ConfigLoaderTest, LoadConfigWithExtraFieldsIgnoresThem) {
+    writeConfig(R"({
+        "alsaDevice": "hw:Test",
+        "unknownField": "should be ignored",
+        "anotherUnknown": 12345
+    })");
+
+    AppConfig config;
+    bool result = loadAppConfig(testConfigPath, config, false);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(config.alsaDevice, "hw:Test");
+}
+
+// ============================================================
+// AppConfig default values tests
+// ============================================================
+
+TEST_F(ConfigLoaderTest, AppConfigDefaultValues) {
+    AppConfig config;
+
+    EXPECT_EQ(config.alsaDevice, "hw:USB");
+    EXPECT_EQ(config.bufferSize, 262144);
+    EXPECT_EQ(config.periodSize, 32768);
+    EXPECT_EQ(config.upsampleRatio, 16);
+    EXPECT_EQ(config.blockSize, 4096);
+    EXPECT_FLOAT_EQ(config.gain, 16.0f);
+    EXPECT_EQ(config.filterPath, "data/coefficients/filter_1m_min_phase.bin");
+    EXPECT_EQ(config.inputSampleRate, 44100);
+    EXPECT_FALSE(config.eqEnabled);
+    EXPECT_EQ(config.eqProfilePath, "");
+}
+
+// ============================================================
+// DEFAULT_CONFIG_FILE constant test
+// ============================================================
+
+TEST_F(ConfigLoaderTest, DefaultConfigFileConstant) {
+    EXPECT_STREQ(DEFAULT_CONFIG_FILE, "config.json");
+}

--- a/tests/cpp/test_eq_parser.cpp
+++ b/tests/cpp/test_eq_parser.cpp
@@ -1,0 +1,238 @@
+/**
+ * @file test_eq_parser.cpp
+ * @brief Unit tests for EQ parser (Equalizer APO format)
+ */
+
+#include "eq_parser.h"
+
+#include <gtest/gtest.h>
+
+using namespace EQ;
+
+class EqParserTest : public ::testing::Test {
+   protected:
+    void SetUp() override {}
+};
+
+// ============================================================
+// filterTypeName tests
+// ============================================================
+
+TEST_F(EqParserTest, FilterTypeNamePK) {
+    EXPECT_STREQ(filterTypeName(FilterType::PK), "PK");
+}
+
+TEST_F(EqParserTest, FilterTypeNameLS) {
+    EXPECT_STREQ(filterTypeName(FilterType::LS), "LS");
+}
+
+TEST_F(EqParserTest, FilterTypeNameHS) {
+    EXPECT_STREQ(filterTypeName(FilterType::HS), "HS");
+}
+
+TEST_F(EqParserTest, FilterTypeNameLP) {
+    EXPECT_STREQ(filterTypeName(FilterType::LP), "LP");
+}
+
+TEST_F(EqParserTest, FilterTypeNameHP) {
+    EXPECT_STREQ(filterTypeName(FilterType::HP), "HP");
+}
+
+// ============================================================
+// parseFilterType tests
+// ============================================================
+
+TEST_F(EqParserTest, ParseFilterTypePK) {
+    EXPECT_EQ(parseFilterType("PK"), FilterType::PK);
+    EXPECT_EQ(parseFilterType("pk"), FilterType::PK);
+    EXPECT_EQ(parseFilterType("PEAK"), FilterType::PK);
+    EXPECT_EQ(parseFilterType("peaking"), FilterType::PK);
+}
+
+TEST_F(EqParserTest, ParseFilterTypeLS) {
+    EXPECT_EQ(parseFilterType("LS"), FilterType::LS);
+    EXPECT_EQ(parseFilterType("ls"), FilterType::LS);
+    EXPECT_EQ(parseFilterType("LSC"), FilterType::LS);
+    EXPECT_EQ(parseFilterType("LOWSHELF"), FilterType::LS);
+}
+
+TEST_F(EqParserTest, ParseFilterTypeHS) {
+    EXPECT_EQ(parseFilterType("HS"), FilterType::HS);
+    EXPECT_EQ(parseFilterType("hs"), FilterType::HS);
+    EXPECT_EQ(parseFilterType("HSC"), FilterType::HS);
+    EXPECT_EQ(parseFilterType("HIGHSHELF"), FilterType::HS);
+}
+
+TEST_F(EqParserTest, ParseFilterTypeLP) {
+    EXPECT_EQ(parseFilterType("LP"), FilterType::LP);
+    EXPECT_EQ(parseFilterType("LPQ"), FilterType::LP);
+    EXPECT_EQ(parseFilterType("LOWPASS"), FilterType::LP);
+}
+
+TEST_F(EqParserTest, ParseFilterTypeHP) {
+    EXPECT_EQ(parseFilterType("HP"), FilterType::HP);
+    EXPECT_EQ(parseFilterType("HPQ"), FilterType::HP);
+    EXPECT_EQ(parseFilterType("HIGHPASS"), FilterType::HP);
+}
+
+TEST_F(EqParserTest, ParseFilterTypeUnknownDefaultsToPK) {
+    EXPECT_EQ(parseFilterType("UNKNOWN"), FilterType::PK);
+    EXPECT_EQ(parseFilterType(""), FilterType::PK);
+}
+
+// ============================================================
+// EqProfile tests
+// ============================================================
+
+TEST_F(EqParserTest, EqProfileIsEmptyWhenNoBands) {
+    EqProfile profile;
+    EXPECT_TRUE(profile.isEmpty());
+}
+
+TEST_F(EqParserTest, EqProfileIsEmptyWithPreampOnly) {
+    EqProfile profile;
+    profile.preampDb = -5.0;
+    EXPECT_FALSE(profile.isEmpty());
+}
+
+TEST_F(EqParserTest, EqProfileIsNotEmptyWithBands) {
+    EqProfile profile;
+    profile.bands.push_back(EqBand{});
+    EXPECT_FALSE(profile.isEmpty());
+}
+
+TEST_F(EqParserTest, EqProfileActiveBandCount) {
+    EqProfile profile;
+
+    // Add 3 bands: 2 enabled, 1 disabled
+    EqBand band1;
+    band1.enabled = true;
+    profile.bands.push_back(band1);
+
+    EqBand band2;
+    band2.enabled = false;
+    profile.bands.push_back(band2);
+
+    EqBand band3;
+    band3.enabled = true;
+    profile.bands.push_back(band3);
+
+    EXPECT_EQ(profile.activeBandCount(), 2u);
+}
+
+// ============================================================
+// parseEqString tests
+// ============================================================
+
+TEST_F(EqParserTest, ParseEqStringPreampOnly) {
+    EqProfile profile;
+    std::string content = "Preamp: -5.5 dB";
+
+    EXPECT_TRUE(parseEqString(content, profile));
+    EXPECT_DOUBLE_EQ(profile.preampDb, -5.5);
+    EXPECT_TRUE(profile.bands.empty());
+}
+
+TEST_F(EqParserTest, ParseEqStringSingleFilter) {
+    EqProfile profile;
+    std::string content = "Filter 1: ON PK Fc 1000 Hz Gain -3 dB Q 1.41";
+
+    EXPECT_TRUE(parseEqString(content, profile));
+    EXPECT_EQ(profile.bands.size(), 1u);
+    EXPECT_TRUE(profile.bands[0].enabled);
+    EXPECT_EQ(profile.bands[0].type, FilterType::PK);
+    EXPECT_DOUBLE_EQ(profile.bands[0].frequency, 1000.0);
+    EXPECT_DOUBLE_EQ(profile.bands[0].gain, -3.0);
+    EXPECT_DOUBLE_EQ(profile.bands[0].q, 1.41);
+}
+
+TEST_F(EqParserTest, ParseEqStringDisabledFilter) {
+    EqProfile profile;
+    std::string content = "Filter 1: OFF PK Fc 1000 Hz Gain -3 dB Q 1.41";
+
+    EXPECT_TRUE(parseEqString(content, profile));
+    EXPECT_EQ(profile.bands.size(), 1u);
+    EXPECT_FALSE(profile.bands[0].enabled);
+}
+
+TEST_F(EqParserTest, ParseEqStringMultipleFilters) {
+    EqProfile profile;
+    std::string content = R"(
+Preamp: -6 dB
+Filter 1: ON PK Fc 100 Hz Gain 3 dB Q 0.7
+Filter 2: ON LS Fc 50 Hz Gain 2 dB Q 0.71
+Filter 3: OFF HS Fc 10000 Hz Gain -2 dB Q 0.71
+)";
+
+    EXPECT_TRUE(parseEqString(content, profile));
+    EXPECT_DOUBLE_EQ(profile.preampDb, -6.0);
+    EXPECT_EQ(profile.bands.size(), 3u);
+    EXPECT_EQ(profile.activeBandCount(), 2u);
+
+    EXPECT_EQ(profile.bands[0].type, FilterType::PK);
+    EXPECT_EQ(profile.bands[1].type, FilterType::LS);
+    EXPECT_EQ(profile.bands[2].type, FilterType::HS);
+}
+
+TEST_F(EqParserTest, ParseEqStringSkipsComments) {
+    EqProfile profile;
+    std::string content = R"(
+# This is a comment
+; This is also a comment
+Preamp: -3 dB
+# Another comment
+Filter 1: ON PK Fc 1000 Hz Gain -2 dB Q 1.0
+)";
+
+    EXPECT_TRUE(parseEqString(content, profile));
+    EXPECT_DOUBLE_EQ(profile.preampDb, -3.0);
+    EXPECT_EQ(profile.bands.size(), 1u);
+}
+
+TEST_F(EqParserTest, ParseEqStringEmptyContent) {
+    EqProfile profile;
+    std::string content = "";
+
+    EXPECT_FALSE(parseEqString(content, profile));
+}
+
+TEST_F(EqParserTest, ParseEqStringOnlyComments) {
+    EqProfile profile;
+    std::string content = R"(
+# Comment 1
+; Comment 2
+)";
+
+    EXPECT_FALSE(parseEqString(content, profile));
+}
+
+TEST_F(EqParserTest, ParseEqStringDecimalFrequency) {
+    EqProfile profile;
+    std::string content = "Filter 1: ON PK Fc 140.3 Hz Gain -2.5 dB Q 0.81";
+
+    EXPECT_TRUE(parseEqString(content, profile));
+    EXPECT_DOUBLE_EQ(profile.bands[0].frequency, 140.3);
+    EXPECT_DOUBLE_EQ(profile.bands[0].gain, -2.5);
+    EXPECT_DOUBLE_EQ(profile.bands[0].q, 0.81);
+}
+
+TEST_F(EqParserTest, ParseEqStringPositiveGain) {
+    EqProfile profile;
+    std::string content = "Filter 1: ON PK Fc 1000 Hz Gain +3 dB Q 1.0";
+
+    EXPECT_TRUE(parseEqString(content, profile));
+    EXPECT_DOUBLE_EQ(profile.bands[0].gain, 3.0);
+}
+
+// ============================================================
+// EqBand default values tests
+// ============================================================
+
+TEST_F(EqParserTest, EqBandDefaultValues) {
+    EqBand band;
+    EXPECT_TRUE(band.enabled);
+    EXPECT_EQ(band.type, FilterType::PK);
+    EXPECT_DOUBLE_EQ(band.frequency, 1000.0);
+    EXPECT_DOUBLE_EQ(band.gain, 0.0);
+    EXPECT_DOUBLE_EQ(band.q, 1.0);
+}

--- a/tests/cpp/test_eq_to_fir.cpp
+++ b/tests/cpp/test_eq_to_fir.cpp
@@ -1,0 +1,299 @@
+/**
+ * @file test_eq_to_fir.cpp
+ * @brief Unit tests for EQ to FIR conversion (biquad calculations)
+ */
+
+#include "eq_to_fir.h"
+
+#include <cmath>
+#include <gtest/gtest.h>
+
+using namespace EQ;
+
+class EqToFirTest : public ::testing::Test {
+   protected:
+    static constexpr double SAMPLE_RATE = 44100.0;
+    static constexpr double TOLERANCE = 1e-6;
+
+    void SetUp() override {}
+};
+
+// ============================================================
+// calculateBiquadCoeffs tests
+// ============================================================
+
+TEST_F(EqToFirTest, BiquadCoeffsDisabledBandReturnsUnity) {
+    EqBand band;
+    band.enabled = false;
+    band.gain = 6.0;  // Would normally boost
+
+    BiquadCoeffs c = calculateBiquadCoeffs(band, SAMPLE_RATE);
+
+    // Unity gain: b0=1, b1=b2=a1=a2=0
+    EXPECT_DOUBLE_EQ(c.b0, 1.0);
+    EXPECT_DOUBLE_EQ(c.b1, 0.0);
+    EXPECT_DOUBLE_EQ(c.b2, 0.0);
+    EXPECT_DOUBLE_EQ(c.a1, 0.0);
+    EXPECT_DOUBLE_EQ(c.a2, 0.0);
+}
+
+TEST_F(EqToFirTest, BiquadCoeffsZeroGainReturnsUnity) {
+    EqBand band;
+    band.enabled = true;
+    band.gain = 0.0;
+
+    BiquadCoeffs c = calculateBiquadCoeffs(band, SAMPLE_RATE);
+
+    EXPECT_DOUBLE_EQ(c.b0, 1.0);
+    EXPECT_DOUBLE_EQ(c.b1, 0.0);
+    EXPECT_DOUBLE_EQ(c.b2, 0.0);
+}
+
+TEST_F(EqToFirTest, BiquadCoeffsPeakingNonZero) {
+    EqBand band;
+    band.enabled = true;
+    band.type = FilterType::PK;
+    band.frequency = 1000.0;
+    band.gain = 6.0;
+    band.q = 1.41;
+
+    BiquadCoeffs c = calculateBiquadCoeffs(band, SAMPLE_RATE);
+
+    // Coefficients should be non-trivial
+    EXPECT_NE(c.b0, 1.0);
+    EXPECT_NE(c.b1, 0.0);
+    EXPECT_NE(c.b2, 0.0);
+    EXPECT_NE(c.a1, 0.0);
+    EXPECT_NE(c.a2, 0.0);
+}
+
+TEST_F(EqToFirTest, BiquadCoeffsLowShelfNonZero) {
+    EqBand band;
+    band.enabled = true;
+    band.type = FilterType::LS;
+    band.frequency = 100.0;
+    band.gain = 3.0;
+    band.q = 0.71;
+
+    BiquadCoeffs c = calculateBiquadCoeffs(band, SAMPLE_RATE);
+
+    EXPECT_NE(c.b0, 1.0);
+}
+
+TEST_F(EqToFirTest, BiquadCoeffsHighShelfNonZero) {
+    EqBand band;
+    band.enabled = true;
+    band.type = FilterType::HS;
+    band.frequency = 10000.0;
+    band.gain = -3.0;
+    band.q = 0.71;
+
+    BiquadCoeffs c = calculateBiquadCoeffs(band, SAMPLE_RATE);
+
+    EXPECT_NE(c.b0, 1.0);
+}
+
+// ============================================================
+// biquadFrequencyResponse tests
+// ============================================================
+
+TEST_F(EqToFirTest, FrequencyResponseUnityAtDCForUnityCoeffs) {
+    BiquadCoeffs unity = {1.0, 0.0, 0.0, 0.0, 0.0};
+    std::vector<double> freqs = {0.0, 100.0, 1000.0, 10000.0};
+
+    auto response = biquadFrequencyResponse(freqs, unity, SAMPLE_RATE);
+
+    for (size_t i = 0; i < response.size(); ++i) {
+        EXPECT_NEAR(std::abs(response[i]), 1.0, TOLERANCE);
+    }
+}
+
+TEST_F(EqToFirTest, FrequencyResponsePeakingHasGainAtCenter) {
+    EqBand band;
+    band.enabled = true;
+    band.type = FilterType::PK;
+    band.frequency = 1000.0;
+    band.gain = 6.0;
+    band.q = 1.41;
+
+    BiquadCoeffs c = calculateBiquadCoeffs(band, SAMPLE_RATE);
+    std::vector<double> freqs = {1000.0};
+
+    auto response = biquadFrequencyResponse(freqs, c, SAMPLE_RATE);
+    double magnitude = std::abs(response[0]);
+    double magnitudeDb = 20.0 * std::log10(magnitude);
+
+    // At center frequency, gain should be approximately the specified gain
+    EXPECT_NEAR(magnitudeDb, 6.0, 0.5);
+}
+
+TEST_F(EqToFirTest, FrequencyResponsePeakingFlatAwayFromCenter) {
+    EqBand band;
+    band.enabled = true;
+    band.type = FilterType::PK;
+    band.frequency = 1000.0;
+    band.gain = 6.0;
+    band.q = 1.41;
+
+    BiquadCoeffs c = calculateBiquadCoeffs(band, SAMPLE_RATE);
+
+    // Far from center frequency (low and high)
+    std::vector<double> freqs = {100.0, 10000.0};
+    auto response = biquadFrequencyResponse(freqs, c, SAMPLE_RATE);
+
+    // Should be close to unity (0 dB)
+    for (const auto& r : response) {
+        double magnitudeDb = 20.0 * std::log10(std::abs(r));
+        EXPECT_NEAR(magnitudeDb, 0.0, 1.0);  // Within 1 dB of flat
+    }
+}
+
+// ============================================================
+// generateR2cFftFrequencies tests
+// ============================================================
+
+TEST_F(EqToFirTest, R2cFftFrequenciesStartsAtZero) {
+    auto freqs = generateR2cFftFrequencies(513, 1024, SAMPLE_RATE);
+
+    EXPECT_DOUBLE_EQ(freqs[0], 0.0);
+}
+
+TEST_F(EqToFirTest, R2cFftFrequenciesEndsAtNyquist) {
+    size_t fftSize = 1024;
+    size_t numBins = fftSize / 2 + 1;  // 513
+    auto freqs = generateR2cFftFrequencies(numBins, fftSize, SAMPLE_RATE);
+
+    double nyquist = SAMPLE_RATE / 2.0;
+    EXPECT_NEAR(freqs.back(), nyquist, 1.0);
+}
+
+TEST_F(EqToFirTest, R2cFftFrequenciesCorrectSize) {
+    size_t fftSize = 1024;
+    size_t numBins = fftSize / 2 + 1;
+    auto freqs = generateR2cFftFrequencies(numBins, fftSize, SAMPLE_RATE);
+
+    EXPECT_EQ(freqs.size(), numBins);
+}
+
+TEST_F(EqToFirTest, R2cFftFrequenciesEvenlySpaced) {
+    size_t fftSize = 1024;
+    size_t numBins = fftSize / 2 + 1;
+    auto freqs = generateR2cFftFrequencies(numBins, fftSize, SAMPLE_RATE);
+
+    double df = SAMPLE_RATE / static_cast<double>(fftSize);
+
+    for (size_t i = 0; i < numBins; ++i) {
+        EXPECT_NEAR(freqs[i], i * df, TOLERANCE);
+    }
+}
+
+// ============================================================
+// computeEqFrequencyResponse tests
+// ============================================================
+
+TEST_F(EqToFirTest, EqFrequencyResponseEmptyProfileIsUnity) {
+    EqProfile profile;
+    std::vector<double> freqs = {100.0, 1000.0, 10000.0};
+
+    auto response = computeEqFrequencyResponse(freqs, profile, SAMPLE_RATE);
+
+    for (const auto& r : response) {
+        EXPECT_NEAR(std::abs(r), 1.0, TOLERANCE);
+    }
+}
+
+TEST_F(EqToFirTest, EqFrequencyResponsePreampApplied) {
+    EqProfile profile;
+    profile.preampDb = -6.0;  // -6dB = 0.5 linear
+    std::vector<double> freqs = {1000.0};
+
+    auto response = computeEqFrequencyResponse(freqs, profile, SAMPLE_RATE);
+
+    double expectedLinear = std::pow(10.0, -6.0 / 20.0);  // ~0.5
+    EXPECT_NEAR(std::abs(response[0]), expectedLinear, 0.01);
+}
+
+TEST_F(EqToFirTest, EqFrequencyResponseSingleBand) {
+    EqProfile profile;
+    EqBand band;
+    band.enabled = true;
+    band.type = FilterType::PK;
+    band.frequency = 1000.0;
+    band.gain = 6.0;
+    band.q = 1.41;
+    profile.bands.push_back(band);
+
+    std::vector<double> freqs = {1000.0};
+    auto response = computeEqFrequencyResponse(freqs, profile, SAMPLE_RATE);
+
+    double magnitudeDb = 20.0 * std::log10(std::abs(response[0]));
+    EXPECT_NEAR(magnitudeDb, 6.0, 0.5);
+}
+
+TEST_F(EqToFirTest, EqFrequencyResponseDisabledBandIgnored) {
+    EqProfile profile;
+    EqBand band;
+    band.enabled = false;
+    band.type = FilterType::PK;
+    band.frequency = 1000.0;
+    band.gain = 6.0;
+    band.q = 1.41;
+    profile.bands.push_back(band);
+
+    std::vector<double> freqs = {1000.0};
+    auto response = computeEqFrequencyResponse(freqs, profile, SAMPLE_RATE);
+
+    // Disabled band should result in unity response
+    EXPECT_NEAR(std::abs(response[0]), 1.0, TOLERANCE);
+}
+
+// ============================================================
+// computeEqMagnitudeForFft tests
+// ============================================================
+
+TEST_F(EqToFirTest, EqMagnitudeForFftEmptyProfileIsUnity) {
+    EqProfile profile;
+    size_t fftSize = 1024;
+    size_t numBins = fftSize / 2 + 1;
+    double outputRate = SAMPLE_RATE * 16;  // Upsampled
+
+    auto magnitude = computeEqMagnitudeForFft(numBins, fftSize, outputRate, profile);
+
+    EXPECT_EQ(magnitude.size(), numBins);
+    for (double m : magnitude) {
+        EXPECT_NEAR(m, 1.0, TOLERANCE);
+    }
+}
+
+TEST_F(EqToFirTest, EqMagnitudeForFftCorrectSize) {
+    EqProfile profile;
+    size_t fftSize = 2048;
+    size_t numBins = fftSize / 2 + 1;
+    double outputRate = SAMPLE_RATE * 16;
+
+    auto magnitude = computeEqMagnitudeForFft(numBins, fftSize, outputRate, profile);
+
+    EXPECT_EQ(magnitude.size(), numBins);
+}
+
+TEST_F(EqToFirTest, EqMagnitudeForFftAllPositive) {
+    EqProfile profile;
+    profile.preampDb = -12.0;
+    EqBand band;
+    band.enabled = true;
+    band.type = FilterType::PK;
+    band.frequency = 1000.0;
+    band.gain = -10.0;
+    band.q = 1.0;
+    profile.bands.push_back(band);
+
+    size_t fftSize = 1024;
+    size_t numBins = fftSize / 2 + 1;
+    double outputRate = SAMPLE_RATE * 16;
+
+    auto magnitude = computeEqMagnitudeForFft(numBins, fftSize, outputRate, profile);
+
+    for (double m : magnitude) {
+        EXPECT_GT(m, 0.0);
+    }
+}


### PR DESCRIPTION
## Summary
- EQ Parser, EQ to FIR, Config Loaderの包括的なC++ CPU単体テストを追加
- 62テスト全パス（既存9 + 新規53）
- 実行時間: ~5ms

## Test Coverage
| テストスイート | テスト数 | 内容 |
|---------------|----------|------|
| RateFamilyTest | 9 | レートファミリー検出（既存） |
| EqParserTest | 25 | EQ APOフォーマットパーサー |
| EqToFirTest | 19 | Biquad係数計算・周波数応答 |
| ConfigLoaderTest | 9 | JSON設定ファイル読み込み |

## Changes
- `tests/cpp/test_eq_parser.cpp`: filterTypeName, parseFilterType, parseEqString
- `tests/cpp/test_eq_to_fir.cpp`: BiquadCoeffs, frequencyResponse, R2C FFT
- `tests/cpp/test_config_loader.cpp`: JSON loading, defaults, edge cases
- `CMakeLists.txt`: cpu_testsに新テストとソースファイルを追加

## Test Results
```
[==========] Running 62 tests from 4 test suites.
[  PASSED  ] 62 tests.
```

## Test Plan
- [x] `./build/cpu_tests` で全62テストパス確認
- [x] clang-formatでフォーマット済み
- [ ] レビュー後マージ

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)