### PR TITLE
#215 Graceful Shutdown Enhancement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,15 +23,15 @@ pkg_check_modules(ALSA REQUIRED alsa)
 pkg_check_modules(ZMQ REQUIRED libzmq)
 
 # systemd for daemon notification (optional, for Type=notify support)
+# Service file Type is automatically set based on libsystemd availability
 pkg_check_modules(SYSTEMD libsystemd)
 if(SYSTEMD_FOUND)
     set(HAVE_SYSTEMD TRUE)
-    message(STATUS "libsystemd found - systemd notification enabled")
+    message(STATUS "libsystemd found - systemd notification enabled (Type=notify)")
 else()
     set(HAVE_SYSTEMD FALSE)
-    message(STATUS "libsystemd not found - systemd notification disabled")
-    message(STATUS "  To enable: sudo apt-get install libsystemd-dev")
-    message(STATUS "  Or change Type=notify to Type=simple in service file")
+    message(STATUS "libsystemd not found - systemd notification disabled (Type=simple)")
+    message(STATUS "  To enable: sudo apt-get install libsystemd-dev && cmake -B build")
 endif()
 
 # NVML for GPU utilization monitoring (optional)
@@ -329,6 +329,17 @@ if(NOT DEFINED SYSTEMD_USER_UNIT_DIR)
     else()
         set(SYSTEMD_USER_UNIT_DIR "${CMAKE_INSTALL_PREFIX}/lib/systemd/user")
     endif()
+endif()
+
+# Set systemd service type based on libsystemd availability
+if(HAVE_SYSTEMD)
+    set(SYSTEMD_SERVICE_TYPE "notify")
+    set(SYSTEMD_NOTIFY_ACCESS "NotifyAccess=main")
+    set(SYSTEMD_WATCHDOG_SEC "# Watchdog: Daemon sends WATCHDOG=1 every 100ms, systemd expects it within 5s\nWatchdogSec=5")
+else()
+    set(SYSTEMD_SERVICE_TYPE "simple")
+    set(SYSTEMD_NOTIFY_ACCESS "# NotifyAccess not needed for Type=simple")
+    set(SYSTEMD_WATCHDOG_SEC "# Watchdog disabled (libsystemd not available at build time)")
 endif()
 
 # Generate service file with correct install paths

--- a/systemd/gpu-upsampler.service.in
+++ b/systemd/gpu-upsampler.service.in
@@ -7,19 +7,16 @@ After=pipewire.service
 BindsTo=pipewire.service
 
 [Service]
-# Type=notify: Daemon sends READY=1 when initialization is complete
-# This ensures systemd waits for full initialization before considering the service "started"
-# NOTE: If built without libsystemd (HAVE_SYSTEMD=OFF), change to Type=simple
-#       or install libsystemd-dev and rebuild
-Type=notify
-NotifyAccess=main
+# Service type depends on libsystemd availability at build time:
+# - Type=notify (HAVE_SYSTEMD=ON): Daemon sends READY=1/WATCHDOG=1
+# - Type=simple (HAVE_SYSTEMD=OFF): No systemd notification
+Type=@SYSTEMD_SERVICE_TYPE@
+@SYSTEMD_NOTIFY_ACCESS@
 WorkingDirectory=@CMAKE_INSTALL_FULL_DATADIR@/gpu_upsampler
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/gpu_upsampler_alsa
 ExecReload=/bin/kill -HUP $MAINPID
 
-# Watchdog: Daemon sends WATCHDOG=1 every 100ms, systemd expects it within 5s
-# If daemon hangs, systemd will restart it automatically
-WatchdogSec=5
+@SYSTEMD_WATCHDOG_SEC@
 
 # Graceful shutdown timeout: Allow 3 seconds for fade-out and cleanup
 # After this timeout, systemd will send SIGKILL


### PR DESCRIPTION
## Summary
- シグナルハンドラをasync-signal-safe化（volatile sig_atomic_tフラグ + メインループポーリング）
- systemd Type=notify統合（READY=1, STOPPING=1, WATCHDOG=1）
- シャットダウンシーケンスの明確化（ステップ番号付きログ）

## Changes
### Signal Handling (async-signal-safe)
- シグナルハンドラは`g_signal_shutdown`/`g_signal_reload`フラグの設定のみ
- PipeWireタイマー（100ms間隔）でフラグをポーリング
- `process_pending_signals()`でシャットダウン/リロード処理を実行

### systemd Integration
- `sd_notify(READY=1)` - 初期化完了通知
- `sd_notify(STOPPING=1)` - シャットダウン開始通知  
- `sd_notify(WATCHDOG=1)` - ヘルスチェック（100ms間隔）
- libsystemdはオプション（`HAVE_SYSTEMD`マクロで条件付きコンパイル）

### Service File Updates
- `Type=notify` - systemdが初期化完了を待機
- `WatchdogSec=5` - 5秒以内にWATCHDOG=1がなければ再起動
- `OOMScoreAdjust=-900` - OOMキラーからの保護
- `TimeoutStopSec=3` - グレースフルシャットダウンの猶予時間

## Test plan
- [x] ビルド確認（libsystemdあり/なし両方）
- [x] cpu_tests, soft_mute_tests, zmq_testsすべてパス
- [ ] SIGTERM送信後、フェードアウト→クリーンシャットダウンを確認
- [ ] SIGHUP送信後、設定リロードを確認
- [ ] systemdサービスとしての起動・停止を確認

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)