### PR TITLE
#44 C++ Error Codes Implementation

### DIFF
--- a/include/dac_capability.h
+++ b/include/dac_capability.h
@@ -1,6 +1,8 @@
 #ifndef DAC_CAPABILITY_H
 #define DAC_CAPABILITY_H
 
+#include "error_codes.h"
+
 #include <string>
 #include <vector>
 
@@ -15,6 +17,10 @@ struct Capability {
     int maxChannels;                  // Maximum channels
     bool isValid;                     // Whether scan was successful
     std::string errorMessage;         // Error message if scan failed
+
+    // Error code for structured error handling (Issue #44)
+    AudioEngine::ErrorCode errorCode = AudioEngine::ErrorCode::OK;
+    int alsaErrno = 0;  // ALSA error number if applicable
 };
 
 // Scan DAC capabilities via ALSA

--- a/include/error_codes.h
+++ b/include/error_codes.h
@@ -61,6 +61,10 @@ enum class ErrorCode : uint32_t {
     VALIDATION_FILE_NOT_FOUND = 0x5004,
     VALIDATION_PROFILE_EXISTS = 0x5005,
     VALIDATION_INVALID_HEADPHONE = 0x5006,
+
+    // Internal (0xF000) - Reserved for fallback
+    /** @brief Unknown/unmapped error */
+    INTERNAL_UNKNOWN = 0xF001,
 };
 
 /**
@@ -110,6 +114,13 @@ int toHttpStatus(ErrorCode code);
  */
 std::string errorCodeToHex(ErrorCode code);
 
+/**
+ * @brief Convert string to ErrorCode enum.
+ * @param str Error code string (e.g., "DAC_DEVICE_NOT_FOUND")
+ * @return Corresponding ErrorCode, or INTERNAL_UNKNOWN if not found
+ */
+ErrorCode stringToErrorCode(const std::string& str);
+
 // Category check helpers
 constexpr bool isAudioError(ErrorCode code) {
     return (static_cast<uint32_t>(code) & 0xF000) == 0x1000;
@@ -125,6 +136,24 @@ constexpr bool isGpuError(ErrorCode code) {
 }
 constexpr bool isValidationError(ErrorCode code) {
     return (static_cast<uint32_t>(code) & 0xF000) == 0x5000;
+}
+constexpr bool isInternalError(ErrorCode code) {
+    return (static_cast<uint32_t>(code) & 0xF000) == 0xF000;
+}
+
+/**
+ * @brief Check if error is retryable.
+ * @param code Error code
+ * @return true if operation can be retried
+ *
+ * Retryable errors (503/504 HTTP status):
+ * - IPC_DAEMON_NOT_RUNNING
+ * - IPC_TIMEOUT
+ * - IPC_CONNECTION_FAILED
+ */
+constexpr bool isRetryable(ErrorCode code) {
+    return code == ErrorCode::IPC_DAEMON_NOT_RUNNING || code == ErrorCode::IPC_TIMEOUT ||
+           code == ErrorCode::IPC_CONNECTION_FAILED;
 }
 
 }  // namespace AudioEngine

--- a/include/gpu/cuda_utils.h
+++ b/include/gpu/cuda_utils.h
@@ -1,6 +1,8 @@
 #ifndef GPU_CUDA_UTILS_H
 #define GPU_CUDA_UTILS_H
 
+#include "error_codes.h"
+
 #include <cuda_runtime.h>
 #include <cufft.h>
 
@@ -31,6 +33,40 @@ void checkCufftError(cufftResult result, const char* context);
 
 // Measure GPU utilization (requires nvidia-ml)
 double getGPUUtilization();
+
+// =========================================================================
+// ErrorCode-based error handling (Issue #44)
+// =========================================================================
+
+/**
+ * @brief Convert CUDA error to ErrorCode
+ * @param error CUDA error code
+ * @return Corresponding ErrorCode
+ */
+AudioEngine::ErrorCode cudaErrorToErrorCode(cudaError_t error);
+
+/**
+ * @brief Convert cuFFT result to ErrorCode
+ * @param result cuFFT result code
+ * @return GPU_CUFFT_ERROR on failure, OK on success
+ */
+AudioEngine::ErrorCode cufftResultToErrorCode(cufftResult result);
+
+/**
+ * @brief Check CUDA error and return ErrorCode (non-throwing)
+ * @param error CUDA error code
+ * @param context Context string for logging
+ * @return OK on success, appropriate ErrorCode on failure
+ */
+AudioEngine::ErrorCode checkCudaErrorCode(cudaError_t error, const char* context = nullptr);
+
+/**
+ * @brief Check cuFFT result and return ErrorCode (non-throwing)
+ * @param result cuFFT result code
+ * @param context Context string for logging
+ * @return OK on success, GPU_CUFFT_ERROR on failure
+ */
+AudioEngine::ErrorCode checkCufftErrorCode(cufftResult result, const char* context = nullptr);
 
 }  // namespace Utils
 

--- a/src/error_codes.cpp
+++ b/src/error_codes.cpp
@@ -49,6 +49,9 @@ static const std::unordered_map<ErrorCode, const char*> kErrorCodeStrings = {
     {ErrorCode::VALIDATION_FILE_NOT_FOUND, "VALIDATION_FILE_NOT_FOUND"},
     {ErrorCode::VALIDATION_PROFILE_EXISTS, "VALIDATION_PROFILE_EXISTS"},
     {ErrorCode::VALIDATION_INVALID_HEADPHONE, "VALIDATION_INVALID_HEADPHONE"},
+
+    // Internal
+    {ErrorCode::INTERNAL_UNKNOWN, "INTERNAL_UNKNOWN"},
 };
 
 // Error code to HTTP status mapping
@@ -94,6 +97,57 @@ static const std::unordered_map<ErrorCode, int> kHttpStatusMap = {
     {ErrorCode::VALIDATION_FILE_NOT_FOUND, 404},
     {ErrorCode::VALIDATION_PROFILE_EXISTS, 409},
     {ErrorCode::VALIDATION_INVALID_HEADPHONE, 404},
+
+    // Internal
+    {ErrorCode::INTERNAL_UNKNOWN, 500},
+};
+
+// String to error code mapping (reverse lookup)
+static const std::unordered_map<std::string, ErrorCode> kStringToErrorCode = {
+    {"OK", ErrorCode::OK},
+
+    // Audio Processing
+    {"AUDIO_INVALID_INPUT_RATE", ErrorCode::AUDIO_INVALID_INPUT_RATE},
+    {"AUDIO_INVALID_OUTPUT_RATE", ErrorCode::AUDIO_INVALID_OUTPUT_RATE},
+    {"AUDIO_UNSUPPORTED_FORMAT", ErrorCode::AUDIO_UNSUPPORTED_FORMAT},
+    {"AUDIO_FILTER_NOT_FOUND", ErrorCode::AUDIO_FILTER_NOT_FOUND},
+    {"AUDIO_BUFFER_OVERFLOW", ErrorCode::AUDIO_BUFFER_OVERFLOW},
+    {"AUDIO_XRUN_DETECTED", ErrorCode::AUDIO_XRUN_DETECTED},
+
+    // DAC/ALSA
+    {"DAC_DEVICE_NOT_FOUND", ErrorCode::DAC_DEVICE_NOT_FOUND},
+    {"DAC_OPEN_FAILED", ErrorCode::DAC_OPEN_FAILED},
+    {"DAC_CAPABILITY_SCAN_FAILED", ErrorCode::DAC_CAPABILITY_SCAN_FAILED},
+    {"DAC_RATE_NOT_SUPPORTED", ErrorCode::DAC_RATE_NOT_SUPPORTED},
+    {"DAC_FORMAT_NOT_SUPPORTED", ErrorCode::DAC_FORMAT_NOT_SUPPORTED},
+    {"DAC_BUSY", ErrorCode::DAC_BUSY},
+
+    // IPC/ZeroMQ
+    {"IPC_CONNECTION_FAILED", ErrorCode::IPC_CONNECTION_FAILED},
+    {"IPC_TIMEOUT", ErrorCode::IPC_TIMEOUT},
+    {"IPC_INVALID_COMMAND", ErrorCode::IPC_INVALID_COMMAND},
+    {"IPC_INVALID_PARAMS", ErrorCode::IPC_INVALID_PARAMS},
+    {"IPC_DAEMON_NOT_RUNNING", ErrorCode::IPC_DAEMON_NOT_RUNNING},
+    {"IPC_PROTOCOL_ERROR", ErrorCode::IPC_PROTOCOL_ERROR},
+
+    // GPU/CUDA
+    {"GPU_INIT_FAILED", ErrorCode::GPU_INIT_FAILED},
+    {"GPU_DEVICE_NOT_FOUND", ErrorCode::GPU_DEVICE_NOT_FOUND},
+    {"GPU_MEMORY_ERROR", ErrorCode::GPU_MEMORY_ERROR},
+    {"GPU_KERNEL_LAUNCH_FAILED", ErrorCode::GPU_KERNEL_LAUNCH_FAILED},
+    {"GPU_FILTER_LOAD_FAILED", ErrorCode::GPU_FILTER_LOAD_FAILED},
+    {"GPU_CUFFT_ERROR", ErrorCode::GPU_CUFFT_ERROR},
+
+    // Validation
+    {"VALIDATION_INVALID_CONFIG", ErrorCode::VALIDATION_INVALID_CONFIG},
+    {"VALIDATION_INVALID_PROFILE", ErrorCode::VALIDATION_INVALID_PROFILE},
+    {"VALIDATION_PATH_TRAVERSAL", ErrorCode::VALIDATION_PATH_TRAVERSAL},
+    {"VALIDATION_FILE_NOT_FOUND", ErrorCode::VALIDATION_FILE_NOT_FOUND},
+    {"VALIDATION_PROFILE_EXISTS", ErrorCode::VALIDATION_PROFILE_EXISTS},
+    {"VALIDATION_INVALID_HEADPHONE", ErrorCode::VALIDATION_INVALID_HEADPHONE},
+
+    // Internal
+    {"INTERNAL_UNKNOWN", ErrorCode::INTERNAL_UNKNOWN},
 };
 
 InnerError::InnerError(ErrorCode code, const std::string& message)
@@ -141,6 +195,14 @@ std::string errorCodeToHex(ErrorCode code) {
     std::ostringstream oss;
     oss << "0x" << std::hex << std::setfill('0') << std::setw(4) << static_cast<uint32_t>(code);
     return oss.str();
+}
+
+ErrorCode stringToErrorCode(const std::string& str) {
+    auto it = kStringToErrorCode.find(str);
+    if (it != kStringToErrorCode.end()) {
+        return it->second;
+    }
+    return ErrorCode::INTERNAL_UNKNOWN;
 }
 
 }  // namespace AudioEngine


### PR DESCRIPTION
## Summary
- C++ Audio Engine全体で統一されたエラーコード体系を実装
- 設計書 `docs/architecture/error-codes.md` に基づく30個のエラーコードを定義
- CUDA、ALSA、ZeroMQ各レイヤーでのエラーコード対応

## Changes

### Phase 1: Foundation
- `include/error_codes.h` - ErrorCode enum (6カテゴリ × 約5コード = 30コード)
- `src/error_codes.cpp` - ヘルパー関数群
- `tests/cpp/test_error_codes.cpp` - 22テストケース

### Phase 2: GPU/CUDA Error Handling
- `cudaErrorToErrorCode()` / `cufftResultToErrorCode()` 追加
- 非例外版 `checkCudaErrorCode()` / `checkCufftErrorCode()` 追加

### Phase 3: DAC/ALSA Error Handling
- `DacCapability::Capability` に `errorCode`, `alsaErrno` フィールド追加
- ALSAエラーからErrorCodeへのマッピング

### Phase 4: IPC Layer Error Propagation
- `InnerError` 構造体追加（詳細エラー情報伝播用）
- `CommandResult` に `errorCode` フィールド追加
- `buildResponseWithErrorCode()` / `parseResponseWithErrorCode()` 追加

## Test plan
- [x] `./build/error_codes_tests` - 22テスト全パス
- [x] `./build/cpu_tests` - 71テスト全パス
- [x] `./build/zmq_tests` - 20テスト全パス
- [x] 全体ビルド成功

## Related Issues
- Closes #44
- Part of #207 (統一エラーハンドリング設計 EPIC)
- 依存: #208 (エラーコード体系設計)
- 後続: #214 (Web API Error Integration)
- 後続: #215 (Graceful Shutdown Enhancement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)