### PR TITLE
#290 Jetson向けUnified Memory対応: GPU転送後のCPU側係数メモリ解放

### DIFF
--- a/include/convolution_engine.h
+++ b/include/convolution_engine.h
@@ -375,6 +375,11 @@ class GPUUpsampler {
     // Free all GPU resources
     void cleanup();
 
+    // Release CPU-side filter coefficient memory after GPU transfer
+    // This saves ~100MB of RAM, especially important for Jetson Unified Memory
+    // Call this after all GPU transfers are complete (FFT pre-computation done)
+    void releaseHostCoefficients();
+
     // Configuration
     int upsampleRatio_;
     int blockSize_;

--- a/include/crossfeed_engine.h
+++ b/include/crossfeed_engine.h
@@ -249,6 +249,10 @@ class HRTFProcessor {
     // Free all GPU resources
     void cleanup();
 
+    // Release CPU-side HRTF coefficient memory after GPU transfer
+    // This saves memory, especially important for Jetson Unified Memory
+    void releaseHostCoefficients();
+
     void registerStreamBuffer(std::vector<float>& buffer, void** trackedPtr, size_t* trackedBytes,
                               const char* context);
 


### PR DESCRIPTION
## Summary
- GPU転送完了後にCPU側のフィルタ係数vectorを`clear()`+`shrink_to_fit()`で解放
- `releaseHostCoefficients()`関数を追加し、各初期化関数で呼び出し
- HRTFProcessor（crossfeed_engine）にも同様の最適化を適用

## 変更ファイル
- `include/convolution_engine.h` - 関数宣言追加
- `include/crossfeed_engine.h` - 関数宣言追加
- `src/gpu/gpu_upsampler_core.cu` - 関数実装 + initialize()で呼び出し
- `src/gpu/gpu_upsampler_multi_rate.cu` - 各初期化関数で呼び出し
- `src/gpu/crossfeed_engine.cu` - 関数実装 + initialize()で呼び出し

## 期待効果
- CPU側メモリ約100MB削減（2Mタップフィルタ×複数構成）
- Jetson Orin Nano（8GB Unified Memory）での動作マージン向上

## Test plan
- [x] cpu_tests: 104件パス
- [x] gpu_tests: 52件パス
- [x] メモリ解放ログの出力確認

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)