### PR TITLE
Fix #330: Add missing dac_capability dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,7 @@ target_link_libraries(gpu_upsampler_alsa
     graceful_shutdown
     fallback_manager
     zeromq_interface
+    dac_capability
     logging
     ${PIPEWIRE_LIBRARIES}
     ${ALSA_LIBRARIES}


### PR DESCRIPTION
Build fixes for DAC hotplug feature:
- Add dac_capability.h include to alsa_daemon.cpp
- Link dac_capability library in gpu_upsampler_alsa target

This resolves compilation errors:
- "DacCapability does not name a type"
- "undefined reference to DacCapability::scan"

All tests pass (cpu_tests, gpu_tests, crossfeed_tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)