### PR TITLE
フィルタ生成ガイドを2Mフィルタに更新

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,7 +150,7 @@ int main(int argc, char* argv[]) {
                 std::cerr << "To generate: "
                           << "python scripts/generate_filter.py --input-rate 48000 "
                           << "--stopband-start 24000 --passband-end 21500 "
-                          << "--output-prefix filter_48k_1m_min_phase" << std::endl;
+                          << "--output-prefix filter_48k_2m_min_phase" << std::endl;
                 if (!applyPreset(FILTER_PRESET_44K)) {
                     std::cerr << "Error: 44.1kHz fallback filter also missing: "
                               << FILTER_PRESET_44K.path << std::endl;
@@ -179,7 +179,7 @@ int main(int argc, char* argv[]) {
                 std::cerr << "Generate it via: "
                           << "python scripts/generate_filter.py --input-rate 48000 "
                           << "--stopband-start 24000 --passband-end 21500 "
-                          << "--output-prefix filter_48k_1m_min_phase" << std::endl;
+                          << "--output-prefix filter_48k_2m_min_phase" << std::endl;
             } else {
                 std::cerr << "Generate it via scripts/generate_filter.py or specify with --filter."
                           << std::endl;


### PR DESCRIPTION
## 概要

Issue #250のフォローアップ修正。

`src/main.cpp` のエラーメッセージ内で、48kHzフィルタ欠品時の生成ガイドが旧1M版 (`filter_48k_1m_min_phase`) を指していた問題を修正。

## 変更内容

### `src/main.cpp`

**148-153行目**: 48kHzプリセットフィルタ欠品時の警告メッセージ
```cpp
// Before
--output-prefix filter_48k_1m_min_phase

// After
--output-prefix filter_48k_2m_min_phase
```

**178-182行目**: フィルタファイル不在時の一般エラーメッセージ
```cpp
// Before
--output-prefix filter_48k_1m_min_phase

// After
--output-prefix filter_48k_2m_min_phase
```

## 修正の必要性

PR #254でデフォルトフィルタを1M→2Mに切り替えた際、エラーメッセージ内のフィルタ生成ガイドを更新し忘れていた。

このまま放置すると:
- ユーザーが48kHzフィルタを欠品した場合
- エラーメッセージに従って `filter_48k_1m_min_phase` を生成
- しかしプログラムは `filter_48k_2m_min_phase` を要求
- 結果として正しいフィルタが使われず、再び-24dB音量低下が発生する恐れ

## テスト結果

```
All tests passed (71 assertions in 9 test cases)
```

関連: #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)