### PR TITLE
#90 Add mypy type checking to pre-push hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,20 @@ repos:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
 
+  # Pre-push: Type checking with mypy
+  # Uses system Python to access project dependencies
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy type checker
+        entry: uv run mypy
+        language: system
+        types: [python]
+        args: [--config-file=pyproject.toml]
+        stages: [pre-push]
+        pass_filenames: false
+        files: ^(scripts|web|tests/python)/.*\.py$
+
   # Pre-push: Diff-based tests
   # Only runs tests relevant to changed files
   - repo: local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-cov>=4.1.0",
     "detect-secrets>=1.5.0",
+    "mypy>=1.13.0",
 ]
 
 [tool.pytest.ini_options]
@@ -37,3 +38,14 @@ exclude_lines = [
     "pragma: no cover",
     "if __name__ == .__main__.:",
 ]
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
+no_strict_optional = true
+warn_return_any = false
+warn_unused_ignores = true
+show_error_codes = true
+# Start with relaxed settings, gradually tighten
+check_untyped_defs = false
+disallow_untyped_defs = false

--- a/scripts/plot_eq_response.py
+++ b/scripts/plot_eq_response.py
@@ -14,7 +14,7 @@ import sys
 def parse_eq_file(filepath: str) -> tuple[float, list[dict]]:
     """Parse AutoEq/Equalizer APO format EQ file."""
     preamp_db = 0.0
-    bands = []
+    bands: list[dict] = []
 
     with open(filepath, "r") as f:
         for line in f:
@@ -215,7 +215,7 @@ def compare_eq_profiles(
     fig, ax = plt.subplots(figsize=(12, 6))
 
     freqs = np.logspace(np.log10(20), np.log10(20000), 1000)
-    colors = plt.cm.tab10(np.linspace(0, 1, len(eq_files)))
+    colors = plt.cm.tab10(np.linspace(0, 1, len(eq_files)))  # type: ignore[attr-defined]
 
     for eq_file, color in zip(eq_files, colors):
         preamp_db, bands = parse_eq_file(eq_file)
@@ -254,12 +254,12 @@ if __name__ == "__main__":
 
     if len(sys.argv) > 1:
         # Plot specified file
-        eq_file = sys.argv[1]
-        output_file = output_dir / f"{Path(eq_file).stem}_response.png"
-        plot_eq_response(eq_file, str(output_file))
+        eq_file_arg = sys.argv[1]
+        output_file = output_dir / f"{Path(eq_file_arg).stem}_response.png"
+        plot_eq_response(eq_file_arg, str(output_file))
     else:
         # Plot all EQ files in data/EQ directory
-        eq_files = list(eq_dir.glob("*.txt"))
+        eq_files: list[Path] = list(eq_dir.glob("*.txt"))
 
         if not eq_files:
             print(f"No EQ files found in {eq_dir}")

--- a/scripts/test_eq_effect.py
+++ b/scripts/test_eq_effect.py
@@ -78,7 +78,7 @@ def compute_eq_response_python(
     import re
 
     preamp_db = 0.0
-    bands = []
+    bands: list[dict] = []
 
     with open(eq_file, "r") as f:
         for line in f:


### PR DESCRIPTION
## Summary

- mypy を pre-push ステージで実行する設定を追加
- 段階的導入のため緩めの設定から開始
- 既存コードの型エラーを修正

## Changes

### Pre-commit hook
```yaml
- repo: local
  hooks:
    - id: mypy
      name: mypy type checker
      entry: uv run mypy
      language: system
      types: [python]
      args: [--config-file=pyproject.toml]
      stages: [pre-push]
```

### mypy configuration (pyproject.toml)
```toml
[tool.mypy]
python_version = "3.11"
ignore_missing_imports = true
no_strict_optional = true
warn_return_any = false
warn_unused_ignores = true
show_error_codes = true
check_untyped_defs = false
disallow_untyped_defs = false
```

### Type annotation fixes
- `scripts/test_eq_effect.py`: `bands` 変数に型アノテーション追加
- `scripts/plot_eq_response.py`:
  - `bands` 変数に型アノテーション追加
  - `eq_files` 変数に型アノテーション追加
  - 変数名の競合を修正 (`eq_file` → `eq_file_arg`)
  - `plt.cm.tab10` に `# type: ignore` 追加

## Test plan

- [x] `uv run mypy scripts/ web/ tests/python/` がエラーなしで完了
- [x] `uv run pre-commit run --all-files` がパス

## Related Issues

- Closes #90 (mypy 導入)
- Parent: #87 (静的解析ツール導入)

🤖 Generated with [Claude Code](https://claude.com/claude-code)