### PR TITLE
#244 save_configで既存のconfig.json設定を保持

### DIFF
--- a/tests/python/test_config.py
+++ b/tests/python/test_config.py
@@ -47,6 +47,26 @@ class TestLoadRawConfig:
 
         assert result == {}
 
+    def test_load_non_dict_json_array(self, tmp_path: Path) -> None:
+        """Test loading when config file contains a JSON array (not dict)."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text('["item1", "item2"]')
+
+        with patch("web.services.config.CONFIG_PATH", config_file):
+            result = load_raw_config()
+
+        assert result == {}
+
+    def test_load_non_dict_json_string(self, tmp_path: Path) -> None:
+        """Test loading when config file contains a JSON string (not dict)."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text('"just a string"')
+
+        with patch("web.services.config.CONFIG_PATH", config_file):
+            result = load_raw_config()
+
+        assert result == {}
+
 
 class TestSaveConfig:
     """Tests for save_config function."""

--- a/web/services/config.py
+++ b/web/services/config.py
@@ -27,11 +27,18 @@ def load_config() -> Settings:
 
 
 def load_raw_config() -> dict[str, Any]:
-    """Load raw config.json as dictionary, preserving all fields."""
+    """Load raw config.json as dictionary, preserving all fields.
+
+    Returns an empty dict if the file doesn't exist, is invalid JSON,
+    or contains non-dict JSON (e.g., array or string).
+    """
     if CONFIG_PATH.exists():
         try:
             with open(CONFIG_PATH) as f:
-                return json.load(f)
+                data = json.load(f)
+            # Guard: ensure we got a dict, not array/string/etc
+            if isinstance(data, dict):
+                return data
         except (json.JSONDecodeError, IOError):
             pass
     return {}


### PR DESCRIPTION
## Summary
- `save_config()`がconfig.jsonを完全に上書きしていたため、`quadPhaseEnabled`等の設定が消えていた
- 既存設定を読み込み、Settingsのフィールドのみを更新するよう修正

## 変更内容
- `load_raw_config()`: 既存のconfig.jsonを辞書として読み込む新関数を追加
- `save_config()`: 既存設定をマージしてからファイルに書き込むよう修正

## Test plan
- [ ] EQを適用後、config.jsonに`quadPhaseEnabled`が残っていることを確認
- [ ] daemon再起動後、quad-phaseモードで起動することを確認
- [ ] Linear Phase切り替えが正常に動作することを確認

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)