### PR TITLE
Add clang-tidy to pre-push hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,16 @@ repos:
         types_or: [c, c++]
         files: \.(c|cpp|h|hpp|cu|cuh)$
 
+  # clang-tidy for C/C++ static analysis (pre-push only - heavy)
+  - repo: https://github.com/pocc/pre-commit-hooks
+    rev: v1.3.5
+    hooks:
+      - id: clang-tidy
+        args: [-p=build]
+        files: \.(c|cpp|h|hpp)$
+        exclude: ^build/
+        stages: [pre-push]
+
   # General file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CUDA_STANDARD 17)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 
+# Export compile commands for clang-tidy
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Find required packages
 find_package(CUDAToolkit REQUIRED)
 find_package(PkgConfig REQUIRED)


### PR DESCRIPTION
## Summary
- pre-pushフックにclang-tidy静的解析を追加
- compile_commands.json生成のためCMAKE_EXPORT_COMPILE_COMMANDSを有効化
- build/ディレクトリは解析対象から除外

## 変更内容
- `.pre-commit-config.yaml`: clang-tidy hook追加（pocc/pre-commit-hooks）
- `CMakeLists.txt`: CMAKE_EXPORT_COMPILE_COMMANDS=ON追加

## 実行タイミング
| Hook | タイミング |
|------|-----------|
| clang-format | git commit |
| **clang-tidy** | git push ← New |
| mypy | git push |
| diff-based-tests | git push |

## 前提条件
```bash
sudo apt-get install -y clang-tidy
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)