### PR TITLE
#317 Fix auto_negotiation CUDA include path for Jetson build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,7 @@ target_link_libraries(auto_negotiation PUBLIC
 )
 target_include_directories(auto_negotiation PUBLIC
     ${CMAKE_SOURCE_DIR}/include
+    ${CUDAToolkit_INCLUDE_DIRS}
 )
 target_compile_options(auto_negotiation PRIVATE
     $<$<COMPILE_LANGUAGE:CXX>:-Wall -Wextra -O3>


### PR DESCRIPTION
auto_negotiation.h includes convolution_engine.h which requires cuda_runtime.h. Add CUDAToolkit_INCLUDE_DIRS to auto_negotiation target for cross-platform builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)