### PR TITLE
#359 Control Plane: RTPハンドシェイクAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,33 @@ Jetson環境では PipeWire を介さずにネットワークRTPストリーム�
 
 詳細は `docs/architecture/rtp_session_manager.md` を参照してください。
 
+#### Control Plane (FastAPI) からの制御
+
+FastAPI 側に `/api/rtp/sessions` エンドポイントを追加しました。GUI なしでも以下の手順でセッションを作成／監視できます。
+
+```bash
+uv sync
+uv run uvicorn web.main:app --reload --port 8000
+
+# セッション作成
+curl -X POST http://127.0.0.1:8000/api/rtp/sessions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "session_id": "aes67-main",
+    "endpoint": {"bind_address": "0.0.0.0", "port": 6000},
+    "format": {"sample_rate": 48000, "channels": 2, "bits_per_sample": 24},
+    "sync": {"target_latency_ms": 5}
+  }'
+
+# 状態確認
+curl http://127.0.0.1:8000/api/rtp/sessions/aes67-main
+
+# 停止
+curl -X DELETE http://127.0.0.1:8000/api/rtp/sessions/aes67-main
+```
+
+`GET /api/rtp/sessions` はバックグラウンドポーラがキャッシュした RTCP テレメトリを返し、Data Plane に負荷を掛けません。
+
 ---
 
 ## 主要機能

--- a/tests/python/test_rtp_api.py
+++ b/tests/python/test_rtp_api.py
@@ -1,0 +1,157 @@
+"""
+Tests for RTP session FastAPI endpoints.
+"""
+
+import os
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("MAGICBOX_DISABLE_RTP_POLLING", "1")
+
+from web.main import app  # noqa: E402
+from web.services import telemetry_store  # noqa: E402
+from web.services.daemon_client import DaemonError, DaemonResponse  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_store():
+    telemetry_store.clear()
+    yield
+    telemetry_store.clear()
+
+
+class DummyDaemonClient:
+    """Context-manager friendly fake daemon client."""
+
+    def __init__(
+        self,
+        *,
+        start_response: DaemonResponse | None = None,
+        stop_response: DaemonResponse | None = None,
+        get_response: DaemonResponse | None = None,
+    ):
+        self.start_response = start_response or DaemonResponse(success=True, data={})
+        self.stop_response = stop_response or DaemonResponse(success=True, data={})
+        self.get_response = get_response or DaemonResponse(success=True, data={})
+        self.last_params: dict[str, Any] | None = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    def rtp_start_session(self, params: dict[str, Any]) -> DaemonResponse:
+        self.last_params = params
+        return self.start_response
+
+    def rtp_stop_session(self, session_id: str) -> DaemonResponse:
+        self.last_params = {"session_id": session_id}
+        return self.stop_response
+
+    def rtp_get_session(self, session_id: str) -> DaemonResponse:
+        self.last_params = {"session_id": session_id}
+        return self.get_response
+
+
+def test_create_session_success(client):
+    """POST /api/rtp/sessions should forward payload to daemon."""
+    dummy = DummyDaemonClient(
+        start_response=DaemonResponse(
+            success=True,
+            data={
+                "session_id": "aes67-main",
+                "bind_address": "0.0.0.0",
+                "port": 6000,
+            },
+        )
+    )
+
+    with patch("web.routers.rtp.get_daemon_client", return_value=dummy):
+        response = client.post("/api/rtp/sessions", json={"session_id": "aes67-main"})
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["session"]["session_id"] == "aes67-main"
+    assert dummy.last_params is not None
+    assert dummy.last_params["session_id"] == "aes67-main"
+    assert dummy.last_params["payload_type"] == 97
+
+
+def test_create_session_invalid_session_id(client):
+    """Invalid session IDs should trigger validation errors."""
+    response = client.post("/api/rtp/sessions", json={"session_id": "invalid id"})
+    assert response.status_code == 422
+
+
+def test_list_sessions_refreshes_from_daemon(client):
+    """GET /api/rtp/sessions should refresh cache when empty."""
+
+    async def fake_refresh():
+        telemetry_store.update_from_list(
+            [
+                {
+                    "session_id": "aes67-main",
+                    "packets_received": 10,
+                    "packets_dropped": 0,
+                }
+            ]
+        )
+        sessions, _ = telemetry_store.snapshot()
+        return sessions
+
+    with patch("web.routers.rtp.refresh_sessions_from_daemon", new=fake_refresh):
+        response = client.get("/api/rtp/sessions")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["sessions"][0]["session_id"] == "aes67-main"
+    assert data["sessions"][0]["packets_received"] == 10
+
+
+def test_get_session_fetches_from_daemon(client):
+    """GET /api/rtp/sessions/{id} should fallback to daemon when cache empty."""
+    dummy = DummyDaemonClient(
+        get_response=DaemonResponse(
+            success=True,
+            data={
+                "session_id": "aes67-main",
+                "packets_received": 42,
+                "packets_dropped": 1,
+            },
+        )
+    )
+
+    with patch("web.routers.rtp.get_daemon_client", return_value=dummy):
+        response = client.get("/api/rtp/sessions/aes67-main")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session"]["packets_received"] == 42
+
+
+def test_delete_session_error_propagates(client):
+    """Daemon error should map to HTTP status via exception handler."""
+    dummy = DummyDaemonClient(
+        stop_response=DaemonResponse(
+            success=False,
+            error=DaemonError(
+                error_code="AUDIO_RTP_SESSION_NOT_FOUND",
+                message="Session missing",
+            ),
+        )
+    )
+
+    with patch("web.routers.rtp.get_daemon_client", return_value=dummy):
+        response = client.delete("/api/rtp/sessions/unknown")
+
+    assert response.status_code == 404
+

--- a/web/main.py
+++ b/web/main.py
@@ -17,6 +17,7 @@ from .routers import (
     daemon_router,
     eq_router,
     opra_router,
+    rtp_router,
     status_router,
 )
 from .templates import get_admin_html
@@ -46,6 +47,10 @@ tags_metadata = [
     {
         "name": "crossfeed",
         "description": "Crossfeed (HRTF-based headphone virtualization) control",
+    },
+    {
+        "name": "rtp",
+        "description": "RTP session lifecycle management and telemetry",
     },
     {
         "name": "legacy",
@@ -88,6 +93,7 @@ app.include_router(eq_router)
 app.include_router(opra_router)
 app.include_router(dac_router)
 app.include_router(crossfeed_router)
+app.include_router(rtp_router)
 
 
 # Legacy restart endpoint (forwards to daemon restart)

--- a/web/routers/__init__.py
+++ b/web/routers/__init__.py
@@ -6,6 +6,7 @@ from .daemon import router as daemon_router
 from .eq import router as eq_router
 from .opra import router as opra_router
 from .status import router as status_router
+from .rtp import router as rtp_router
 
 __all__ = [
     "crossfeed_router",
@@ -14,4 +15,5 @@ __all__ = [
     "eq_router",
     "opra_router",
     "status_router",
+    "rtp_router",
 ]

--- a/web/routers/rtp.py
+++ b/web/routers/rtp.py
@@ -1,0 +1,148 @@
+"""RTP session management API."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable
+
+from fastapi import APIRouter, HTTPException, Path, status
+
+from ..models import (
+    ApiResponse,
+    RtpSessionCreateRequest,
+    RtpSessionCreateResponse,
+    RtpSessionDetailResponse,
+    RtpSessionListResponse,
+)
+from ..services import (
+    build_session_config_payload,
+    get_daemon_client,
+    parse_config_snapshot,
+    parse_metrics_payload,
+    refresh_sessions_from_daemon,
+    telemetry_poller,
+    telemetry_store,
+)
+
+router = APIRouter(prefix="/api/rtp", tags=["rtp"])
+
+SESSION_ID_PARAM = Path(
+    ...,
+    pattern=r"^[A-Za-z0-9._-]{1,64}$",
+    description="RTP session identifier",
+)
+
+
+async def _execute_daemon(callable_fn: Callable[[], Any]):
+    """Run blocking ZeroMQ calls on a worker thread."""
+    return await asyncio.to_thread(callable_fn)
+
+
+@router.on_event("startup")
+async def _start_poller():
+    await telemetry_poller.start()
+
+
+@router.on_event("shutdown")
+async def _stop_poller():
+    await telemetry_poller.stop()
+
+
+@router.post(
+    "/sessions",
+    response_model=RtpSessionCreateResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create RTP session",
+)
+async def create_session(request: RtpSessionCreateRequest) -> RtpSessionCreateResponse:
+    """Create a new RTP session and start receiving packets."""
+    params = build_session_config_payload(request)
+
+    def _command():
+        with get_daemon_client() as client:
+            return client.rtp_start_session(params)
+
+    response = await _execute_daemon(_command)
+    if not response.success:
+        if response.error:
+            raise response.error
+        raise HTTPException(status_code=502, detail="Failed to start RTP session")
+
+    data = response.data if isinstance(response.data, dict) else {}
+    if "session_id" not in data:
+        data["session_id"] = request.session_id
+    snapshot = parse_config_snapshot(data)
+    return RtpSessionCreateResponse(session=snapshot)
+
+
+@router.get(
+    "/sessions",
+    response_model=RtpSessionListResponse,
+    summary="List RTP sessions",
+)
+async def list_sessions() -> RtpSessionListResponse:
+    """Return cached RTP session telemetry."""
+    sessions, polled_at = telemetry_store.snapshot()
+    if not sessions:
+        await refresh_sessions_from_daemon()
+        sessions, polled_at = telemetry_store.snapshot()
+    return RtpSessionListResponse(sessions=sessions, polled_at_unix_ms=polled_at)
+
+
+@router.get(
+    "/sessions/{session_id}",
+    response_model=RtpSessionDetailResponse,
+    summary="Get RTP session detail",
+)
+async def get_session(session_id: str = SESSION_ID_PARAM) -> RtpSessionDetailResponse:
+    """Return telemetry for a single RTP session."""
+    cached, polled_at = telemetry_store.get(session_id)
+    if cached:
+        return RtpSessionDetailResponse(session=cached, polled_at_unix_ms=polled_at)
+
+    def _command():
+        with get_daemon_client() as client:
+            return client.rtp_get_session(session_id)
+
+    response = await _execute_daemon(_command)
+    if not response.success:
+        if response.error:
+            raise response.error
+        raise HTTPException(status_code=404, detail="RTP session not found")
+
+    data = response.data if isinstance(response.data, dict) else {}
+    telemetry_store.upsert(data)
+    session, polled_at = telemetry_store.get(session_id)
+    if not session:
+        session = parse_metrics_payload(data)
+        if session is None:
+            raise HTTPException(
+                status_code=502, detail="Daemon returned invalid telemetry payload"
+            )
+    return RtpSessionDetailResponse(session=session, polled_at_unix_ms=polled_at)
+
+
+@router.delete(
+    "/sessions/{session_id}",
+    response_model=ApiResponse,
+    summary="Delete RTP session",
+)
+async def delete_session(session_id: str = SESSION_ID_PARAM) -> ApiResponse:
+    """Stop and remove an RTP session."""
+
+    def _command():
+        with get_daemon_client() as client:
+            return client.rtp_stop_session(session_id)
+
+    response = await _execute_daemon(_command)
+    if not response.success:
+        if response.error:
+            raise response.error
+        raise HTTPException(status_code=404, detail="RTP session not found")
+
+    telemetry_store.remove(session_id)
+    return ApiResponse(
+        success=True,
+        message="RTP session stopped",
+        data={"session_id": session_id},
+    )

--- a/web/services/__init__.py
+++ b/web/services/__init__.py
@@ -32,6 +32,14 @@ from .pipewire import (
     setup_pipewire_links,
     wait_for_daemon_node,
 )
+from .rtp import (
+    build_session_config_payload,
+    parse_config_snapshot,
+    parse_metrics_payload,
+    refresh_sessions_from_daemon,
+    telemetry_poller,
+    telemetry_store,
+)
 
 __all__ = [
     # alsa
@@ -67,4 +75,11 @@ __all__ = [
     "setup_audio_routing",
     "setup_pipewire_links",
     "wait_for_daemon_node",
+    # rtp
+    "build_session_config_payload",
+    "parse_config_snapshot",
+    "parse_metrics_payload",
+    "refresh_sessions_from_daemon",
+    "telemetry_poller",
+    "telemetry_store",
 ]

--- a/web/services/daemon_client.py
+++ b/web/services/daemon_client.py
@@ -454,6 +454,24 @@ class DaemonClient:
         params = {"head_size": head_size.lower()}
         return self.send_json_command_v2("CROSSFEED_SET_SIZE", params)
 
+    # ========== RTP Session Commands (#359) ==========
+
+    def rtp_start_session(self, params: dict[str, Any]) -> DaemonResponse:
+        """Start an RTP session with the provided SessionConfig parameters."""
+        return self.send_json_command_v2("RTP_START_SESSION", params)
+
+    def rtp_stop_session(self, session_id: str) -> DaemonResponse:
+        """Stop a running RTP session."""
+        return self.send_json_command_v2("RTP_STOP_SESSION", {"session_id": session_id})
+
+    def rtp_list_sessions(self) -> DaemonResponse:
+        """List current RTP sessions and telemetry."""
+        return self.send_json_command_v2("RTP_LIST_SESSIONS")
+
+    def rtp_get_session(self, session_id: str) -> DaemonResponse:
+        """Retrieve metrics for a single RTP session."""
+        return self.send_json_command_v2("RTP_GET_SESSION", {"session_id": session_id})
+
 
 def get_daemon_client(timeout_ms: int = 3000) -> DaemonClient:
     """

--- a/web/services/rtp.py
+++ b/web/services/rtp.py
@@ -1,0 +1,312 @@
+"""Helpers for RTP session control and telemetry polling."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import threading
+import time
+from typing import Any
+
+from ..models import (
+    RtpAdvancedSettings,
+    RtpEndpointSettings,
+    RtpFormatSettings,
+    RtpRtcpSettings,
+    RtpSdpConfig,
+    RtpSecurityConfig,
+    RtpSessionConfigSnapshot,
+    RtpSessionCreateRequest,
+    RtpSessionMetrics,
+    RtpSyncSettings,
+)
+from .daemon_client import DaemonResponse, get_daemon_client
+
+logger = logging.getLogger(__name__)
+
+
+def _ms_now() -> int:
+    return int(time.time() * 1000)
+
+
+def _format_media_descriptor(fmt: RtpFormatSettings) -> str:
+    return f"L{fmt.bits_per_sample}/{fmt.sample_rate}/{fmt.channels}"
+
+
+def _render_sdp_body(
+    request: RtpSessionCreateRequest,
+    endpoint: RtpEndpointSettings,
+    fmt: RtpFormatSettings,
+    sync: RtpSyncSettings,
+    rtcp: RtpRtcpSettings,
+    sdp: RtpSdpConfig | None,
+    security: RtpSecurityConfig | None,
+) -> str | None:
+    if not sdp and not security:
+        return None
+    if sdp and sdp.body:
+        return sdp.body.strip()
+
+    connection_address = (
+        (sdp.connection_address if sdp else None)
+        or endpoint.multicast_group
+        or endpoint.bind_address
+    )
+
+    media_format = sdp.media_format if sdp and sdp.media_format else _format_media_descriptor(fmt)
+
+    lines = [
+        "v=0",
+        f"o=- 0 0 IN IP4 {connection_address}",
+        f"s={(sdp.session_name if sdp else 'MagicBox RTP Session')}",
+        f"c=IN IP4 {connection_address}",
+        "t=0 0",
+        f"m=audio {endpoint.port} RTP/AVP {fmt.payload_type}",
+        f"a=rtpmap:{fmt.payload_type} {media_format}",
+    ]
+
+    if rtcp.enable:
+        rtcp_port = rtcp.port or (endpoint.port + 1)
+        lines.append(f"a=rtcp:{rtcp_port}")
+
+    if sdp and sdp.media_clock:
+        lines.append(f"a=mediaclk:{sdp.media_clock}")
+
+    if security:
+        lines.append(
+            f"a=crypto:1 {security.crypto_suite} inline:{security.key_base64}"
+        )
+
+    return "\r\n".join(lines) + "\r\n"
+
+
+def build_session_config_payload(request: RtpSessionCreateRequest) -> dict[str, Any]:
+    """Convert API request into daemon SessionConfig payload."""
+    endpoint = request.endpoint
+    fmt = request.format
+    sync = request.sync
+    rtcp = request.rtcp
+    advanced = request.advanced
+
+    params: dict[str, Any] = {
+        "session_id": request.session_id,
+        "bind_address": endpoint.bind_address,
+        "port": endpoint.port,
+        "multicast": endpoint.multicast,
+        "ttl": endpoint.ttl,
+        "dscp": endpoint.dscp,
+        "sample_rate": fmt.sample_rate,
+        "channels": fmt.channels,
+        "bits_per_sample": fmt.bits_per_sample,
+        "big_endian": fmt.big_endian,
+        "signed": fmt.signed_samples,
+        "payload_type": fmt.payload_type,
+        "socket_buffer_bytes": advanced.socket_buffer_bytes,
+        "mtu_bytes": advanced.mtu_bytes,
+        "target_latency_ms": sync.target_latency_ms,
+        "watchdog_timeout_ms": sync.watchdog_timeout_ms,
+        "telemetry_interval_ms": sync.telemetry_interval_ms,
+        "enable_rtcp": rtcp.enable,
+        "enable_ptp": sync.enable_ptp,
+        "ptp_domain": sync.ptp_domain,
+    }
+
+    if endpoint.source_host:
+        params["source_host"] = endpoint.source_host
+    if endpoint.multicast_group:
+        params["multicast_group"] = endpoint.multicast_group
+    if endpoint.interface:
+        params["interface"] = endpoint.interface
+    if rtcp.port:
+        params["rtcp_port"] = rtcp.port
+    if sync.ptp_interface:
+        params["ptp_interface"] = sync.ptp_interface
+
+    sdp_body = _render_sdp_body(
+        request,
+        endpoint,
+        fmt,
+        sync,
+        rtcp,
+        request.sdp,
+        request.security,
+    )
+    if sdp_body:
+        params["sdp"] = sdp_body
+
+    return params
+
+
+def parse_config_snapshot(payload: dict[str, Any]) -> RtpSessionConfigSnapshot:
+    """Convert daemon payload into typed snapshot."""
+    return RtpSessionConfigSnapshot.from_daemon(payload)
+
+
+def parse_metrics_payload(
+    payload: dict[str, Any], polled_at_ms: int | None = None
+) -> RtpSessionMetrics | None:
+    """Convert daemon metrics JSON into RtpSessionMetrics."""
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str):
+        return None
+    return RtpSessionMetrics.from_daemon(payload, polled_at_unix_ms=polled_at_ms)
+
+
+class RtpTelemetryStore:
+    """In-memory cache of RTP telemetry for UI consumption."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._sessions: dict[str, RtpSessionMetrics] = {}
+        self._polled_at_ms: int | None = None
+
+    def update_from_list(self, sessions: list[dict[str, Any]]) -> None:
+        polled_at = _ms_now()
+        with self._lock:
+            updated: dict[str, RtpSessionMetrics] = {}
+            for payload in sessions:
+                metrics = parse_metrics_payload(payload, polled_at)
+                if metrics:
+                    updated[metrics.session_id] = metrics
+            self._sessions = updated
+            self._polled_at_ms = polled_at if updated else self._polled_at_ms
+
+    def upsert(self, payload: dict[str, Any]) -> None:
+        metrics = parse_metrics_payload(payload, _ms_now())
+        if not metrics:
+            return
+        with self._lock:
+            self._sessions[metrics.session_id] = metrics
+            self._polled_at_ms = metrics.updated_at_unix_ms
+
+    def remove(self, session_id: str) -> None:
+        with self._lock:
+            if session_id in self._sessions:
+                del self._sessions[session_id]
+
+    def snapshot(self) -> tuple[list[RtpSessionMetrics], int | None]:
+        with self._lock:
+            sessions = [metrics.model_copy() for metrics in self._sessions.values()]
+            return sessions, self._polled_at_ms
+
+    def get(self, session_id: str) -> tuple[RtpSessionMetrics | None, int | None]:
+        with self._lock:
+            metrics = self._sessions.get(session_id)
+            if metrics:
+                return metrics.model_copy(), self._polled_at_ms
+            return None, self._polled_at_ms
+
+    def clear(self) -> None:
+        with self._lock:
+            self._sessions.clear()
+            self._polled_at_ms = None
+
+
+class RtpTelemetryPoller:
+    """Background task that polls daemon for RTP telemetry."""
+
+    def __init__(
+        self,
+        store: RtpTelemetryStore,
+        *,
+        interval_s: float = 1.5,
+        enabled: bool = True,
+    ) -> None:
+        self._store = store
+        self._interval_s = max(0.25, interval_s)
+        self._enabled = enabled
+        self._task: asyncio.Task | None = None
+        self._stop_event: asyncio.Event | None = None
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    async def start(self) -> None:
+        if not self._enabled:
+            return
+        if self._task and not self._task.done():
+            return
+        self._stop_event = asyncio.Event()
+        loop = asyncio.get_running_loop()
+        self._task = loop.create_task(self._run())
+
+    async def stop(self) -> None:
+        if not self._task:
+            return
+        if self._stop_event:
+            self._stop_event.set()
+        try:
+            await self._task
+        finally:
+            self._task = None
+            self._stop_event = None
+
+    async def _run(self) -> None:
+        assert self._stop_event is not None
+        while not self._stop_event.is_set():
+            try:
+                await self._poll_once()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("RTP telemetry poller error: %s", exc)
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=self._interval_s)
+            except asyncio.TimeoutError:
+                continue
+
+    async def _poll_once(self) -> None:
+        def _execute() -> DaemonResponse:
+            with get_daemon_client() as client:
+                return client.rtp_list_sessions()
+
+        response = await asyncio.to_thread(_execute)
+        if response.success and isinstance(response.data, dict):
+            sessions = response.data.get("sessions", [])
+            if isinstance(sessions, list):
+                self._store.update_from_list(sessions)
+        elif response.error:
+            logger.debug("RTP telemetry poll failed: %s", response.error)
+
+
+def _is_polling_enabled() -> bool:
+    flag = os.getenv("MAGICBOX_DISABLE_RTP_POLLING", "").lower()
+    return flag not in {"1", "true", "yes", "on"}
+
+
+def _poll_interval() -> float:
+    value = os.getenv("MAGICBOX_RTP_POLL_INTERVAL_SEC", "").strip()
+    try:
+        parsed = float(value)
+        return parsed if parsed > 0 else 1.5
+    except ValueError:
+        return 1.5
+
+
+telemetry_store = RtpTelemetryStore()
+telemetry_poller = RtpTelemetryPoller(
+    telemetry_store,
+    interval_s=_poll_interval(),
+    enabled=_is_polling_enabled(),
+)
+
+
+async def refresh_sessions_from_daemon() -> list[RtpSessionMetrics]:
+    """Force-refresh telemetry cache by calling RTP_LIST_SESSIONS."""
+
+    def _execute() -> DaemonResponse:
+        with get_daemon_client() as client:
+            return client.rtp_list_sessions()
+
+    response = await asyncio.to_thread(_execute)
+    if not response.success:
+        if response.error:
+            raise response.error
+        return []
+
+    sessions = response.data.get("sessions", []) if isinstance(response.data, dict) else []
+    if isinstance(sessions, list):
+        telemetry_store.update_from_list(sessions)
+    snapshot, _ = telemetry_store.snapshot()
+    return snapshot
+


### PR DESCRIPTION
## Summary\n- add FastAPI /api/rtp/sessions endpoints with validation + ZeroMQ bridging\n- cache RTP telemetry via background poller and expose DTOs\n- document verification steps and add API unit tests\n\n## Testing\n- Not run (per instruction)