### PR TITLE
#349 パーティション畳み込みプランの土台

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ add_library(gpu_upsampler_core STATIC
     src/audio_io.cpp
     src/gpu/convolution_kernels.cu
     src/gpu/cuda_utils.cu
+    src/gpu/partition_plan.cpp
     src/gpu/gpu_upsampler_core.cu
     src/gpu/gpu_upsampler_multi_rate.cu
     src/gpu/gpu_upsampler_streaming.cu

--- a/config.json
+++ b/config.json
@@ -21,6 +21,13 @@
     "headSize": "m",
     "hrtfPath": "data/crossfeed/hrtf/"
   },
+  "partitionedConvolution": {
+    "enabled": false,
+    "fastPartitionTaps": 32768,
+    "minPartitionTaps": 8192,
+    "maxPartitions": 4,
+    "targetLatencyMs": 5.0
+  },
   "fallback": {
     "enabled": true,
     "gpuThreshold": 80.0,

--- a/include/config_loader.h
+++ b/include/config_loader.h
@@ -46,6 +46,15 @@ struct AppConfig {
         std::string hrtfPath = "data/crossfeed/hrtf/";
     } crossfeed;
 
+    // Partitioned convolution (Issue #349)
+    struct PartitionedConvolutionConfig {
+        bool enabled = false;
+        int fastPartitionTaps = 32768;
+        int minPartitionTaps = 8192;
+        int maxPartitions = 4;
+        float targetLatencyMs = 5.0f;
+    } partitionedConvolution;
+
     // Fallback settings (Issue #139)
     struct FallbackConfig {
         bool enabled = true;                 // Enable dynamic fallback

--- a/include/gpu/partition_plan.h
+++ b/include/gpu/partition_plan.h
@@ -1,0 +1,33 @@
+#ifndef GPU_PARTITION_PLAN_H
+#define GPU_PARTITION_PLAN_H
+
+#include "config_loader.h"
+
+#include <string>
+#include <vector>
+
+namespace ConvolutionEngine {
+
+struct PartitionDescriptor {
+    int taps = 0;
+    int fftSize = 0;
+    int validOutput = 0;
+    bool realtime = false;
+};
+
+struct PartitionPlan {
+    bool enabled = false;
+    int totalTaps = 0;
+    int realtimeTaps = 0;
+    std::vector<PartitionDescriptor> partitions;
+
+    std::string describe(int outputSampleRate) const;
+};
+
+PartitionPlan buildPartitionPlan(int totalTaps, int upsampleRatio,
+                                 const AppConfig::PartitionedConvolutionConfig& config);
+
+}  // namespace ConvolutionEngine
+
+#endif  // GPU_PARTITION_PLAN_H
+

--- a/src/gpu/partition_plan.cpp
+++ b/src/gpu/partition_plan.cpp
@@ -1,0 +1,110 @@
+#include "gpu/partition_plan.h"
+
+#include <algorithm>
+#include <cmath>
+#include <sstream>
+#include <string>
+
+namespace ConvolutionEngine {
+namespace {
+
+int nextPow2(int value) {
+    if (value <= 0) {
+        return 1;
+    }
+    int result = 1;
+    while (result < value) {
+        result <<= 1;
+    }
+    return result;
+}
+
+PartitionDescriptor makeDescriptor(int taps, bool realtime) {
+    PartitionDescriptor desc;
+    desc.taps = taps;
+    desc.realtime = realtime;
+    // Require enough FFT bins to accommodate taps + overlap
+    const int fftTarget = std::max(taps * 2, taps + 1);
+    desc.fftSize = nextPow2(fftTarget);
+    desc.validOutput = std::max(1, desc.fftSize - taps + 1);
+    return desc;
+}
+
+}  // namespace
+
+PartitionPlan buildPartitionPlan(int totalTaps, int upsampleRatio,
+                                 const AppConfig::PartitionedConvolutionConfig& config) {
+    PartitionPlan plan;
+    plan.totalTaps = totalTaps;
+    if (!config.enabled || totalTaps <= 0 || upsampleRatio <= 0) {
+        return plan;
+    }
+
+    plan.enabled = true;
+
+    const int minPartitionTaps = std::max(1024, config.minPartitionTaps);
+    const int maxPartitions = std::max(1, config.maxPartitions);
+
+    int remaining = totalTaps;
+    int fastTaps =
+        std::clamp(config.fastPartitionTaps, minPartitionTaps, std::max(minPartitionTaps, totalTaps));
+
+    plan.partitions.push_back(makeDescriptor(fastTaps, true));
+    plan.realtimeTaps = fastTaps;
+    remaining -= fastTaps;
+
+    int previousTaps = fastTaps;
+    int partitionsUsed = 1;
+
+    while (remaining > 0 && partitionsUsed < maxPartitions) {
+        int suggested = previousTaps * 2;
+        int taps = std::min(std::max(suggested, minPartitionTaps), remaining);
+
+        // Last allowed partition takes the rest
+        if (partitionsUsed == maxPartitions - 1) {
+            taps = remaining;
+        }
+
+        plan.partitions.push_back(makeDescriptor(taps, false));
+        remaining -= taps;
+        previousTaps = taps;
+        ++partitionsUsed;
+    }
+
+    if (remaining > 0) {
+        plan.partitions.push_back(makeDescriptor(remaining, false));
+    }
+
+    // Recompute realtime taps in case fast partition consumed entire filter
+    plan.realtimeTaps = plan.partitions.front().taps;
+    return plan;
+}
+
+std::string PartitionPlan::describe(int outputSampleRate) const {
+    if (!enabled || partitions.empty()) {
+        return "disabled";
+    }
+
+    std::ostringstream oss;
+    oss << partitions.size() << " partition(s): ";
+
+    for (size_t i = 0; i < partitions.size(); ++i) {
+        const auto& part = partitions[i];
+        if (i > 0) {
+            oss << " | ";
+        }
+        oss << (part.realtime ? "fast" : "tail") << "#" << i << "=" << part.taps << " taps, FFT "
+            << part.fftSize << ", valid " << part.validOutput;
+        if (outputSampleRate > 0) {
+            double latencyMs =
+                (static_cast<double>(part.validOutput) / static_cast<double>(outputSampleRate)) *
+                1000.0;
+            oss << " (" << std::round(latencyMs * 10.0) / 10.0 << " ms)";
+        }
+    }
+
+    return oss.str();
+}
+
+}  // namespace ConvolutionEngine
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -190,6 +190,7 @@ int main(int argc, char* argv[]) {
         // Step 2: Initialize GPU upsampler
         std::cout << std::endl << "Step 2: Initializing GPU engine..." << std::endl;
         ConvolutionEngine::GPUUpsampler upsampler;
+        upsampler.setPartitionedConvolutionConfig(appConfig.partitionedConvolution);
         if (!upsampler.initialize(config.filterPath, config.upsampleRatio, config.blockSize)) {
             return 1;
         }


### PR DESCRIPTION
## 概要\n- config.jsonにpartitionedConvolutionセクションを追加し、ConfigLoader/テストを更新\n- GPUアップサンプラにパーティションプラン機構を追加し、設定が有効な場合はプランをログ出力\n- ALSA/PipeWire両デーモンとCLIで新設定を渡し、プランサマリを表示\n\n## テスト\n- 未実施（ユーザー環境で実行予定）