### PR TITLE
Fix #177: worktree名から#を削除

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,8 +88,8 @@ cmake --build build -j$(nproc)
 ### Workflow
 
 ```bash
-git worktree add worktrees/#123-feature -b feature/#123-feature
-cd worktrees/#123-feature
+git worktree add worktrees/123-feature -b feature/#123-feature
+cd worktrees/123-feature
 # ... work ...
 git push -u origin feature/#123-feature
 gh pr create --title "#123 機能の説明" --body "..."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,17 +255,17 @@ gpu_os/
 
 ```bash
 # Create a new worktree for the feature branch (with Issue number)
-git worktree add worktrees/#123-feature-name -b feature/#123-feature-name
+git worktree add worktrees/123-feature-name -b feature/#123-feature-name
 
 # Work in the worktree directory
-cd worktrees/#123-feature-name
+cd worktrees/123-feature-name
 
 # After completion, push and create PR (with Issue number in title)
 git push -u origin feature/#123-feature-name
 gh pr create --title "#123 機能の説明" --body "..."
 
 # Clean up after PR is merged
-git worktree remove worktrees/#123-feature-name
+git worktree remove worktrees/123-feature-name
 ```
 
 ### GitHub Operations (via `gh` command)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -89,8 +89,8 @@ cmake --build build -j$(nproc)
 ### Workflow
 
 ```bash
-git worktree add worktrees/#123-feature -b feature/#123-feature
-cd worktrees/#123-feature
+git worktree add worktrees/123-feature -b feature/#123-feature
+cd worktrees/123-feature
 # ... work ...
 git push -u origin feature/#123-feature
 gh pr create --title "#123 機能の説明" --body "..."


### PR DESCRIPTION
## Summary
- worktree名から`#`を削除（シェルでコメントとして解釈される問題を回避）
- `worktrees/#123-feature` → `worktrees/123-feature`

## Test plan
- [ ] ドキュメントの記述が正しいことを確認

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)