### PR TITLE
#192 EQ API統合テストの追加

### DIFF
--- a/web/constants.py
+++ b/web/constants.py
@@ -42,5 +42,9 @@ GAIN_MAX_DB = 30.0
 Q_MIN = 0.1
 Q_MAX = 100.0
 
-# Allowed filename pattern: alphanumeric, underscore, hyphen, dot
+# Allowed filename pattern: alphanumeric, underscore, hyphen, dot (with .txt extension)
 SAFE_FILENAME_PATTERN = re.compile(r"^[a-zA-Z0-9_\-\.]+\.txt$")
+
+# Allowed profile name pattern: alphanumeric, underscore, hyphen, dot (no extension)
+# Used for EQ profile names in config and URL parameters
+SAFE_PROFILE_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_\-\.]+$")

--- a/web/services/__init__.py
+++ b/web/services/__init__.py
@@ -13,6 +13,7 @@ from .daemon import (
 )
 from .daemon_client import DaemonClient, get_daemon_client
 from .eq import (
+    is_safe_profile_name,
     parse_eq_profile_content,
     read_and_validate_upload,
     sanitize_filename,
@@ -37,6 +38,7 @@ __all__ = [
     "DaemonClient",
     "get_daemon_client",
     # eq
+    "is_safe_profile_name",
     "parse_eq_profile_content",
     "read_and_validate_upload",
     "sanitize_filename",

--- a/web/services/eq.py
+++ b/web/services/eq.py
@@ -18,7 +18,32 @@ from ..constants import (
     Q_MAX,
     Q_MIN,
     SAFE_FILENAME_PATTERN,
+    SAFE_PROFILE_NAME_PATTERN,
 )
+
+
+def is_safe_profile_name(name: str | None) -> bool:
+    """
+    Check if profile name is safe (no path traversal risk).
+
+    Args:
+        name: Profile name to validate (can be None)
+
+    Returns:
+        True if name is safe, False otherwise
+    """
+    if not name:
+        return True  # None/empty is valid (means no profile)
+
+    # Check against safe pattern
+    if not SAFE_PROFILE_NAME_PATTERN.match(name):
+        return False
+
+    # Reject path traversal patterns
+    if ".." in name or name.startswith("."):
+        return False
+
+    return True
 
 
 def sanitize_filename(filename: str) -> str | None:


### PR DESCRIPTION
## Summary
- EQ APIエンドポイントの統合テスト24件を追加
- 全エンドポイント（validate, import, profiles, activate, deactivate, delete, active）をカバー
- セキュリティテスト（パストラバーサル防止、ファイル名サニタイズ）を含む

## Test Coverage
| Endpoint | Tests |
|----------|-------|
| POST /eq/validate | 6 |
| POST /eq/import | 4 |
| GET /eq/profiles | 4 |
| POST /eq/activate/{name} | 2 |
| POST /eq/deactivate | 1 |
| DELETE /eq/profiles/{name} | 2 |
| GET /eq/active | 2 |
| Security | 3 |

## Test plan
- [x] 24テスト全てパス
- [x] ruff lint/formatパス
- [x] pre-commitフックパス

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)