### PR TITLE
#197 Python側: 位相タイプAPI実装

### DIFF
--- a/docs/api/CHANGELOG.md
+++ b/docs/api/CHANGELOG.md
@@ -7,6 +7,9 @@ APIへの重要な変更はこのファイルに記録されます。
 ## [Unreleased]
 
 ### Added
+- **Phase Type Control**: 位相タイプのランタイム切り替え
+  - `GET /daemon/phase-type` - 現在の位相タイプ取得
+  - `PUT /daemon/phase-type` - 位相タイプ変更（quad-phaseモード必須）
 - **DAC**: DAC Capability検出API (#199)
   - `GET /dac/capabilities` - DAC対応サンプリングレート取得
   - `GET /dac/devices` - デバイス一覧とCapability

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -267,6 +267,68 @@
         }
       }
     },
+    "/daemon/phase-type": {
+      "get": {
+        "tags": [
+          "daemon"
+        ],
+        "summary": "Get Phase Type",
+        "description": "Get current phase type from daemon.\n\nReturns the current filter phase type (minimum or linear).\nLinear phase has high latency (~1 second) but no phase distortion.\nMinimum phase has no pre-ringing and low latency.",
+        "operationId": "get_phase_type_daemon_phase_type_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PhaseTypeResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "daemon"
+        ],
+        "summary": "Set Phase Type",
+        "description": "Set phase type on daemon.\n\nRequires quad-phase mode to be enabled (4 filter variants preloaded).\nChanges take effect immediately without daemon restart.\n\n- minimum: Minimum phase filter (recommended, no pre-ringing)\n- linear: Linear phase filter (high latency ~1 second)",
+        "operationId": "set_phase_type_daemon_phase_type_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PhaseTypeUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/daemon/restart-full": {
       "post": {
         "tags": [
@@ -1842,6 +1904,56 @@
         ],
         "title": "OpraVendorsResponse",
         "description": "OPRA vendors list response model."
+      },
+      "PhaseTypeResponse": {
+        "properties": {
+          "phase_type": {
+            "type": "string",
+            "enum": [
+              "minimum",
+              "linear"
+            ],
+            "title": "Phase Type",
+            "description": "Current phase type: 'minimum' or 'linear'"
+          },
+          "latency_warning": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latency Warning",
+            "description": "Warning message for linear phase (high latency ~1 second)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "phase_type"
+        ],
+        "title": "PhaseTypeResponse",
+        "description": "Phase type response model."
+      },
+      "PhaseTypeUpdateRequest": {
+        "properties": {
+          "phase_type": {
+            "type": "string",
+            "enum": [
+              "minimum",
+              "linear"
+            ],
+            "title": "Phase Type",
+            "description": "Target phase type: 'minimum' or 'linear'"
+          }
+        },
+        "type": "object",
+        "required": [
+          "phase_type"
+        ],
+        "title": "PhaseTypeUpdateRequest",
+        "description": "Phase type update request model."
       },
       "RewireRequest": {
         "properties": {

--- a/tests/python/test_phase_type_api.py
+++ b/tests/python/test_phase_type_api.py
@@ -1,0 +1,205 @@
+"""Tests for phase type API endpoints."""
+
+from unittest.mock import patch, MagicMock
+
+from fastapi.testclient import TestClient
+
+from web.main import app
+
+
+client = TestClient(app)
+
+
+class TestPhaseTypeGet:
+    """Tests for GET /daemon/phase-type endpoint."""
+
+    def test_get_phase_type_minimum(self):
+        """Test getting minimum phase type."""
+        with patch("web.routers.daemon.get_daemon_client") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+            mock_instance.__exit__ = MagicMock(return_value=False)
+            mock_instance.get_phase_type.return_value = (
+                True,
+                {"phase_type": "minimum"},
+            )
+            mock_client.return_value = mock_instance
+
+            response = client.get("/daemon/phase-type")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["phase_type"] == "minimum"
+            assert data["latency_warning"] is None
+
+    def test_get_phase_type_linear_with_warning(self):
+        """Test getting linear phase type includes latency warning."""
+        with patch("web.routers.daemon.get_daemon_client") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+            mock_instance.__exit__ = MagicMock(return_value=False)
+            mock_instance.get_phase_type.return_value = (
+                True,
+                {"phase_type": "linear"},
+            )
+            mock_client.return_value = mock_instance
+
+            response = client.get("/daemon/phase-type")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["phase_type"] == "linear"
+            assert data["latency_warning"] is not None
+            assert "latency" in data["latency_warning"].lower()
+
+    def test_get_phase_type_daemon_error(self):
+        """Test error handling when daemon communication fails."""
+        with patch("web.routers.daemon.get_daemon_client") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+            mock_instance.__exit__ = MagicMock(return_value=False)
+            mock_instance.get_phase_type.return_value = (
+                False,
+                "Daemon not responding",
+            )
+            mock_client.return_value = mock_instance
+
+            response = client.get("/daemon/phase-type")
+
+            assert response.status_code == 503
+            assert "Failed to get phase type" in response.json()["detail"]
+
+
+class TestPhaseTypeSet:
+    """Tests for PUT /daemon/phase-type endpoint."""
+
+    def test_set_phase_type_minimum(self):
+        """Test setting phase type to minimum."""
+        with patch("web.routers.daemon.get_daemon_client") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+            mock_instance.__exit__ = MagicMock(return_value=False)
+            mock_instance.set_phase_type.return_value = (
+                True,
+                "Phase type set to minimum",
+            )
+            mock_client.return_value = mock_instance
+
+            response = client.put(
+                "/daemon/phase-type",
+                json={"phase_type": "minimum"},
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert data["data"]["phase_type"] == "minimum"
+
+    def test_set_phase_type_linear(self):
+        """Test setting phase type to linear."""
+        with patch("web.routers.daemon.get_daemon_client") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+            mock_instance.__exit__ = MagicMock(return_value=False)
+            mock_instance.set_phase_type.return_value = (
+                True,
+                "Phase type set to linear",
+            )
+            mock_client.return_value = mock_instance
+
+            response = client.put(
+                "/daemon/phase-type",
+                json={"phase_type": "linear"},
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert data["data"]["phase_type"] == "linear"
+
+    def test_set_phase_type_invalid(self):
+        """Test setting invalid phase type returns 422 (Pydantic Literal validation)."""
+        response = client.put(
+            "/daemon/phase-type",
+            json={"phase_type": "invalid"},
+        )
+
+        assert response.status_code == 422
+        # Pydantic returns structured validation error
+        data = response.json()
+        assert "detail" in data
+        assert "error_code" in data
+        assert data["error_code"] == "VALIDATION_ERROR"
+
+    def test_set_phase_type_daemon_error(self):
+        """Test error handling when daemon returns error."""
+        with patch("web.routers.daemon.get_daemon_client") as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+            mock_instance.__exit__ = MagicMock(return_value=False)
+            mock_instance.set_phase_type.return_value = (
+                False,
+                "Quad-phase mode not enabled",
+            )
+            mock_client.return_value = mock_instance
+
+            response = client.put(
+                "/daemon/phase-type",
+                json={"phase_type": "linear"},
+            )
+
+            assert response.status_code == 503
+            assert "Failed to set phase type" in response.json()["detail"]
+
+
+class TestDaemonClientPhaseType:
+    """Tests for DaemonClient phase type methods."""
+
+    def test_get_phase_type_parses_json(self):
+        """Test that get_phase_type correctly parses JSON response."""
+        from web.services.daemon_client import DaemonClient
+
+        client = DaemonClient()
+        with patch.object(client, "send_command") as mock_send:
+            mock_send.return_value = (True, '{"phase_type": "minimum"}')
+
+            success, result = client.get_phase_type()
+
+            assert success is True
+            assert result == {"phase_type": "minimum"}
+
+    def test_get_phase_type_invalid_json(self):
+        """Test that get_phase_type handles invalid JSON."""
+        from web.services.daemon_client import DaemonClient
+
+        client = DaemonClient()
+        with patch.object(client, "send_command") as mock_send:
+            mock_send.return_value = (True, "not json")
+
+            success, result = client.get_phase_type()
+
+            assert success is False
+            assert "Invalid JSON" in result
+
+    def test_set_phase_type_validates_input(self):
+        """Test that set_phase_type validates input."""
+        from web.services.daemon_client import DaemonClient
+
+        client = DaemonClient()
+
+        success, message = client.set_phase_type("invalid")
+
+        assert success is False
+        assert "Invalid phase type" in message
+
+    def test_set_phase_type_sends_correct_command(self):
+        """Test that set_phase_type sends correct command."""
+        from web.services.daemon_client import DaemonClient
+
+        client = DaemonClient()
+        with patch.object(client, "send_command") as mock_send:
+            mock_send.return_value = (True, "Phase type set")
+
+            client.set_phase_type("linear")
+
+            mock_send.assert_called_once_with("PHASE_TYPE_SET:linear")

--- a/web/models.py
+++ b/web/models.py
@@ -1,6 +1,6 @@
 """Pydantic models for the GPU Upsampler Web API."""
 
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -66,6 +66,29 @@ class ZmqPingResponse(BaseModel):
     success: bool
     response: Optional[Any] = None
     daemon_running: bool
+
+
+PhaseType = Literal["minimum", "linear"]
+
+
+class PhaseTypeResponse(BaseModel):
+    """Phase type response model."""
+
+    phase_type: PhaseType = Field(
+        description="Current phase type: 'minimum' or 'linear'"
+    )
+    latency_warning: Optional[str] = Field(
+        default=None,
+        description="Warning message for linear phase (high latency ~1 second)",
+    )
+
+
+class PhaseTypeUpdateRequest(BaseModel):
+    """Phase type update request model."""
+
+    phase_type: PhaseType = Field(
+        description="Target phase type: 'minimum' or 'linear'"
+    )
 
 
 # ============================================================================

--- a/web/services/daemon_client.py
+++ b/web/services/daemon_client.py
@@ -112,6 +112,38 @@ class DaemonClient:
         success, _ = self.send_command("PING")
         return success
 
+    def get_phase_type(self) -> tuple[bool, dict | str]:
+        """
+        Get current phase type from daemon.
+
+        Returns:
+            (success, {"phase_type": "minimum"|"linear"}) on success
+            (False, error_message) on failure
+        """
+        import json
+
+        success, response = self.send_command("PHASE_TYPE_GET")
+        if success:
+            try:
+                return True, json.loads(response)
+            except json.JSONDecodeError:
+                return False, f"Invalid JSON response: {response}"
+        return False, response
+
+    def set_phase_type(self, phase_type: str) -> tuple[bool, str]:
+        """
+        Set phase type on daemon.
+
+        Args:
+            phase_type: "minimum" or "linear"
+
+        Returns:
+            (success, message) tuple
+        """
+        if phase_type not in ("minimum", "linear"):
+            return False, f"Invalid phase type: {phase_type}"
+        return self.send_command(f"PHASE_TYPE_SET:{phase_type}")
+
 
 def get_daemon_client(timeout_ms: int = 3000) -> DaemonClient:
     """


### PR DESCRIPTION
## Summary
- `GET /daemon/phase-type`: 現在の位相タイプを取得（Linear時は警告付き）
- `PUT /daemon/phase-type`: 位相タイプを変更（quad-phaseモード必須）
- `DaemonClient`に`get_phase_type()`/`set_phase_type()`メソッド追加
- 包括的なユニットテスト追加

## API Examples
```bash
# Get current phase type
curl http://localhost:8000/daemon/phase-type
# Response: {"phase_type": "minimum", "latency_warning": null}

# Set to linear (high latency warning)
curl -X PUT http://localhost:8000/daemon/phase-type \
  -H "Content-Type: application/json" \
  -d '{"phase_type": "linear"}'
```

## Test plan
- [x] 全11テストがパス
- [ ] 実際のデーモンとの結合テスト

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)