### PR TITLE
#239 config.jsonにquad-phase mode設定を追加

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,6 +8,11 @@
   "gain": 1.0,
   "phaseType": "minimum",
   "filterPath": "data/coefficients/filter_44k_2m_min_phase.bin",
+  "quadPhaseEnabled": true,
+  "filterPath44kMin": "data/coefficients/filter_44k_2m_min_phase.bin",
+  "filterPath48kMin": "data/coefficients/filter_48k_2m_min_phase.bin",
+  "filterPath44kLinear": "data/coefficients/filter_44k_16x_2m_linear.bin",
+  "filterPath48kLinear": "data/coefficients/filter_48k_16x_2m_linear.bin",
   "eqEnabled": true,
   "eqProfilePath": "/home/michihito/Working/gpu_os/data/EQ/Sample_EQ.txt"
 }


### PR DESCRIPTION
## Summary
- `quadPhaseEnabled: true` を追加してquad-phaseモードを有効化
- 4つのフィルタパス（44k/48k × minimum/linear）を追加
- これによりLinear Phase / Minimum Phaseのランタイム切り替えが可能になる

## 修正内容
管理画面からLinear Phaseに切り替えようとすると以下のエラーが発生していた：
```
Quad-phase mode not enabled (runtime switching unavailable)
```

原因は `config.json` に `quadPhaseEnabled` 設定が欠落していたため。

## Test plan
- [ ] daemonを再起動
- [ ] 管理画面からLinear Phaseに切り替えてエラーが出ないことを確認
- [ ] Minimum Phaseに戻せることを確認

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)