### PR TITLE
Limit clang-tidy to .cpp files only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,14 @@ repos:
         files: \.(c|cpp|h|hpp|cu|cuh)$
 
   # clang-tidy for C/C++ static analysis (pre-push only - heavy)
+  # Note: Only .cpp files targeted (headers analyzed transitively)
+  # CUDA projects have incompatible compile flags for clang-tidy
   - repo: https://github.com/pocc/pre-commit-hooks
     rev: v1.3.5
     hooks:
       - id: clang-tidy
         args: [-p=build]
-        files: \.(c|cpp|h|hpp)$
+        files: \.(c|cpp)$
         exclude: ^build/
         stages: [pre-push]
 


### PR DESCRIPTION
## Summary
- clang-tidyの対象を`.cpp`ファイルのみに限定
- CUDAプロジェクトのコンパイルフラグがclang-tidyと互換性がないため
- ヘッダファイルは`.cpp`からインクルード時に間接的に分析される

## 背景
#154 で追加したclang-tidyが、`.h`ファイルを直接分析しようとすると`.cu`のcompile_commands.jsonエントリが使われ、CUDAコンパイルフラグでエラーになる問題があった。

## 変更内容
```yaml
# Before
files: \.(c|cpp|h|hpp)$

# After
files: \.(c|cpp)$
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)