### PR TITLE
#353 EQ/phase support for partition mode

### DIFF
--- a/include/convolution_engine.h
+++ b/include/convolution_engine.h
@@ -534,7 +534,8 @@ class GPUUpsampler {
         int overlapSize = 0;
         size_t fftComplexSize = 0;
         int64_t sampleOffset = 0;
-        cufftComplex* d_filterFFT = nullptr;
+        cufftComplex* d_filterFFT[2] = {nullptr, nullptr};
+        int activeFilterIndex = 0;
 
         // Runtime buffers (allocated when streaming is enabled)
         float* d_timeDomain = nullptr;
@@ -576,6 +577,11 @@ class GPUUpsampler {
                                const float* d_newSamples, int newSamples,
                                float* d_channelOverlap, StreamFloatVector& tempOutput,
                                StreamFloatVector& outputData);
+    void setActiveHostCoefficients(const std::vector<float>& source);
+    bool updateActiveImpulseFromSpectrum(const cufftComplex* spectrum,
+                                         std::vector<float>& destination);
+    bool refreshPartitionFiltersFromHost();
+    bool refreshPartitionFiltersFromActiveSpectrum();
 
     struct PhaseCrossfadeState {
         bool active = false;
@@ -607,6 +613,8 @@ class GPUUpsampler {
     void registerStreamOutputBuffer(StreamFloatVector& buffer, cudaStream_t stream);
     void removePinnedHostBuffer(void* ptr);
     void unregisterHostBuffers();
+    cufftHandle partitionImpulsePlanInverse_ = 0;
+    float* d_partitionImpulse_ = nullptr;
 };
 
 // Utility functions

--- a/src/gpu/gpu_upsampler_eq.cu
+++ b/src/gpu/gpu_upsampler_eq.cu
@@ -33,6 +33,9 @@ void GPUUpsampler::restoreOriginalFilter() {
 
         eqApplied_ = false;
         std::cout << "EQ: Restored original filter (ping-pong)" << std::endl;
+        if (!refreshPartitionFiltersFromActiveSpectrum()) {
+            std::cerr << "EQ: Failed to refresh partition filters after restore" << std::endl;
+        }
     } catch (const std::exception& e) {
         std::cerr << "EQ: Failed to restore: " << e.what() << std::endl;
     }
@@ -110,6 +113,10 @@ bool GPUUpsampler::applyEqMagnitudeOnly(const std::vector<double>& eqMagnitude) 
 
         eqApplied_ = true;
         std::cout << "EQ: Applied with magnitude-only (linear phase preserved, ping-pong)" << std::endl;
+        if (!refreshPartitionFiltersFromActiveSpectrum()) {
+            std::cerr << "EQ: Failed to refresh partition filters after linear-phase EQ" << std::endl;
+            return false;
+        }
         return true;
 
     } catch (const std::exception& e) {
@@ -220,6 +227,11 @@ bool GPUUpsampler::applyEqMagnitudeMinPhase(const std::vector<double>& eqMagnitu
 
         eqApplied_ = true;
         std::cout << "EQ: Applied with minimum phase reconstruction (GPU, ping-pong)" << std::endl;
+        if (!refreshPartitionFiltersFromActiveSpectrum()) {
+            std::cerr << "EQ: Failed to refresh partition filters after minimum-phase EQ"
+                      << std::endl;
+            return false;
+        }
         return true;
 
     } catch (const std::exception& e) {

--- a/src/partition_runtime_utils.cpp
+++ b/src/partition_runtime_utils.cpp
@@ -34,7 +34,7 @@ void applyPartitionPolicy(const RuntimeRequest& request,
     }
 
     config.partitionedConvolution.enabled = true;
-    config.eqEnabled = false;
+    config.eqEnabled = request.eqEnabled;
     config.crossfeed.enabled = false;
 
     const auto& plan = upsampler.getPartitionPlan();
@@ -47,8 +47,7 @@ void applyPartitionPolicy(const RuntimeRequest& request,
               << " output)" << std::endl;
 
     if (request.eqEnabled) {
-        std::cout << "[Partition][" << tag
-                  << "] EQ disabled (unsupported in low-latency mode, see #353)" << std::endl;
+        std::cout << "[Partition][" << tag << "] EQ enabled for low-latency streaming" << std::endl;
     }
     if (request.crossfeedEnabled) {
         std::cout << "[Partition][" << tag


### PR DESCRIPTION
## Summary
- allow partitioned convolution to keep EQ + host coeff sync
- refresh partition filters during EQ/phase/rate switches
- add regression tests for eq + multi-rate in low-latency mode

## Testing
- not run (per instructions)
