### PR TITLE
#208 エラーコード体系設計書

### DIFF
--- a/docs/architecture/error-codes.md
+++ b/docs/architecture/error-codes.md
@@ -35,6 +35,18 @@ C++ Audio Engine から Web API クライアントまで、システム全体で
 | Validation | `VALIDATION_` | 0x5000-0x5FFF | 入力検証、設定ファイル関連 |
 | Internal | `INTERNAL_` | 0xF000-0xFFFF | 予約：未分類エラー、フォールバック用 |
 
+### 2.1 カテゴリ選択ガイドライン
+
+```
+Q: どのカテゴリを使うべきか？
+
+1. 入力サンプリングレートやフォーマットの問題 → AUDIO_
+2. DAC/ALSAデバイスへのアクセス問題 → DAC_
+3. ZeroMQやデーモンとの通信問題 → IPC_
+4. CUDAの初期化やメモリ確保の問題 → GPU_
+5. ユーザー入力や設定ファイルの問題 → VALIDATION_
+```
+
 ### 2.2 Internal カテゴリについて
 
 `INTERNAL` カテゴリは以下の用途で使用する**予約カテゴリ**である：
@@ -47,18 +59,6 @@ C++ Audio Engine から Web API クライアントまで、システム全体で
 - 新しいエラーが発生した場合、まず適切な主要カテゴリへの追加を検討する
 - `INTERNAL` は一時的なフォールバックであり、恒久的な使用は避ける
 - `INTERNAL` エラーが頻発する場合は、エラーコード体系の見直しを検討する
-
-### 2.1 カテゴリ選択ガイドライン
-
-```
-Q: どのカテゴリを使うべきか？
-
-1. 入力サンプリングレートやフォーマットの問題 → AUDIO_
-2. DAC/ALSAデバイスへのアクセス問題 → DAC_
-3. ZeroMQやデーモンとの通信問題 → IPC_
-4. CUDAの初期化やメモリ確保の問題 → GPU_
-5. ユーザー入力や設定ファイルの問題 → VALIDATION_
-```
 
 ## 3. エラーコード一覧
 
@@ -269,12 +269,15 @@ enum class ErrorCode : uint32_t {
 };
 
 // エラーコードを文字列に変換
+// 未知のコードの場合は "UNKNOWN_ERROR" を返す
 const char* errorCodeToString(ErrorCode code);
 
 // カテゴリ名を取得
+// 未知のコードの場合は "internal" を返す
 const char* getErrorCategory(ErrorCode code);
 
 // HTTPステータスコードに変換
+// 未知のコードの場合は 500 を返す（Python側と同様のフォールバック）
 int toHttpStatus(ErrorCode code);
 
 // カテゴリ判定ヘルパー


### PR DESCRIPTION
## 概要

Issue #208 のエラーコード体系設計書です。実装前に設計レビューを行います。

## 設計内容

### エラーカテゴリ（5種類）
| カテゴリ | プレフィックス | 説明 |
|---------|---------------|------|
| Audio Processing | `AUDIO_` | 入出力レート、フォーマット、バッファ |
| DAC/ALSA | `DAC_` | DACデバイス、ALSA関連 |
| IPC/ZeroMQ | `IPC_` | プロセス間通信 |
| GPU/CUDA | `GPU_` | CUDA、GPUメモリ |
| Validation | `VALIDATION_` | 入力検証、設定ファイル |

### 準拠規格
- RFC 9457 Problem Details
- Google AIP-193
- gRPC Status Codes

### 成果物
- `docs/architecture/error-codes.md` - 設計ドキュメント

## レビューポイント

1. エラーカテゴリの分類は適切か
2. エラーコードの粒度は適切か（多すぎ/少なすぎ）
3. HTTPステータスコードのマッピングは適切か
4. C++/Python実装ガイドラインで不足はないか
5. エラー伝播フローで考慮漏れはないか

## 次のステップ

レビュー承認後、以下のサブIssueで実装を進めます：
- #44 C++ Daemon エラーハンドリング
- #209 ZeroMQ エラーメッセージ設計
- #210 REST API エラーレスポンス確定

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)