### PR TITLE
Fix #331: Jetson開発用自動起動スクリプト

### DIFF
--- a/docs/jetson/README.md
+++ b/docs/jetson/README.md
@@ -100,6 +100,7 @@ USBケーブル接続後、ブラウザで以下にアクセス：
 | [deployment/](./deployment/) | デプロイメント・OTA設計 |
 | [reliability/](./reliability/) | 信頼性・エラー回復設計 |
 | [quality/](./quality/) | 品質基準・テスト |
+| [dev-autostart.md](./dev-autostart.md) | Jetson開発機向け自動起動セットアップ |
 | [troubleshooting.md](./troubleshooting.md) | トラブルシューティング |
 
 ---

--- a/docs/jetson/dev-autostart.md
+++ b/docs/jetson/dev-autostart.md
@@ -1,0 +1,103 @@
+# Jetson 開発用自動起動スクリプト
+
+Jetson Orin上で Magic Box を開発する際、再起動の度に
+`gpu_upsampler_alsa` と Web UI を手動起動する手間をなくすための
+systemd セットアップスクリプトを追加しました。
+
+> ⚠️ **注意**: これは `/opt/magicbox` 以下に正規インストールされた
+> プロダクション環境向けではなく、
+> 「GitHub から clone した開発用ワークツリー」専用の機能です。
+
+---
+
+## スクリプト概要
+
+`scripts/jetson/setup-dev-autostart.sh` が以下を行います。
+
+1. リポジトリルート（デフォルト: スクリプト位置から逆算）を検出
+2. `gpu-upsampler-dev.service` と `magicbox-web-dev.service` を `/etc/systemd/system/` に生成
+3. `systemctl enable --now` で再起動後も常駐するように設定
+4. `uninstall` でサービス停止＋ファイル削除、`status` で状態参照が可能
+
+---
+
+## 依存条件
+
+- Jetson Orin 上で本リポジトリを直接 clone 済みであること
+- `cmake -B build && cmake --build build` で `build/gpu_upsampler_alsa` を生成済み
+- `uv` コマンドがインストール済み（`uv run uvicorn ...` を systemd で利用）
+- `sudo` 実行権限（サービスは system レベルで登録）
+
+---
+
+## 使い方
+
+### インストール
+
+```bash
+sudo ./scripts/jetson/setup-dev-autostart.sh install \
+  --user jetson \
+  --port 80
+```
+
+- `--user` : Web UI を動かす Linux ユーザー（デフォルト `jetson`）
+- `--port` : Web UI ポート。80 未満を指定すると
+  `CAP_NET_BIND_SERVICE` を自動付与します（既定は 80）。
+- `--repo` : リポジトリルートを手動指定したい場合に利用
+
+インストール後の確認:
+
+```bash
+sudo systemctl status gpu-upsampler-dev.service magicbox-web-dev.service
+```
+
+### 解除
+
+```bash
+sudo ./scripts/jetson/setup-dev-autostart.sh uninstall
+```
+
+`systemctl disable --now` を実行した上でサービスファイルを削除します。
+
+### 状態表示
+
+```bash
+sudo ./scripts/jetson/setup-dev-autostart.sh status
+```
+
+内部的に `systemctl status` を呼び出します。失敗時には systemd の
+標準的なエラーをそのまま確認できます。
+
+---
+
+## 作成される systemd サービス
+
+| サービス名 | 役割 | 主な設定 |
+|------------|------|----------|
+| `gpu-upsampler-dev.service` | `build/gpu_upsampler_alsa` をリポジトリ root で実行 | `LimitRTPRIO=99`, `LimitMEMLOCK=infinity`, `Restart=always` |
+| `magicbox-web-dev.service` | `uv run uvicorn web.main:app` を起動し Web UI を提供 | `After=gpu-upsampler-dev`, `Restart=always`, ポート <1024 の場合は Capability 付与 |
+
+- どちらも `WantedBy=multi-user.target` のため、Jetson 再起動後に自動で起動します。
+- Web UI は指定ユーザー権限で実行され、`PartOf=gpu-upsampler-dev` により
+  音声デーモンの停止に連動して終了します。
+
+---
+
+## トラブルシューティング
+
+| 症状 | 対応 |
+|------|------|
+| `uv` が見つからない | `curl -LsSf https://astral.sh/uv/install.sh \| sh` などでインストール |
+| `build/gpu_upsampler_alsa` が無い | Jetson 上で `cmake -B build && cmake --build build -j$(nproc)` を実行 |
+| ポート 80 で起動に失敗する | `--port 11881` など 1024 以上を指定して動作確認 |
+| サービスを完全に無効化したい | `sudo systemctl disable --now magicbox-web-dev gpu-upsampler-dev` を実行 |
+
+---
+
+## 今後の拡張アイデア
+
+- `magicbox-gadget.service` など USB Gadget まわりとの連携
+- `/opt/magicbox` パッケージとの差分を自動検出し警告
+- `--oneshot` でインストールのみ／有効化のみを切り替えるオプション
+
+

--- a/scripts/jetson/setup-dev-autostart.sh
+++ b/scripts/jetson/setup-dev-autostart.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Jetson Development Autostart Helper
+# -----------------------------------------------------------------------------
+# このスクリプトは「Jetson上でGitHubからcloneした開発用ワークツリー」を対象に、
+# 再起動後もgpu_upsamplerデーモンとWeb UIを自動で起動させるための
+# systemdサービス(gpu-upsampler-dev / magicbox-web-dev)を作成・削除します。
+#
+# ⚠️ Production用(正規バイナリ / /opt/magicbox レイアウト)では使用しないでください。
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT_DEFAULT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+UPS_SERVICE_NAME="gpu-upsampler-dev.service"
+WEB_SERVICE_NAME="magicbox-web-dev.service"
+UPS_SERVICE_PATH="/etc/systemd/system/$UPS_SERVICE_NAME"
+WEB_SERVICE_PATH="/etc/systemd/system/$WEB_SERVICE_NAME"
+
+ACTION="${1:-}"
+if [[ -z "$ACTION" ]]; then
+    ACTION="install"
+else
+    shift
+fi
+
+REPO_ROOT="$REPO_ROOT_DEFAULT"
+DEV_USER="${MAGICBOX_DEV_USER:-jetson}"
+WEB_PORT="${MAGICBOX_DEV_PORT:-80}"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  sudo scripts/jetson/setup-dev-autostart.sh [install|uninstall|status] [options]
+
+Options:
+  --repo <path>   : 任意のワークツリーパス（デフォルト: スクリプト位置から推定）
+  --user <name>   : Web UIを実行するユーザー（デフォルト: $MAGICBOX_DEV_USER または "jetson"）
+  --port <port>   : Web UIの待受ポート（デフォルト: $MAGICBOX_DEV_PORT または 80）
+
+環境変数:
+  MAGICBOX_DEV_USER : --user のデフォルト値
+  MAGICBOX_DEV_PORT : --port のデフォルト値
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)
+            [[ $# -lt 2 ]] && { echo "[ERROR] --repo requires a path" >&2; exit 1; }
+            REPO_ROOT="$(realpath "$2")"
+            shift 2
+            ;;
+        --user)
+            [[ $# -lt 2 ]] && { echo "[ERROR] --user requires a value" >&2; exit 1; }
+            DEV_USER="$2"
+            shift 2
+            ;;
+        --port)
+            [[ $# -lt 2 ]] && { echo "[ERROR] --port requires a value" >&2; exit 1; }
+            WEB_PORT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "[ERROR] Unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+info() {
+    echo -e "[INFO] $*"
+}
+
+warn() {
+    echo -e "[WARN] $*" >&2
+}
+
+error() {
+    echo -e "[ERROR] $*" >&2
+    exit 1
+}
+
+require_root() {
+    if [[ $EUID -ne 0 ]]; then
+        error "root権限が必要です。sudo経由で実行してください。"
+    fi
+}
+
+ensure_binary_exists() {
+    local path="$1"
+    if [[ ! -x "$path" ]]; then
+        warn "バイナリが見つかりません: $path"
+        warn "Jetson上で 'cmake -B build && cmake --build build -j\$(nproc)' を先に実行してください。"
+    fi
+}
+
+detect_uv_bin() {
+    local uv_path
+    uv_path="$(command -v uv || true)"
+    [[ -n "$uv_path" ]] || error "'uv' コマンドが見つかりません。https://github.com/astral-sh/uv をインストールしてください。"
+    echo "$uv_path"
+}
+
+ensure_user_exists() {
+    if ! id "$DEV_USER" >/dev/null 2>&1; then
+        error "ユーザー '$DEV_USER' が存在しません。--user で既存ユーザーを指定してください。"
+    fi
+}
+
+write_upsampler_service() {
+    local binary="$1"
+    cat > "$UPS_SERVICE_PATH" <<EOF
+[Unit]
+Description=GPU Upsampler (dev worktree: $REPO_ROOT)
+After=network.target sound.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=$REPO_ROOT
+ExecStart=$binary
+Restart=always
+RestartSec=2
+Environment=LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu
+LimitRTPRIO=99
+LimitMEMLOCK=infinity
+Nice=-10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+write_web_service() {
+    local uv_bin="$1"
+    local cap_section=""
+    if [[ "$WEB_PORT" -lt 1024 ]]; then
+        cap_section=$'AmbientCapabilities=CAP_NET_BIND_SERVICE\nCapabilityBoundingSet=CAP_NET_BIND_SERVICE'
+    fi
+
+    local dev_group
+    dev_group="$(id -gn "$DEV_USER")"
+
+    cat > "$WEB_SERVICE_PATH" <<EOF
+[Unit]
+Description=Magic Box Web UI (dev worktree: $REPO_ROOT)
+After=network.target gpu-upsampler-dev.service
+Requires=gpu-upsampler-dev.service
+PartOf=gpu-upsampler-dev.service
+
+[Service]
+Type=simple
+User=$DEV_USER
+Group=$dev_group
+WorkingDirectory=$REPO_ROOT
+ExecStart=$uv_bin run uvicorn web.main:app --host 0.0.0.0 --port $WEB_PORT --workers 1 --log-level warning
+Restart=always
+RestartSec=2
+Environment=UV_LINK_MODE=copy
+$cap_section
+NoNewPrivileges=yes
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+install_services() {
+    require_root
+    ensure_user_exists
+
+    local repo_binary="$REPO_ROOT/build/gpu_upsampler_alsa"
+    ensure_binary_exists "$repo_binary"
+
+    local uv_bin
+    uv_bin="$(detect_uv_bin)"
+
+    info "開発用ワークツリー: $REPO_ROOT"
+    info "Web UI実行ユーザー: $DEV_USER"
+    info "Web UIポート     : $WEB_PORT"
+    info "uvコマンド       : $uv_bin"
+
+    write_upsampler_service "$repo_binary"
+    info "Created $UPS_SERVICE_PATH"
+
+    write_web_service "$uv_bin"
+    info "Created $WEB_SERVICE_PATH"
+
+    systemctl daemon-reload
+    systemctl enable --now "$UPS_SERVICE_NAME"
+    systemctl enable --now "$WEB_SERVICE_NAME"
+
+    info "自動起動のセットアップが完了しました。"
+    info "ステータス確認: sudo systemctl status $UPS_SERVICE_NAME $WEB_SERVICE_NAME"
+}
+
+uninstall_services() {
+    require_root
+
+    systemctl disable --now "$WEB_SERVICE_NAME" >/dev/null 2>&1 || true
+    systemctl disable --now "$UPS_SERVICE_NAME" >/dev/null 2>&1 || true
+
+    rm -f "$WEB_SERVICE_PATH" "$UPS_SERVICE_PATH"
+    systemctl daemon-reload
+
+    info "自動起動設定を削除しました。"
+}
+
+show_status() {
+    systemctl status "$UPS_SERVICE_NAME" "$WEB_SERVICE_NAME"
+}
+
+case "$ACTION" in
+    install)
+        install_services
+        ;;
+    uninstall|remove|disable)
+        uninstall_services
+        ;;
+    status)
+        show_status
+        ;;
+    *)
+        echo "[ERROR] 不正なアクション: $ACTION" >&2
+        usage
+        exit 1
+        ;;
+esac
+


### PR DESCRIPTION
## Summary
- Jetson開発用のsystemd自動起動スクリプトを追加
- スクリプトの利用手順と注意点をjetsonドキュメントに整理しREADMEから参照
## Testing
- bash -n scripts/jetson/setup-dev-autostart.sh