### PR TITLE
#203 OpenAPI自動生成とREST API開発ガイドライン整備

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,3 +85,15 @@ repos:
         stages: [pre-push]
         pass_filenames: false
         always_run: true
+
+  # OpenAPI spec export (pre-commit, web/ changes only)
+  # Generates docs/api/openapi.json from FastAPI app
+  - repo: local
+    hooks:
+      - id: export-openapi
+        name: Export OpenAPI spec
+        entry: uv run python scripts/export_openapi.py
+        language: system
+        files: ^web/.*\.py$
+        pass_filenames: false
+        stages: [pre-commit]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,10 @@ gpu_os/
 │   └── EQ/                # EQ profiles
 │
 ├── docs/
+│   ├── api/               # REST API documentation
+│   │   ├── openapi.json   # OpenAPI spec (auto-generated)
+│   │   ├── README.md      # API overview
+│   │   └── CHANGELOG.md   # API change history
 │   ├── architecture/      # System design docs
 │   ├── reports/           # Phase implementation reports
 │   ├── investigations/    # Investigation logs
@@ -237,6 +241,86 @@ gpu_os/
 ├── plots/                 # Analysis plots
 └── build/                 # Build output
 ```
+
+## REST API Development Guidelines
+
+### レスポンスモデル必須
+
+すべてのAPIエンドポイントには `response_model` を指定すること。
+これにより OpenAPI スキーマが自動生成され、ドキュメントの整合性が保たれる。
+
+```python
+# Good
+@router.get("/status", response_model=Status)
+async def get_status():
+    return Status(...)
+
+# Bad - response_model なし
+@router.get("/status")
+async def get_status():
+    return {"status": "ok"}
+```
+
+### エラーハンドリング統一
+
+HTTPExceptionは以下の形式で統一する：
+
+```python
+from fastapi import HTTPException
+
+# 標準的なエラー
+raise HTTPException(status_code=404, detail="Profile not found")
+
+# 構造化エラー（将来対応）
+raise HTTPException(status_code=400, detail={"field": "name", "error": "invalid"})
+```
+
+エラーレスポンスは自動的に `ErrorResponse` 形式に変換される：
+```json
+{"detail": "...", "error_code": "HTTP_404"}
+```
+
+### OpenAPIドキュメント
+
+#### タグの使用
+
+各ルーターには適切なタグを設定：
+
+```python
+router = APIRouter(prefix="/eq", tags=["eq"])
+```
+
+#### Deprecated エンドポイント
+
+非推奨エンドポイントは明示的にマーク：
+
+```python
+@app.post("/restart", deprecated=True, tags=["legacy"])
+async def restart():
+    """Deprecated: Use POST /daemon/restart instead."""
+    ...
+```
+
+### OpenAPI仕様の自動生成
+
+`web/` 配下のファイルを変更すると、pre-commit フックにより `docs/api/openapi.json` が自動更新される。
+
+手動実行：
+```bash
+# OpenAPI spec を出力
+uv run python scripts/export_openapi.py
+
+# 最新かどうか確認
+uv run python scripts/export_openapi.py --check
+```
+
+### API変更時のチェックリスト
+
+- [ ] `response_model` を指定したか
+- [ ] エラーケースは `HTTPException` で処理しているか
+- [ ] 適切なタグを設定したか
+- [ ] 破壊的変更の場合は `deprecated` を使用したか
+- [ ] `docs/api/CHANGELOG.md` を更新したか
 
 ## Git Workflow
 

--- a/docs/api/CHANGELOG.md
+++ b/docs/api/CHANGELOG.md
@@ -1,0 +1,58 @@
+# API Changelog
+
+APIへの重要な変更はこのファイルに記録されます。
+
+フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) に基づきます。
+
+## [Unreleased]
+
+## [1.0.0] - 2024-11-24
+
+### Added
+- 初期APIリリース
+- **Status**: システム状態・設定管理
+  - `GET /status` - システム状態取得
+  - `POST /settings` - 設定更新
+  - `GET /devices` - ALSAデバイス一覧
+  - `WS /ws/stats` - リアルタイム統計
+- **Daemon**: デーモン制御
+  - `POST /daemon/start|stop|restart` - ライフサイクル管理
+  - `GET /daemon/status` - デーモン状態
+  - `GET /daemon/zmq/ping` - ZeroMQ疎通確認
+- **EQ**: プロファイル管理
+  - CRUD操作（list, import, activate, delete）
+  - プロファイル検証機能
+- **OPRA**: ヘッドホンEQデータベース連携
+  - 検索・フィルタ機能
+  - Modern Target (KB5000_7) 補正対応
+
+### Deprecated
+- `POST /restart` - `POST /daemon/restart` を使用してください
+
+---
+
+## テンプレート
+
+新しいバージョンを追加する際は以下のフォーマットを使用してください：
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+- 新しいエンドポイント
+
+### Changed
+- 既存エンドポイントの変更
+
+### Deprecated
+- 非推奨になったエンドポイント
+
+### Removed
+- 削除されたエンドポイント
+
+### Fixed
+- バグ修正
+
+### Security
+- セキュリティ修正
+```

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,111 @@
+# GPU Upsampler Web API
+
+GPU音声アップサンプラーのREST API仕様です。
+
+## 概要
+
+| 項目 | 値 |
+|------|-----|
+| ベースURL | `http://localhost:11881` |
+| 認証 | なし（ローカルネットワーク専用） |
+| フォーマット | JSON |
+
+## インタラクティブドキュメント
+
+サーバー起動後、以下のURLでインタラクティブなAPIドキュメントにアクセスできます：
+
+- **Swagger UI**: http://localhost:11881/docs
+- **ReDoc**: http://localhost:11881/redoc
+
+## エンドポイント一覧
+
+### Status (`/status`)
+システム状態と設定の管理
+
+| Method | Path | 説明 |
+|--------|------|------|
+| GET | `/status` | システム状態取得 |
+| POST | `/settings` | 設定更新 |
+| GET | `/devices` | ALSAデバイス一覧 |
+| WS | `/ws/stats` | リアルタイム統計（WebSocket） |
+
+### Daemon (`/daemon`)
+オーディオデーモンのライフサイクル管理
+
+| Method | Path | 説明 |
+|--------|------|------|
+| POST | `/daemon/start` | デーモン起動 |
+| POST | `/daemon/stop` | デーモン停止 |
+| POST | `/daemon/restart` | デーモン再起動 |
+| GET | `/daemon/status` | デーモン状態取得 |
+| GET | `/daemon/zmq/ping` | ZeroMQ疎通確認 |
+| POST | `/daemon/zmq/command/{cmd}` | ZeroMQコマンド送信 |
+
+### EQ (`/eq`)
+EQプロファイル管理
+
+| Method | Path | 説明 |
+|--------|------|------|
+| GET | `/eq/profiles` | プロファイル一覧 |
+| POST | `/eq/validate` | プロファイル検証 |
+| POST | `/eq/import` | プロファイルインポート |
+| POST | `/eq/activate/{name}` | プロファイル有効化 |
+| POST | `/eq/deactivate` | EQ無効化 |
+| DELETE | `/eq/profiles/{name}` | プロファイル削除 |
+| GET | `/eq/active` | アクティブプロファイル取得 |
+
+### OPRA (`/opra`)
+OPRAヘッドホンEQデータベース連携
+
+| Method | Path | 説明 |
+|--------|------|------|
+| GET | `/opra/stats` | データベース統計 |
+| GET | `/opra/vendors` | ベンダー一覧 |
+| GET | `/opra/search` | ヘッドホン検索 |
+| GET | `/opra/products/{id}` | 製品詳細取得 |
+| GET | `/opra/eq/{id}` | EQプロファイル取得 |
+| POST | `/opra/apply/{id}` | EQプロファイル適用 |
+
+## レスポンス形式
+
+### 成功レスポンス（変更系）
+```json
+{
+  "success": true,
+  "message": "操作完了メッセージ",
+  "data": { ... },
+  "restart_required": false
+}
+```
+
+### エラーレスポンス
+```json
+{
+  "detail": "エラーメッセージ",
+  "error_code": "HTTP_404"
+}
+```
+
+## OpenAPI仕様
+
+機械可読なOpenAPI仕様は以下のファイルで提供されます：
+
+- **[openapi.json](./openapi.json)** - OpenAPI 3.1仕様（JSONフォーマット）
+
+### OpenAPIファイルの更新
+
+`web/` 配下のPythonファイルを変更すると、pre-commitフックにより自動的に `openapi.json` が更新されます。
+
+手動で更新する場合：
+```bash
+uv run python scripts/export_openapi.py
+```
+
+最新かどうか確認する場合：
+```bash
+uv run python scripts/export_openapi.py --check
+```
+
+## ライセンス
+
+OPRAデータは [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) ライセンスです。

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1,0 +1,1658 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "GPU Upsampler Control",
+    "description": "\n## GPU Audio Upsampler Web API\n\nControl interface for the GPU-accelerated audio upsampler daemon.\n\n### Features\n- **Daemon Control**: Start/stop/restart the audio processing daemon\n- **EQ Management**: Import and manage EQ profiles (AutoEq/Equalizer APO format)\n- **OPRA Integration**: Access the OPRA headphone EQ database\n- **Real-time Stats**: WebSocket endpoint for live statistics\n\n### Authentication\nNo authentication required (local network only).\n    ",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "tags": [
+          "status"
+        ],
+        "summary": "Root",
+        "description": "Serve the embedded HTML page.",
+        "operationId": "root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/status": {
+      "get": {
+        "tags": [
+          "status"
+        ],
+        "summary": "Get Status",
+        "description": "Get current system status.",
+        "operationId": "get_status_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Status"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/settings": {
+      "post": {
+        "tags": [
+          "status"
+        ],
+        "summary": "Update Settings",
+        "description": "Update application settings.",
+        "operationId": "update_settings_settings_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SettingsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/devices": {
+      "get": {
+        "tags": [
+          "status"
+        ],
+        "summary": "List Devices",
+        "description": "List available ALSA devices.",
+        "operationId": "list_devices_devices_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DevicesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/daemon/start": {
+      "post": {
+        "tags": [
+          "daemon"
+        ],
+        "summary": "Daemon Start",
+        "description": "Start the daemon.",
+        "operationId": "daemon_start_daemon_start_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/daemon/stop": {
+      "post": {
+        "tags": [
+          "daemon"
+        ],
+        "summary": "Daemon Stop",
+        "description": "Stop the daemon.",
+        "operationId": "daemon_stop_daemon_stop_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/daemon/restart": {
+      "post": {
+        "tags": [
+          "daemon"
+        ],
+        "summary": "Daemon Restart",
+        "description": "Restart the daemon.",
+        "operationId": "daemon_restart_daemon_restart_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/daemon/status": {
+      "get": {
+        "tags": [
+          "daemon"
+        ],
+        "summary": "Daemon Status",
+        "description": "Get detailed daemon status.",
+        "operationId": "daemon_status_daemon_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DaemonStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/daemon/zmq/ping": {
+      "get": {
+        "tags": [
+          "daemon"
+        ],
+        "summary": "Zmq Ping",
+        "description": "Ping the daemon via ZeroMQ.",
+        "operationId": "zmq_ping_daemon_zmq_ping_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ZmqPingResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/daemon/zmq/command/{cmd}": {
+      "post": {
+        "tags": [
+          "daemon"
+        ],
+        "summary": "Zmq Command",
+        "description": "Send arbitrary command to daemon via ZeroMQ.",
+        "operationId": "zmq_command_daemon_zmq_command__cmd__post",
+        "parameters": [
+          {
+            "name": "cmd",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cmd"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/daemon/restart-full": {
+      "post": {
+        "tags": [
+          "daemon"
+        ],
+        "summary": "Reload Daemon",
+        "description": "Restart daemon with updated configuration.\n\nThis is called after settings changes that require a daemon restart\n(e.g., sample rate changes, EQ profile changes).",
+        "operationId": "reload_daemon_daemon_restart_full_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/daemon/rewire": {
+      "post": {
+        "tags": [
+          "daemon"
+        ],
+        "summary": "Rewire Pipewire",
+        "description": "Rewire PipeWire connections.",
+        "operationId": "rewire_pipewire_daemon_rewire_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RewireRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/eq/profiles": {
+      "get": {
+        "tags": [
+          "eq"
+        ],
+        "summary": "List Eq Profiles",
+        "description": "List available EQ profiles in data/EQ directory.\nReturns extended info including file size and profile type.",
+        "operationId": "list_eq_profiles_eq_profiles_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EqProfilesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/eq/validate": {
+      "post": {
+        "tags": [
+          "eq"
+        ],
+        "summary": "Validate Eq Profile",
+        "description": "Validate an EQ profile file before importing.\nChecks format, parameter ranges, and security constraints.\nDoes not save the file.",
+        "operationId": "validate_eq_profile_eq_validate_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_validate_eq_profile_eq_validate_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EqValidationResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/eq/import": {
+      "post": {
+        "tags": [
+          "eq"
+        ],
+        "summary": "Import Eq Profile",
+        "description": "Import an EQ profile file (AutoEq/Equalizer APO format).\n\nSecurity features:\n- File size limit (1MB)\n- Filename sanitization (path traversal prevention)\n- Content validation (format, parameter ranges)\n- Overwrite protection (requires explicit flag)",
+        "operationId": "import_eq_profile_eq_import_post",
+        "parameters": [
+          {
+            "name": "overwrite",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Overwrite"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_import_eq_profile_eq_import_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/eq/activate/{name}": {
+      "post": {
+        "tags": [
+          "eq"
+        ],
+        "summary": "Activate Eq Profile",
+        "description": "Activate an EQ profile by name.",
+        "operationId": "activate_eq_profile_eq_activate__name__post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/eq/deactivate": {
+      "post": {
+        "tags": [
+          "eq"
+        ],
+        "summary": "Deactivate Eq",
+        "description": "Deactivate current EQ profile.",
+        "operationId": "deactivate_eq_eq_deactivate_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/eq/profiles/{name}": {
+      "delete": {
+        "tags": [
+          "eq"
+        ],
+        "summary": "Delete Eq Profile",
+        "description": "Delete an EQ profile.",
+        "operationId": "delete_eq_profile_eq_profiles__name__delete",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/eq/active": {
+      "get": {
+        "tags": [
+          "eq"
+        ],
+        "summary": "Get Active Eq",
+        "description": "Get the currently active EQ profile with parsed content.",
+        "operationId": "get_active_eq_eq_active_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EqActiveResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/opra/stats": {
+      "get": {
+        "tags": [
+          "opra"
+        ],
+        "summary": "Opra Stats",
+        "description": "Get OPRA database statistics.",
+        "operationId": "opra_stats_opra_stats_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpraStats"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/opra/vendors": {
+      "get": {
+        "tags": [
+          "opra"
+        ],
+        "summary": "Opra Vendors",
+        "description": "List all vendors in OPRA database.",
+        "operationId": "opra_vendors_opra_vendors_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpraVendorsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/opra/search": {
+      "get": {
+        "tags": [
+          "opra"
+        ],
+        "summary": "Opra Search",
+        "description": "Search headphones by name.\nReturns products with embedded vendor info and EQ profiles.",
+        "operationId": "opra_search_opra_search_get",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "",
+              "title": "Q"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpraSearchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/opra/products/{product_id}": {
+      "get": {
+        "tags": [
+          "opra"
+        ],
+        "summary": "Opra Product",
+        "description": "Get a specific product with its EQ profiles.",
+        "operationId": "opra_product_opra_products__product_id__get",
+        "parameters": [
+          {
+            "name": "product_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Product Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/opra/eq/{eq_id}": {
+      "get": {
+        "tags": [
+          "opra"
+        ],
+        "summary": "Opra Eq Profile",
+        "description": "Get a specific EQ profile with APO format preview.\n\nArgs:\n    eq_id: EQ profile ID\n    apply_correction: If True, apply Modern Target (KB5000_7) correction",
+        "operationId": "opra_eq_profile_opra_eq__eq_id__get",
+        "parameters": [
+          {
+            "name": "eq_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Eq Id"
+            }
+          },
+          {
+            "name": "apply_correction",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Apply Correction"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpraEqResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/opra/apply/{eq_id}": {
+      "post": {
+        "tags": [
+          "opra"
+        ],
+        "summary": "Opra Apply Eq",
+        "description": "Apply an OPRA EQ profile.\nConverts to APO format, saves to data/EQ, and activates.\n\nArgs:\n    eq_id: EQ profile ID\n    apply_correction: If True, apply Modern Target (KB5000_7) correction",
+        "operationId": "opra_apply_eq_opra_apply__eq_id__post",
+        "parameters": [
+          {
+            "name": "eq_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Eq Id"
+            }
+          },
+          {
+            "name": "apply_correction",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Apply Correction"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/restart": {
+      "post": {
+        "tags": [
+          "legacy"
+        ],
+        "summary": "Restart daemon (DEPRECATED)",
+        "description": "**Deprecated**: Use `POST /daemon/restart` instead.",
+        "operationId": "restart_restart_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/admin": {
+      "get": {
+        "summary": "Admin Page",
+        "description": "Serve the admin dashboard",
+        "operationId": "admin_page_admin_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AlsaDevice": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "AlsaDevice",
+        "description": "ALSA device info model."
+      },
+      "ApiResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "restart_required": {
+            "type": "boolean",
+            "title": "Restart Required",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message"
+        ],
+        "title": "ApiResponse",
+        "description": "Standard API response model for mutations."
+      },
+      "Body_import_eq_profile_eq_import_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_import_eq_profile_eq_import_post"
+      },
+      "Body_validate_eq_profile_eq_validate_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_validate_eq_profile_eq_validate_post"
+      },
+      "DaemonStatus": {
+        "properties": {
+          "running": {
+            "type": "boolean",
+            "title": "Running"
+          },
+          "pid": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pid"
+          },
+          "pid_file": {
+            "type": "string",
+            "title": "Pid File"
+          },
+          "binary_path": {
+            "type": "string",
+            "title": "Binary Path"
+          },
+          "pipewire_connected": {
+            "type": "boolean",
+            "title": "Pipewire Connected",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "running",
+          "pid_file",
+          "binary_path"
+        ],
+        "title": "DaemonStatus",
+        "description": "Daemon status response model."
+      },
+      "DevicesResponse": {
+        "properties": {
+          "devices": {
+            "items": {
+              "$ref": "#/components/schemas/AlsaDevice"
+            },
+            "type": "array",
+            "title": "Devices"
+          }
+        },
+        "type": "object",
+        "required": [
+          "devices"
+        ],
+        "title": "DevicesResponse",
+        "description": "Available ALSA devices response model."
+      },
+      "EqActiveResponse": {
+        "properties": {
+          "active": {
+            "type": "boolean",
+            "title": "Active"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "source_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Type"
+          },
+          "has_modern_target": {
+            "type": "boolean",
+            "title": "Has Modern Target",
+            "default": false
+          },
+          "opra_info": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Opra Info"
+          },
+          "opra_filters": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Opra Filters",
+            "default": []
+          },
+          "original_filters": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Original Filters",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "active"
+        ],
+        "title": "EqActiveResponse",
+        "description": "Active EQ profile response model."
+      },
+      "EqProfileInfo": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "filename": {
+            "type": "string",
+            "title": "Filename"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "size": {
+            "type": "integer",
+            "title": "Size"
+          },
+          "modified": {
+            "type": "number",
+            "title": "Modified"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "description": "Profile type: 'opra' or 'custom'"
+          },
+          "filter_count": {
+            "type": "integer",
+            "title": "Filter Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "filename",
+          "path",
+          "size",
+          "modified",
+          "type",
+          "filter_count"
+        ],
+        "title": "EqProfileInfo",
+        "description": "EQ profile info model."
+      },
+      "EqProfilesResponse": {
+        "properties": {
+          "profiles": {
+            "items": {
+              "$ref": "#/components/schemas/EqProfileInfo"
+            },
+            "type": "array",
+            "title": "Profiles"
+          }
+        },
+        "type": "object",
+        "required": [
+          "profiles"
+        ],
+        "title": "EqProfilesResponse",
+        "description": "EQ profiles list response model."
+      },
+      "EqValidationResponse": {
+        "properties": {
+          "valid": {
+            "type": "boolean",
+            "title": "Valid"
+          },
+          "errors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Errors",
+            "default": []
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Warnings",
+            "default": []
+          },
+          "preamp_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preamp Db"
+          },
+          "filter_count": {
+            "type": "integer",
+            "title": "Filter Count",
+            "default": 0
+          },
+          "filename": {
+            "type": "string",
+            "title": "Filename"
+          },
+          "file_exists": {
+            "type": "boolean",
+            "title": "File Exists"
+          },
+          "size_bytes": {
+            "type": "integer",
+            "title": "Size Bytes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "valid",
+          "filename",
+          "file_exists",
+          "size_bytes"
+        ],
+        "title": "EqValidationResponse",
+        "description": "EQ profile validation response model."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "OpraEqAttribution": {
+        "properties": {
+          "license": {
+            "type": "string",
+            "title": "License",
+            "default": "CC BY-SA 4.0"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "default": "OPRA Project"
+          },
+          "author": {
+            "type": "string",
+            "title": "Author"
+          }
+        },
+        "type": "object",
+        "required": [
+          "author"
+        ],
+        "title": "OpraEqAttribution",
+        "description": "OPRA EQ attribution model."
+      },
+      "OpraEqResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "author": {
+            "type": "string",
+            "title": "Author"
+          },
+          "details": {
+            "type": "string",
+            "title": "Details"
+          },
+          "parameters": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Parameters",
+            "default": {}
+          },
+          "apo_format": {
+            "type": "string",
+            "title": "Apo Format"
+          },
+          "modern_target_applied": {
+            "type": "boolean",
+            "title": "Modern Target Applied"
+          },
+          "attribution": {
+            "$ref": "#/components/schemas/OpraEqAttribution"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "author",
+          "details",
+          "apo_format",
+          "modern_target_applied",
+          "attribution"
+        ],
+        "title": "OpraEqResponse",
+        "description": "OPRA EQ profile response model."
+      },
+      "OpraSearchResponse": {
+        "properties": {
+          "results": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Results"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          },
+          "query": {
+            "type": "string",
+            "title": "Query"
+          }
+        },
+        "type": "object",
+        "required": [
+          "results",
+          "count",
+          "query"
+        ],
+        "title": "OpraSearchResponse",
+        "description": "OPRA search results response model."
+      },
+      "OpraStats": {
+        "properties": {
+          "vendors": {
+            "type": "integer",
+            "title": "Vendors"
+          },
+          "products": {
+            "type": "integer",
+            "title": "Products"
+          },
+          "eq_profiles": {
+            "type": "integer",
+            "title": "Eq Profiles"
+          },
+          "license": {
+            "type": "string",
+            "title": "License",
+            "default": "CC BY-SA 4.0"
+          },
+          "attribution": {
+            "type": "string",
+            "title": "Attribution",
+            "default": "OPRA Project (https://github.com/opra-project/OPRA)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "vendors",
+          "products",
+          "eq_profiles"
+        ],
+        "title": "OpraStats",
+        "description": "OPRA database statistics response model."
+      },
+      "OpraVendorsResponse": {
+        "properties": {
+          "vendors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Vendors"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "vendors",
+          "count"
+        ],
+        "title": "OpraVendorsResponse",
+        "description": "OPRA vendors list response model."
+      },
+      "RewireRequest": {
+        "properties": {
+          "source_node": {
+            "type": "string",
+            "title": "Source Node"
+          },
+          "target_node": {
+            "type": "string",
+            "title": "Target Node"
+          }
+        },
+        "type": "object",
+        "required": [
+          "source_node",
+          "target_node"
+        ],
+        "title": "RewireRequest",
+        "description": "Request model for rewiring PipeWire connections."
+      },
+      "Settings": {
+        "properties": {
+          "alsa_device": {
+            "type": "string",
+            "title": "Alsa Device",
+            "default": "default"
+          },
+          "upsample_ratio": {
+            "type": "integer",
+            "title": "Upsample Ratio",
+            "default": 8
+          },
+          "eq_profile": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Eq Profile"
+          },
+          "input_rate": {
+            "type": "integer",
+            "title": "Input Rate",
+            "default": 44100
+          },
+          "output_rate": {
+            "type": "integer",
+            "title": "Output Rate",
+            "default": 352800
+          }
+        },
+        "type": "object",
+        "title": "Settings",
+        "description": "Application settings model."
+      },
+      "SettingsUpdate": {
+        "properties": {
+          "alsa_device": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alsa Device"
+          },
+          "upsample_ratio": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Upsample Ratio"
+          },
+          "eq_profile": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Eq Profile"
+          },
+          "input_rate": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input Rate"
+          },
+          "output_rate": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output Rate"
+          }
+        },
+        "type": "object",
+        "title": "SettingsUpdate",
+        "description": "Settings update request model."
+      },
+      "Status": {
+        "properties": {
+          "settings": {
+            "$ref": "#/components/schemas/Settings"
+          },
+          "pipewire_connected": {
+            "type": "boolean",
+            "title": "Pipewire Connected",
+            "default": false
+          },
+          "alsa_connected": {
+            "type": "boolean",
+            "title": "Alsa Connected",
+            "default": false
+          },
+          "clip_count": {
+            "type": "integer",
+            "title": "Clip Count",
+            "default": 0
+          },
+          "total_samples": {
+            "type": "integer",
+            "title": "Total Samples",
+            "default": 0
+          },
+          "clip_rate": {
+            "type": "number",
+            "title": "Clip Rate",
+            "default": 0.0
+          },
+          "daemon_running": {
+            "type": "boolean",
+            "title": "Daemon Running",
+            "default": false
+          },
+          "eq_active": {
+            "type": "boolean",
+            "title": "Eq Active",
+            "default": false
+          },
+          "input_rate": {
+            "type": "integer",
+            "title": "Input Rate",
+            "default": 0
+          },
+          "output_rate": {
+            "type": "integer",
+            "title": "Output Rate",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "settings"
+        ],
+        "title": "Status",
+        "description": "System status response model."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "ZmqPingResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
+          "response": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Response"
+          },
+          "daemon_running": {
+            "type": "boolean",
+            "title": "Daemon Running"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "daemon_running"
+        ],
+        "title": "ZmqPingResponse",
+        "description": "ZeroMQ ping response model."
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "status",
+      "description": "System status and settings management"
+    },
+    {
+      "name": "daemon",
+      "description": "Audio daemon lifecycle and ZeroMQ communication"
+    },
+    {
+      "name": "eq",
+      "description": "EQ profile management (import, activate, delete)"
+    },
+    {
+      "name": "opra",
+      "description": "OPRA headphone database integration (CC BY-SA 4.0)"
+    },
+    {
+      "name": "legacy",
+      "description": "Deprecated endpoints - use alternatives instead"
+    }
+  ]
+}

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Export OpenAPI specification from FastAPI app.
+
+This script exports the OpenAPI schema without running the server.
+Used by pre-commit hooks to keep docs/api/openapi.json up to date.
+
+Usage:
+    uv run python scripts/export_openapi.py
+    uv run python scripts/export_openapi.py --output custom/path.json
+    uv run python scripts/export_openapi.py --check  # Exit 1 if out of date
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Add project root to path
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+DEFAULT_OUTPUT = PROJECT_ROOT / "docs" / "api" / "openapi.json"
+
+
+def get_openapi_schema() -> dict:
+    """Get OpenAPI schema from FastAPI app."""
+    from web.main import app
+
+    return app.openapi()
+
+
+def export_openapi(output_path: Path) -> None:
+    """Export OpenAPI schema to file."""
+    schema = get_openapi_schema()
+
+    # Ensure output directory exists
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write with consistent formatting
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(schema, f, indent=2, ensure_ascii=False)
+        f.write("\n")  # Trailing newline
+
+    print(f"OpenAPI spec exported to: {output_path}")
+
+
+def check_openapi(output_path: Path) -> bool:
+    """Check if OpenAPI spec is up to date.
+
+    Returns:
+        True if up to date, False otherwise.
+    """
+    if not output_path.exists():
+        print(f"OpenAPI spec not found: {output_path}")
+        return False
+
+    current_schema = get_openapi_schema()
+
+    with open(output_path, encoding="utf-8") as f:
+        existing_schema = json.load(f)
+
+    if current_schema == existing_schema:
+        print("OpenAPI spec is up to date")
+        return True
+    else:
+        print(f"OpenAPI spec is OUT OF DATE: {output_path}")
+        print("Run: uv run python scripts/export_openapi.py")
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export OpenAPI spec from FastAPI app",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  uv run python scripts/export_openapi.py              # Export to default location
+  uv run python scripts/export_openapi.py --check      # Check if up to date
+  uv run python scripts/export_openapi.py -o api.json  # Export to custom path
+        """,
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Output file path (default: {DEFAULT_OUTPUT.relative_to(PROJECT_ROOT)})",
+    )
+    parser.add_argument(
+        "--check",
+        "-c",
+        action="store_true",
+        help="Check if spec is up to date (exit 1 if not)",
+    )
+
+    args = parser.parse_args()
+
+    if args.check:
+        if not check_openapi(args.output):
+            sys.exit(1)
+    else:
+        export_openapi(args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
REST API開発のベストプラクティスに基づき、OpenAPIドキュメントの自動生成と開発ガイドラインを整備。

## Changes

### OpenAPI自動生成
| ファイル | 説明 |
|---------|------|
| `scripts/export_openapi.py` | サーバー起動不要でOpenAPI spec出力 |
| `.pre-commit-config.yaml` | `web/*.py`変更時に自動生成するフック追加 |
| `docs/api/openapi.json` | 初回生成済み（1658行） |

### ドキュメント
| ファイル | 説明 |
|---------|------|
| `CLAUDE.md` | REST API Development Guidelines セクション追加 |
| `docs/api/README.md` | API概要・エンドポイント一覧 |
| `docs/api/CHANGELOG.md` | API変更履歴テンプレート |

## CLAUDE.md追加ガイドライン
- レスポンスモデル必須化
- エラーハンドリング統一（ErrorResponse形式）
- OpenAPIタグ・deprecated指定
- API変更時チェックリスト

## 使い方

```bash
# OpenAPI spec を出力
uv run python scripts/export_openapi.py

# 最新かどうか確認
uv run python scripts/export_openapi.py --check
```

Pre-commitフック設定済みのため、`web/`配下のPythonファイル変更時に自動的に`openapi.json`が更新されます。

## Test plan
- [x] `uv run pytest tests/python/` - 258 passed
- [x] `uv run python scripts/export_openapi.py` - 正常出力
- [x] `uv run python scripts/export_openapi.py --check` - 正常判定

🤖 Generated with [Claude Code](https://claude.com/claude-code)