### PR TITLE
Fix test_input_mode_api monkeypatch issue

### DIFF
--- a/tests/python/test_input_mode_api.py
+++ b/tests/python/test_input_mode_api.py
@@ -34,7 +34,8 @@ def _patch_config_paths(monkeypatch: pytest.MonkeyPatch, config_file: Path) -> N
     """Ensure every module reads the temporary config file."""
     monkeypatch.setattr("web.constants.CONFIG_PATH", config_file)
     monkeypatch.setattr("web.services.config.CONFIG_PATH", config_file)
-    monkeypatch.setattr("web.services.daemon.CONFIG_PATH", config_file)
+    # Note: web.services.daemon imports CONFIG_PATH from web.constants internally,
+    # so patching web.constants.CONFIG_PATH is sufficient
 
 
 @pytest.fixture
@@ -116,4 +117,3 @@ def test_status_endpoints_report_input_mode(client):
     daemon_resp = client.get("/daemon/status")
     assert daemon_resp.status_code == 200
     assert daemon_resp.json()["input_mode"] == "rtp"
-


### PR DESCRIPTION
web.services.daemon does not have CONFIG_PATH as module attribute. It imports CONFIG_PATH from web.constants internally in _is_rtp_enabled(). Removed incorrect monkeypatch line that caused AttributeError.

Test results:
- All 3 tests now pass
- test_switch_to_rtp_updates_config_and_restarts: PASSED
- test_switch_noop_when_mode_unchanged: PASSED
- test_status_endpoints_report_input_mode: PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)