### PR TITLE
Add HUTUBS attribution to crossfeed UI

### DIFF
--- a/web/templates/user.py
+++ b/web/templates/user.py
@@ -342,6 +342,9 @@ def get_embedded_html() -> str:
             </div>
         </div>
         <div id="crossfeedMessage" class="message"></div>
+        <div style="font-size:10px; color:#555; margin-top:12px; text-align:center;">
+            HRTF data: <a href="https://depositonce.tu-berlin.de/items/dc2a3076-a291-417e-97f0-7697e332c960" target="_blank" style="color:#00d4ff;">HUTUBS, TU Berlin</a> (CC BY 4.0)
+        </div>
     </div>
 
     <script>


### PR DESCRIPTION
## Summary
- Display HRTF data source attribution in the crossfeed section
- Matches the pattern used for OPRA in the EQ section

## Changes
- `web/templates/user.py`: Added attribution link at bottom of crossfeed card

```
HRTF data: HUTUBS, TU Berlin (CC BY 4.0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)