### PR TITLE
#379 PipeWire ⇄ RTPモード切り替えUI

### DIFF
--- a/tests/python/test_input_mode_api.py
+++ b/tests/python/test_input_mode_api.py
@@ -1,0 +1,119 @@
+"""Tests for PipeWire ⇄ RTP input mode switching (Issue #379)."""
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from web import main as web_main
+from web.services import config as config_service
+
+
+def _write_config(path: Path, *, rtp_enabled: bool) -> None:
+    """Write a minimal config file with the requested RTP flag."""
+    config_data = {
+        "alsaDevice": "hw:AUDIO",
+        "upsampleRatio": 8,
+        "eqEnabled": False,
+        "crossfeed": {
+            "enabled": False,
+            "headSize": "m",
+            "hrtfPath": "data/crossfeed/hrtf/",
+        },
+        "rtp": {
+            "enabled": rtp_enabled,
+            "autoStart": True,
+            "sessionId": "pc_stream",
+        },
+    }
+    path.write_text(json.dumps(config_data))
+
+
+def _patch_config_paths(monkeypatch: pytest.MonkeyPatch, config_file: Path) -> None:
+    """Ensure every module reads the temporary config file."""
+    monkeypatch.setattr("web.constants.CONFIG_PATH", config_file)
+    monkeypatch.setattr("web.services.config.CONFIG_PATH", config_file)
+    monkeypatch.setattr("web.services.daemon.CONFIG_PATH", config_file)
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """Provide a TestClient with temporary config.json."""
+    config_file = tmp_path / "config.json"
+    _write_config(config_file, rtp_enabled=False)
+    _patch_config_paths(monkeypatch, config_file)
+    return TestClient(web_main.app, raise_server_exceptions=False)
+
+
+def test_switch_to_rtp_updates_config_and_restarts(monkeypatch, tmp_path):
+    """POST /api/input-mode/switch should toggle RTP mode and restart daemon."""
+    config_file = tmp_path / "config.json"
+    _write_config(config_file, rtp_enabled=False)
+    _patch_config_paths(monkeypatch, config_file)
+
+    restart_calls = {"stop": 0, "start": 0}
+
+    monkeypatch.setattr("web.routers.input_mode.check_daemon_running", lambda: True)
+
+    def fake_stop():
+        restart_calls["stop"] += 1
+        return True, "stopped"
+
+    def fake_start():
+        restart_calls["start"] += 1
+        return True, "started"
+
+    monkeypatch.setattr("web.routers.input_mode.stop_daemon", lambda: fake_stop())
+    monkeypatch.setattr("web.routers.input_mode.start_daemon", lambda: fake_start())
+    monkeypatch.setattr("web.routers.input_mode.time.sleep", lambda *_: None)
+
+    client = TestClient(web_main.app, raise_server_exceptions=False)
+    response = client.post("/api/input-mode/switch", json={"mode": "rtp"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["current_mode"] == "rtp"
+    assert data["restart_required"] is True
+    assert restart_calls == {"stop": 1, "start": 1}
+
+    updated = json.loads(config_file.read_text())
+    assert updated["rtp"]["enabled"] is True
+
+
+def test_switch_noop_when_mode_unchanged(monkeypatch, tmp_path):
+    """Switch endpoint should be a no-op when mode already matches."""
+    config_file = tmp_path / "config.json"
+    _write_config(config_file, rtp_enabled=True)
+    _patch_config_paths(monkeypatch, config_file)
+
+    monkeypatch.setattr("web.routers.input_mode.check_daemon_running", lambda: False)
+
+    client = TestClient(web_main.app, raise_server_exceptions=False)
+    response = client.post("/api/input-mode/switch", json={"mode": "rtp"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["restart_required"] is False
+    assert data["current_mode"] == "rtp"
+
+    updated = json.loads(config_file.read_text())
+    assert updated["rtp"]["enabled"] is True
+
+
+def test_status_endpoints_report_input_mode(client):
+    """Both /status and /daemon/status should expose the input_mode field."""
+    # Start with PipeWire mode
+    config_file = Path(config_service.CONFIG_PATH)
+    _write_config(config_file, rtp_enabled=False)
+
+    status_resp = client.get("/status")
+    assert status_resp.status_code == 200
+    assert status_resp.json()["input_mode"] == "pipewire"
+
+    # Switch config to RTP and verify /daemon/status reflects it
+    _write_config(config_file, rtp_enabled=True)
+    daemon_resp = client.get("/daemon/status")
+    assert daemon_resp.status_code == 200
+    assert daemon_resp.json()["input_mode"] == "rtp"
+

--- a/tests/python/test_rest_api_design.py
+++ b/tests/python/test_rest_api_design.py
@@ -109,7 +109,7 @@ class TestOpenAPISchema:
         tags = {tag["name"]: tag for tag in schema.get("tags", [])}
 
         # Should have all expected tags
-        expected_tags = ["status", "daemon", "eq", "opra", "legacy"]
+        expected_tags = ["status", "daemon", "eq", "opra", "input-mode", "legacy"]
         for tag_name in expected_tags:
             assert tag_name in tags, f"Missing tag: {tag_name}"
             assert (
@@ -127,6 +127,7 @@ class TestOpenAPISchema:
             ("/devices", "get"),
             ("/daemon/status", "get"),
             ("/daemon/zmq/ping", "get"),
+            ("/api/input-mode/switch", "post"),
             ("/eq/profiles", "get"),
             ("/eq/active", "get"),
         ]
@@ -165,6 +166,7 @@ class TestResponseModels:
             "clip_rate",
             "clip_count",
             "total_samples",
+            "input_mode",
         ]
         for field in required_fields:
             assert field in data, f"Missing field: {field}"
@@ -196,7 +198,13 @@ class TestResponseModels:
         data = response.json()
 
         # Should have DaemonStatus model fields
-        required_fields = ["running", "pid_file", "binary_path", "pipewire_connected"]
+        required_fields = [
+            "running",
+            "pid_file",
+            "binary_path",
+            "pipewire_connected",
+            "input_mode",
+        ]
         for field in required_fields:
             assert field in data, f"Missing field: {field}"
 

--- a/web/main.py
+++ b/web/main.py
@@ -16,6 +16,7 @@ from .routers import (
     dac_router,
     daemon_router,
     eq_router,
+    input_mode_router,
     opra_router,
     partitioned_router,
     rtp_router,
@@ -52,6 +53,10 @@ tags_metadata = [
     {
         "name": "rtp",
         "description": "RTP session lifecycle management and telemetry",
+    },
+    {
+        "name": "input-mode",
+        "description": "Switch between PipeWire and RTP input sources",
     },
     {
         "name": "legacy",
@@ -96,6 +101,7 @@ app.include_router(dac_router)
 app.include_router(crossfeed_router)
 app.include_router(rtp_router)
 app.include_router(partitioned_router)
+app.include_router(input_mode_router)
 
 
 # Legacy restart endpoint (forwards to daemon restart)

--- a/web/models.py
+++ b/web/models.py
@@ -50,6 +50,9 @@ class CrossfeedSettingsUpdate(BaseModel):
     hrtf_path: Optional[str] = None
 
 
+InputMode = Literal["pipewire", "rtp"]
+
+
 class Settings(BaseModel):
     """Application settings model."""
 
@@ -61,6 +64,7 @@ class Settings(BaseModel):
     input_rate: int = 44100
     output_rate: int = 352800
     crossfeed: CrossfeedSettings = Field(default_factory=CrossfeedSettings)
+    rtp_enabled: bool = False
 
 
 class SettingsUpdate(BaseModel):
@@ -128,6 +132,9 @@ class Status(BaseModel):
     input_rate: int = 0
     output_rate: int = 0
     peaks: PeakLevels = Field(default_factory=PeakLevels)
+    input_mode: InputMode = Field(
+        default="pipewire", description="Current input mode reported by config.json"
+    )
 
 
 class DaemonStatus(BaseModel):
@@ -138,6 +145,9 @@ class DaemonStatus(BaseModel):
     pid_file: str
     binary_path: str
     pipewire_connected: bool = False
+    input_mode: InputMode = Field(
+        default="pipewire", description="Current input mode reported by config.json"
+    )
 
 
 class ZmqPingResponse(BaseModel):
@@ -413,6 +423,30 @@ class ApiResponse(BaseModel):
     message: str
     data: Optional[dict[str, Any]] = None
     restart_required: bool = False
+
+
+# ============================================================================
+# Input Mode Models
+# ============================================================================
+
+
+class InputModeSwitchRequest(BaseModel):
+    """Request body for switching between PipeWire and RTP modes."""
+
+    mode: InputMode = Field(
+        description="Target mode: 'pipewire' to use local PipeWire input or 'rtp' for network input"
+    )
+
+
+class InputModeSwitchResponse(BaseModel):
+    """Response returned after attempting to switch input modes."""
+
+    success: bool
+    current_mode: InputMode = Field(description="Mode currently active after the switch")
+    restart_required: bool = Field(
+        default=False, description="True when the daemon was restarted to apply changes"
+    )
+    message: str
 
 
 # ============================================================================

--- a/web/routers/__init__.py
+++ b/web/routers/__init__.py
@@ -4,6 +4,7 @@ from .crossfeed import router as crossfeed_router
 from .dac import router as dac_router
 from .daemon import router as daemon_router
 from .eq import router as eq_router
+from .input_mode import router as input_mode_router
 from .opra import router as opra_router
 from .partitioned import router as partitioned_router
 from .status import router as status_router
@@ -15,6 +16,7 @@ __all__ = [
     "daemon_router",
     "eq_router",
     "opra_router",
+    "input_mode_router",
     "partitioned_router",
     "status_router",
     "rtp_router",

--- a/web/routers/daemon.py
+++ b/web/routers/daemon.py
@@ -79,6 +79,8 @@ async def daemon_status():
     running = check_daemon_running()
     pid = get_daemon_pid()
     pipewire_connected = check_pipewire_sink() if running else False
+    settings = load_config()
+    input_mode = "rtp" if settings.rtp_enabled else "pipewire"
 
     return DaemonStatus(
         running=running,
@@ -86,6 +88,7 @@ async def daemon_status():
         pid_file=str(PID_FILE_PATH),
         binary_path=str(DAEMON_BINARY),
         pipewire_connected=pipewire_connected,
+        input_mode=input_mode,
     )
 
 

--- a/web/routers/input_mode.py
+++ b/web/routers/input_mode.py
@@ -1,0 +1,60 @@
+"""Input mode switching endpoints."""
+
+import time
+
+from fastapi import APIRouter, HTTPException
+
+from ..models import InputModeSwitchRequest, InputModeSwitchResponse
+from ..services import check_daemon_running, start_daemon, stop_daemon
+from ..services.config import get_input_mode, save_input_mode
+
+router = APIRouter(prefix="/api/input-mode", tags=["input-mode"])
+
+
+@router.post("/switch", response_model=InputModeSwitchResponse)
+async def switch_input_mode(request: InputModeSwitchRequest):
+    """Toggle PipeWire ⇄ RTP input modes."""
+    target_mode = request.mode
+    current_mode = get_input_mode()
+
+    if target_mode == current_mode:
+        return InputModeSwitchResponse(
+            success=True,
+            current_mode=current_mode,
+            restart_required=False,
+            message=f"Input mode already set to {current_mode}",
+        )
+
+    if not save_input_mode(target_mode):
+        raise HTTPException(
+            status_code=500, detail="Failed to update input mode in config.json"
+        )
+
+    restart_required = False
+    if check_daemon_running():
+        stop_success, stop_msg = stop_daemon()
+        if not stop_success:
+            raise HTTPException(
+                status_code=500, detail=f"Failed to stop daemon: {stop_msg}"
+            )
+        time.sleep(1.0)
+        start_success, start_msg = start_daemon()
+        if not start_success:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to restart daemon after switching: {start_msg}",
+            )
+        time.sleep(0.5)
+        restart_required = True
+
+    return InputModeSwitchResponse(
+        success=True,
+        current_mode=target_mode,
+        restart_required=restart_required,
+        message=(
+            "Daemon restarted to apply new input mode"
+            if restart_required
+            else "Input mode updated (daemon not running)"
+        ),
+    )
+

--- a/web/routers/status.py
+++ b/web/routers/status.py
@@ -34,6 +34,7 @@ async def get_status():
     daemon_running = check_daemon_running()
     pipewire_connected = check_pipewire_sink() if daemon_running else False
     stats = load_stats()
+    input_mode = "rtp" if settings.rtp_enabled else "pipewire"
 
     return Status(
         settings=settings,
@@ -46,6 +47,7 @@ async def get_status():
         input_rate=stats["input_rate"],
         output_rate=stats["output_rate"],
         peaks=stats["peaks"],
+        input_mode=input_mode,
     )
 
 

--- a/web/services/__init__.py
+++ b/web/services/__init__.py
@@ -2,9 +2,11 @@
 
 from .alsa import get_alsa_devices
 from .config import (
+    get_input_mode,
     load_config,
     load_partitioned_convolution_settings,
     save_config,
+    save_input_mode,
     save_partitioned_convolution_settings,
     save_phase_type,
 )
@@ -57,6 +59,8 @@ __all__ = [
     "load_config",
     "load_partitioned_convolution_settings",
     "save_config",
+    "get_input_mode",
+    "save_input_mode",
     "save_partitioned_convolution_settings",
     "save_phase_type",
     # dac

--- a/web/services/config.py
+++ b/web/services/config.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from ..constants import CONFIG_PATH, EQ_PROFILES_DIR
 from ..models import (
     CrossfeedSettings,
+    InputMode,
     PartitionedConvolutionSettings,
     Settings,
 )
@@ -19,6 +20,15 @@ def _build_profile_path(profile_name: str | None) -> str | None:
     if not profile_name:
         return None
     return str(EQ_PROFILES_DIR / f"{profile_name}.txt")
+
+
+def _resolve_input_mode(config_data: dict[str, Any]) -> InputMode:
+    """Return input mode string based on RTP section."""
+    rtp_section = config_data.get("rtp", {})
+    enabled = False
+    if isinstance(rtp_section, dict):
+        enabled = bool(rtp_section.get("enabled"))
+    return "rtp" if enabled else "pipewire"
 
 
 def load_config() -> Settings:
@@ -57,6 +67,8 @@ def load_config() -> Settings:
                 hrtf_path=crossfeed_data.get("hrtfPath", "data/crossfeed/hrtf/"),
             )
 
+            input_mode = _resolve_input_mode(data)
+
             return Settings(
                 alsa_device=data.get("alsaDevice", "default"),
                 upsample_ratio=data.get("upsampleRatio", 8),
@@ -66,6 +78,7 @@ def load_config() -> Settings:
                 input_rate=data.get("inputRate", 44100),
                 output_rate=data.get("outputRate", 352800),
                 crossfeed=crossfeed,
+                rtp_enabled=input_mode == "rtp",
             )
         except (json.JSONDecodeError, KeyError, ValueError):
             # ValueError catches Pydantic validation errors (e.g., invalid head_size)
@@ -187,7 +200,37 @@ def save_config(settings: Settings) -> bool:
             "headSize": settings.crossfeed.head_size,
             "hrtfPath": settings.crossfeed.hrtf_path,
         }
+        # Preserve RTP settings but update enabled flag when provided
+        if settings.rtp_enabled:
+            rtp_section = existing.get("rtp", {})
+            if not isinstance(rtp_section, dict):
+                rtp_section = {}
+            rtp_section["enabled"] = True
+            existing["rtp"] = rtp_section
 
+        with open(CONFIG_PATH, "w") as f:
+            json.dump(existing, f, indent=2)
+        return True
+    except IOError:
+        return False
+
+
+def get_input_mode() -> InputMode:
+    """Read current input mode from config.json."""
+    raw = load_raw_config()
+    return _resolve_input_mode(raw)
+
+
+def save_input_mode(mode: InputMode) -> bool:
+    """Persist input mode (PipeWire or RTP) to config.json."""
+    normalized: InputMode = "rtp" if mode == "rtp" else "pipewire"
+    try:
+        existing = load_raw_config()
+        rtp_section = existing.get("rtp", {})
+        if not isinstance(rtp_section, dict):
+            rtp_section = {}
+        rtp_section["enabled"] = normalized == "rtp"
+        existing["rtp"] = rtp_section
         with open(CONFIG_PATH, "w") as f:
             json.dump(existing, f, indent=2)
         return True


### PR DESCRIPTION
## Summary
- Web UI に PipeWire/RTP 入力切り替えセクションを追加しステータス表示を拡張
- /api/input-mode/switch エンドポイントと config 管理の入力モード判定を実装
- Daemon/Status API とテストを更新し、入力モード切替の単体テストを追加

## Testing
- not run (not requested)
