### PR TITLE
#161 Admin画面: サンプリングレートステータス表示

### DIFF
--- a/src/alsa_daemon.cpp
+++ b/src/alsa_daemon.cpp
@@ -158,6 +158,11 @@ static void write_stats_file() {
     auto now = std::chrono::system_clock::now();
     auto epoch = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
 
+    // Calculate actual output rate from running config
+    int input_rate = g_config.inputSampleRate;
+    int upsample_ratio = g_config.upsampleRatio;
+    int output_rate = input_rate * upsample_ratio;
+
     // Write to temp file and rename for atomic update
     std::string tmp_path = std::string(STATS_FILE_PATH) + ".tmp";
     std::ofstream ofs(tmp_path);
@@ -166,6 +171,9 @@ static void write_stats_file() {
             << "  \"clip_count\": " << clips << ",\n"
             << "  \"total_samples\": " << total << ",\n"
             << "  \"clip_rate\": " << clip_rate << ",\n"
+            << "  \"input_rate\": " << input_rate << ",\n"
+            << "  \"output_rate\": " << output_rate << ",\n"
+            << "  \"upsample_ratio\": " << upsample_ratio << ",\n"
             << "  \"last_updated\": " << epoch << "\n"
             << "}\n";
         ofs.close();

--- a/web/main.py
+++ b/web/main.py
@@ -490,8 +490,8 @@ def get_configured_rates() -> tuple[int, int]:
 def load_stats() -> dict:
     """Load statistics from daemon stats file.
 
-    Rate information is not included in stats.json (written by C++ daemon),
-    so we get it from config.json values.
+    When daemon is running, stats.json contains actual running rates.
+    Falls back to config.json values if rate info not available.
     """
     input_rate, output_rate = get_configured_rates()
     default_stats = {
@@ -507,12 +507,16 @@ def load_stats() -> dict:
         with open(STATS_FILE_PATH) as f:
             data = json.load(f)
 
+        # Use actual rates from daemon if available, fallback to config
+        actual_input_rate = data.get("input_rate", input_rate)
+        actual_output_rate = data.get("output_rate", output_rate)
+
         return {
             "clip_count": data.get("clip_count", 0),
             "total_samples": data.get("total_samples", 0),
             "clip_rate": data.get("clip_rate", 0.0),
-            "input_rate": input_rate,
-            "output_rate": output_rate,
+            "input_rate": actual_input_rate,
+            "output_rate": actual_output_rate,
         }
     except (json.JSONDecodeError, IOError):
         return default_stats


### PR DESCRIPTION
## Summary

- Admin画面にSampling Rateセクションを追加
- Input/Output サンプリングレートをリアルタイム表示
- WebSocketで1秒ごとに更新

## Changes

### Backend
- `Status` modelに`input_rate`/`output_rate`フィールド追加
- `load_stats()`でstats.jsonからレート情報取得（input_rate * upsample_ratio = output_rate）
- `/status`エンドポイントでレート情報返却
- WebSocket `/ws/stats`でリアルタイムレート配信

### Frontend
- Sampling Rateセクション追加（Statistics と System Info の間）
- `formatSampleRate()`ヘルパー関数追加（44100 → "44.1 kHz"形式）
- WebSocket更新時にレート表示更新

## Test Plan

- [x] 既存テスト全パス（108 passed）
- [x] Python構文チェック通過
- [ ] 実際のデーモン起動時にレート表示確認

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)