### PR TITLE
#166 設定システムの拡張 (PhaseType対応)

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,6 +6,7 @@
   "upsampleRatio": 16,
   "blockSize": 4096,
   "gain": 16.0,
+  "phaseType": "minimum",
   "filterPath": "data/coefficients/filter_44k_2m_min_phase.bin",
   "eqEnabled": true,
   "eqProfilePath": "/home/michihito/Working/gpu_os/data/EQ/Sample_EQ.txt"

--- a/include/config_loader.h
+++ b/include/config_loader.h
@@ -6,6 +6,12 @@
 
 constexpr const char* DEFAULT_CONFIG_FILE = "config.json";
 
+// Phase type for FIR filter
+enum class PhaseType {
+    Minimum,  // Minimum phase: no pre-ringing, frequency-dependent delay (recommended)
+    Linear    // Linear phase: pre-ringing present, constant delay, symmetric
+};
+
 struct AppConfig {
     std::string alsaDevice = "hw:USB";
     int bufferSize = 262144;
@@ -14,12 +20,19 @@ struct AppConfig {
     int blockSize = 4096;
     float gain = 16.0f;
     std::string filterPath = "data/coefficients/filter_1m_min_phase.bin";
-    int inputSampleRate = 44100;  // Input sample rate (44100 or 48000)
+    int inputSampleRate = 44100;               // Input sample rate (44100 or 48000)
+    PhaseType phaseType = PhaseType::Minimum;  // Filter phase type (default: Minimum)
 
     // EQ settings
     bool eqEnabled = false;
     std::string eqProfilePath = "";  // Path to EQ profile file (empty = disabled)
 };
+
+// Convert string to PhaseType (returns Minimum for invalid input)
+PhaseType parsePhaseType(const std::string& str);
+
+// Convert PhaseType to string
+const char* phaseTypeToString(PhaseType type);
 
 bool loadAppConfig(const std::filesystem::path& configPath, AppConfig& outConfig,
                    bool verbose = true);

--- a/src/config_loader.cpp
+++ b/src/config_loader.cpp
@@ -4,6 +4,24 @@
 #include <iostream>
 #include <nlohmann/json.hpp>
 
+PhaseType parsePhaseType(const std::string& str) {
+    if (str == "linear") {
+        return PhaseType::Linear;
+    }
+    // Default to Minimum for "minimum" or any invalid value
+    return PhaseType::Minimum;
+}
+
+const char* phaseTypeToString(PhaseType type) {
+    switch (type) {
+    case PhaseType::Linear:
+        return "linear";
+    case PhaseType::Minimum:
+    default:
+        return "minimum";
+    }
+}
+
 bool loadAppConfig(const std::filesystem::path& configPath, AppConfig& outConfig, bool verbose) {
     outConfig = AppConfig{};
 
@@ -35,6 +53,8 @@ bool loadAppConfig(const std::filesystem::path& configPath, AppConfig& outConfig
             outConfig.filterPath = j["filterPath"].get<std::string>();
         if (j.contains("inputSampleRate"))
             outConfig.inputSampleRate = j["inputSampleRate"].get<int>();
+        if (j.contains("phaseType"))
+            outConfig.phaseType = parsePhaseType(j["phaseType"].get<std::string>());
 
         // EQ settings
         if (j.contains("eqEnabled"))

--- a/tests/cpp/test_config_loader.cpp
+++ b/tests/cpp/test_config_loader.cpp
@@ -161,6 +161,7 @@ TEST_F(ConfigLoaderTest, AppConfigDefaultValues) {
     EXPECT_FLOAT_EQ(config.gain, 16.0f);
     EXPECT_EQ(config.filterPath, "data/coefficients/filter_1m_min_phase.bin");
     EXPECT_EQ(config.inputSampleRate, 44100);
+    EXPECT_EQ(config.phaseType, PhaseType::Minimum);
     EXPECT_FALSE(config.eqEnabled);
     EXPECT_EQ(config.eqProfilePath, "");
 }
@@ -171,4 +172,65 @@ TEST_F(ConfigLoaderTest, AppConfigDefaultValues) {
 
 TEST_F(ConfigLoaderTest, DefaultConfigFileConstant) {
     EXPECT_STREQ(DEFAULT_CONFIG_FILE, "config.json");
+}
+
+// ============================================================
+// PhaseType tests
+// ============================================================
+
+TEST_F(ConfigLoaderTest, ParsePhaseTypeMinimum) {
+    EXPECT_EQ(parsePhaseType("minimum"), PhaseType::Minimum);
+}
+
+TEST_F(ConfigLoaderTest, ParsePhaseTypeLinear) {
+    EXPECT_EQ(parsePhaseType("linear"), PhaseType::Linear);
+}
+
+TEST_F(ConfigLoaderTest, ParsePhaseTypeInvalidDefaultsToMinimum) {
+    EXPECT_EQ(parsePhaseType("invalid"), PhaseType::Minimum);
+    EXPECT_EQ(parsePhaseType(""), PhaseType::Minimum);
+    EXPECT_EQ(parsePhaseType("MINIMUM"), PhaseType::Minimum);  // case sensitive
+}
+
+TEST_F(ConfigLoaderTest, PhaseTypeToStringMinimum) {
+    EXPECT_STREQ(phaseTypeToString(PhaseType::Minimum), "minimum");
+}
+
+TEST_F(ConfigLoaderTest, PhaseTypeToStringLinear) {
+    EXPECT_STREQ(phaseTypeToString(PhaseType::Linear), "linear");
+}
+
+TEST_F(ConfigLoaderTest, AppConfigDefaultPhaseType) {
+    AppConfig config;
+    EXPECT_EQ(config.phaseType, PhaseType::Minimum);
+}
+
+TEST_F(ConfigLoaderTest, LoadConfigWithPhaseTypeMinimum) {
+    writeConfig(R"({"phaseType": "minimum"})");
+
+    AppConfig config;
+    bool result = loadAppConfig(testConfigPath, config, false);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(config.phaseType, PhaseType::Minimum);
+}
+
+TEST_F(ConfigLoaderTest, LoadConfigWithPhaseTypeLinear) {
+    writeConfig(R"({"phaseType": "linear"})");
+
+    AppConfig config;
+    bool result = loadAppConfig(testConfigPath, config, false);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(config.phaseType, PhaseType::Linear);
+}
+
+TEST_F(ConfigLoaderTest, LoadConfigWithInvalidPhaseTypeDefaultsToMinimum) {
+    writeConfig(R"({"phaseType": "invalid"})");
+
+    AppConfig config;
+    bool result = loadAppConfig(testConfigPath, config, false);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(config.phaseType, PhaseType::Minimum);
 }


### PR DESCRIPTION
## Summary
- C++ config_loaderに`PhaseType`列挙型を追加（Minimum/Linear）
- `parsePhaseType()`と`phaseTypeToString()`関数を実装
- `AppConfig`に`phaseType`フィールドを追加（デフォルト: Minimum）
- config.jsonに`phaseType`フィールドを追加
- 9個の新規ユニットテストを追加

## Test plan
- [x] 18個のConfigLoaderTestが全てパス
- [x] clang-format/clang-tidyがパス
- [x] pre-commitフックが全てパス

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)