### PR TITLE
#98 Add aqua for CLI tool version management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ env/
 .uv/
 uv.lock
 
+# aqua (local cache)
+.aqua/
+aqua-checksums.json
+
 # IDE
 .vscode/
 .idea/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,205 @@
+# Installation Guide
+
+GPU Audio Upsamplerのセットアップ手順です。
+
+## Prerequisites
+
+- Linux (Ubuntu 22.04+ 推奨)
+- NVIDIA GPU (Compute Capability 7.5+, RTX 2070以上)
+- NVIDIA Driver (535+)
+
+## Quick Start
+
+```bash
+# 1. システム依存関係のインストール (sudo必要)
+./scripts/setup-system.sh
+
+# 2. aquaのインストール (CLIツール管理)
+curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v3.0.1/aqua-installer | bash
+export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"
+
+# 3. CLIツールのインストール (cmake, uv, gh)
+aqua i
+
+# 4. Python環境のセットアップ
+uv sync
+
+# 5. フィルタ係数の生成
+uv run python scripts/generate_filter.py --taps 1000000
+
+# 6. ビルド
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j$(nproc)
+
+# 7. テスト実行
+./build/cpu_tests
+./build/gpu_tests
+```
+
+## Step-by-Step Installation
+
+### 1. システム依存関係
+
+以下のパッケージはaquaでは管理できないため、aptでインストールします：
+
+```bash
+# Ubuntu/Debian
+sudo apt update
+sudo apt install -y \
+    build-essential \
+    pkg-config \
+    nvidia-cuda-toolkit \
+    libsndfile1-dev \
+    libpipewire-0.3-dev \
+    libasound2-dev \
+    libspa-0.2-dev \
+    git
+```
+
+または、セットアップスクリプトを使用：
+
+```bash
+./scripts/setup-system.sh
+```
+
+> **Note**: このスクリプトはUbuntu/Debian、Fedora、Arch Linuxに対応しています。
+
+### 2. aqua (CLIツールマネージャー)
+
+[aqua](https://aquaproj.github.io/)を使用して、cmake, uv, ghのバージョンを固定します。
+
+```bash
+# aquaのインストール
+curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v3.0.1/aqua-installer | bash
+
+# PATHに追加 (~/.bashrc または ~/.zshrc に追記)
+export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"
+
+# シェルを再起動、または
+source ~/.bashrc  # or source ~/.zshrc
+```
+
+### 3. CLIツールのインストール
+
+```bash
+# プロジェクトディレクトリで実行
+cd /path/to/gpu_os
+aqua i
+```
+
+これにより以下がインストールされます：
+- **cmake** v3.30.0 - ビルドシステム
+- **uv** v0.5.4 - Python環境管理
+- **gh** v2.62.0 - GitHub CLI
+
+### 4. Python環境
+
+```bash
+# 依存関係のインストール
+uv sync
+
+# 開発用依存関係も含める場合
+uv sync --all-groups
+```
+
+### 5. フィルタ係数の生成
+
+```bash
+# 1M-tap minimum phase FIRフィルタを生成
+uv run python scripts/generate_filter.py --taps 1000000
+
+# 2M-tapを生成する場合 (メモリ8GB以上推奨)
+uv run python scripts/generate_filter.py --taps 2000000 --kaiser-beta 55
+```
+
+生成されるファイル：
+- `data/coefficients/filter_*_min_phase.bin` - バイナリ係数
+- `data/coefficients/filter_*_min_phase.json` - メタデータ
+- `plots/analysis/*.png` - 検証用プロット
+
+### 6. ビルド
+
+```bash
+# Release build
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j$(nproc)
+
+# Debug build (開発時)
+cmake -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build -j$(nproc)
+```
+
+### 7. 動作確認
+
+```bash
+# CPU テスト (GPU不要)
+./build/cpu_tests
+
+# GPU テスト (NVIDIA GPU必要)
+./build/gpu_tests
+
+# Python テスト
+uv run pytest
+```
+
+## Managed Tools Summary
+
+| Tool | Managed by | Version |
+|------|------------|---------|
+| cmake | aqua | 3.30.0 |
+| uv | aqua | 0.5.4 |
+| gh | aqua | 2.62.0 |
+| Python packages | uv | pyproject.toml |
+| CUDA toolkit | apt | system |
+| libsndfile | apt | system |
+| PipeWire | apt | system |
+| ALSA | apt | system |
+
+## Troubleshooting
+
+### aquaコマンドが見つからない
+
+```bash
+# PATHを確認
+echo $PATH | tr ':' '\n' | grep aqua
+
+# なければ追加
+export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"
+```
+
+### CUDA toolkit not found
+
+```bash
+# CUDAがインストールされているか確認
+nvcc --version
+nvidia-smi
+
+# なければインストール
+sudo apt install nvidia-cuda-toolkit
+```
+
+### PipeWire開発ライブラリが見つからない
+
+```bash
+# pkg-configで確認
+pkg-config --modversion libpipewire-0.3
+
+# なければインストール
+sudo apt install libpipewire-0.3-dev libspa-0.2-dev
+```
+
+## Next Steps
+
+セットアップ完了後は以下を参照：
+- [PC Development Guide](docs/setup/pc_development.md) - 実行方法の詳細
+- [Architecture Overview](docs/architecture/overview.md) - システム設計
+
+## Files Added by This Setup
+
+```
+gpu_os/
+├── aqua.yaml              # CLIツールバージョン定義
+├── scripts/
+│   └── setup-system.sh    # システム依存関係インストール
+└── INSTALL.md             # このファイル
+```

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,20 @@
+# aqua.yaml - CLI tool version management
+# https://aquaproj.github.io/
+#
+# Usage:
+#   curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v3.0.1/aqua-installer | bash
+#   aqua i
+#
+registries:
+  - type: standard
+    ref: v4.232.0  # https://github.com/aquaproj/aqua-registry/releases
+
+packages:
+  # Build tools
+  - name: Kitware/CMake@v3.30.0
+
+  # Python environment
+  - name: astral-sh/uv@0.5.4
+
+  # GitHub CLI
+  - name: cli/cli@v2.62.0

--- a/scripts/setup-system.sh
+++ b/scripts/setup-system.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# setup-system.sh - Install system-level dependencies (requires sudo)
+#
+# Usage: ./scripts/setup-system.sh
+#
+# These packages cannot be managed by aqua (shared libraries, headers, drivers)
+
+set -euo pipefail
+
+echo "=== GPU Audio Upsampler: System Dependencies ==="
+echo ""
+
+# Check if running as root or with sudo
+if [[ $EUID -eq 0 ]]; then
+    SUDO=""
+else
+    SUDO="sudo"
+fi
+
+# Detect distribution
+if [[ -f /etc/os-release ]]; then
+    . /etc/os-release
+    DISTRO=$ID
+else
+    echo "Error: Cannot detect Linux distribution"
+    exit 1
+fi
+
+echo "Detected: $DISTRO"
+echo ""
+
+case $DISTRO in
+    ubuntu|debian)
+        echo "Installing packages via apt..."
+        $SUDO apt update
+        $SUDO apt install -y \
+            build-essential \
+            pkg-config \
+            nvidia-cuda-toolkit \
+            libsndfile1-dev \
+            libpipewire-0.3-dev \
+            libasound2-dev \
+            libspa-0.2-dev \
+            git
+        ;;
+    fedora)
+        echo "Installing packages via dnf..."
+        $SUDO dnf install -y \
+            gcc-c++ \
+            pkgconfig \
+            cuda \
+            libsndfile-devel \
+            pipewire-devel \
+            alsa-lib-devel \
+            git
+        ;;
+    arch|manjaro)
+        echo "Installing packages via pacman..."
+        $SUDO pacman -Syu --needed \
+            base-devel \
+            pkgconf \
+            cuda \
+            libsndfile \
+            pipewire \
+            alsa-lib \
+            git
+        ;;
+    *)
+        echo "Unsupported distribution: $DISTRO"
+        echo ""
+        echo "Please install the following packages manually:"
+        echo "  - C++ compiler (g++ or clang++)"
+        echo "  - pkg-config"
+        echo "  - CUDA toolkit (nvcc, cuFFT)"
+        echo "  - libsndfile development files"
+        echo "  - PipeWire development files (libpipewire-0.3)"
+        echo "  - ALSA development files"
+        echo "  - git"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "=== System dependencies installed ==="
+echo ""
+echo "Next steps:"
+echo "  1. Install aqua: curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v3.0.1/aqua-installer | bash"
+echo "  2. Add aqua to PATH (see aqua docs)"
+echo "  3. Run: aqua i"
+echo "  4. Run: uv sync"
+echo "  5. Build: cmake -B build && cmake --build build -j\$(nproc)"


### PR DESCRIPTION
## Summary
- aquaを導入してCLIツール（cmake, uv, gh）のバージョンを固定
- 新規開発者のセットアップを簡単にするドキュメントとスクリプトを追加

## Changes
- `aqua.yaml` - CLIツールバージョン定義（cmake v3.30.0, uv v0.5.4, gh v2.62.0）
- `scripts/setup-system.sh` - システム依存関係インストールスクリプト（Ubuntu/Debian/Fedora/Arch対応）
- `INSTALL.md` - セットアップ手順ドキュメント
- `.gitignore` - aquaキャッシュディレクトリを追加

## Test plan
- [ ] `aqua i` でCLIツールがインストールされることを確認
- [ ] `./scripts/setup-system.sh` が正常に動作することを確認
- [ ] INSTALL.mdの手順に従ってビルドできることを確認

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)