### PR TITLE
#189 Multi-rate: update input sample rate after switch

### DIFF
--- a/src/gpu/gpu_upsampler_multi_rate.cu
+++ b/src/gpu/gpu_upsampler_multi_rate.cu
@@ -467,6 +467,7 @@ bool GPUUpsampler::switchToInputRate(int inputSampleRate) {
     // Update state
     currentMultiRateIndex_ = targetIndex;
     currentInputRate_ = inputSampleRate;
+    inputSampleRate_ = inputSampleRate;
     upsampleRatio_ = targetConfig.ratio;
     currentRateFamily_ = targetConfig.family;
 

--- a/tests/gpu/test_convolution_engine.cu
+++ b/tests/gpu/test_convolution_engine.cu
@@ -704,18 +704,21 @@ TEST_F(ConvolutionEngineTest, SwitchToInputRate) {
     EXPECT_EQ(upsampler.getCurrentInputRate(), 88200);
     EXPECT_EQ(upsampler.getUpsampleRatio(), 8);
     EXPECT_EQ(upsampler.getCurrentRateFamily(), RateFamily::RATE_44K);
+    EXPECT_EQ(upsampler.getOutputSampleRate(), 88200 * 8);
 
     // Switch to 48000 (16x, different family)
     EXPECT_TRUE(upsampler.switchToInputRate(48000));
     EXPECT_EQ(upsampler.getCurrentInputRate(), 48000);
     EXPECT_EQ(upsampler.getUpsampleRatio(), 16);
     EXPECT_EQ(upsampler.getCurrentRateFamily(), RateFamily::RATE_48K);
+    EXPECT_EQ(upsampler.getOutputSampleRate(), 48000 * 16);
 
     // Switch to 192000 (4x)
     EXPECT_TRUE(upsampler.switchToInputRate(192000));
     EXPECT_EQ(upsampler.getCurrentInputRate(), 192000);
     EXPECT_EQ(upsampler.getUpsampleRatio(), 4);
     EXPECT_EQ(upsampler.getCurrentRateFamily(), RateFamily::RATE_48K);
+    EXPECT_EQ(upsampler.getOutputSampleRate(), 192000 * 4);
 }
 
 TEST_F(ConvolutionEngineTest, SwitchToSameInputRate) {


### PR DESCRIPTION
## Summary
- update switchToInputRate() to keep inputSampleRate_ in sync with current rate
- add output sample rate expectations to multi-rate switch test to cover regression

## Testing
- PATH=/usr/bin:/home/michihito/.tfenv/bin:/home/michihito/Working/.tfenv/bin:/tmp/.tmpFrM9QM:/usr/lib/node_modules/@openai/codex/vendor/x86_64-unknown-linux-musl/path:/home/michihito/.tfenv/bin:/home/michihito/Working/.tfenv/bin:/home/michihito/.cargo/bin:/home/michihito/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/snap/bin:/home/michihito.python3_venv/bin scripts/run_tests.sh
