### PR TITLE
#402 管理UIのminimum/hybrid刷新

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -273,7 +273,7 @@
           "daemon"
         ],
         "summary": "Get Phase Type",
-        "description": "Get current phase type from daemon.\n\nReturns the current filter phase type (minimum or linear).\nLinear phase has high latency (~1 second) but no phase distortion.\nMinimum phase has no pre-ringing and low latency.",
+        "description": "Get current phase type from daemon.\n\nReturns the current filter phase type (minimum or hybrid).\nHybrid combines minimum phase below 100 Hz with linear phase above 100 Hz (10 ms alignment) to retain imaging while keeping bass tight.",
         "operationId": "get_phase_type_daemon_phase_type_get",
         "responses": {
           "200": {
@@ -293,7 +293,7 @@
           "daemon"
         ],
         "summary": "Set Phase Type",
-        "description": "Set phase type on daemon.\n\nRequires quad-phase mode to be enabled (4 filter variants preloaded).\nChanges take effect immediately without daemon restart.\n\n- minimum: Minimum phase filter (recommended, no pre-ringing)\n- linear: Linear phase filter (high latency ~1 second)",
+        "description": "Set phase type on daemon.\n\nRequires quad-phase mode to be enabled (4 filter variants preloaded).\nChanges take effect immediately without daemon restart.\n\n- minimum: Minimum phase filter (recommended, no pre-ringing)\n- hybrid: Minimum phase below 100 Hz / linear phase above 100 Hz (10 ms alignment)",
         "operationId": "set_phase_type_daemon_phase_type_put",
         "requestBody": {
           "content": {
@@ -3034,10 +3034,10 @@
             "type": "string",
             "enum": [
               "minimum",
-              "linear"
+              "hybrid"
             ],
             "title": "Phase Type",
-            "description": "Current phase type: 'minimum' or 'linear'"
+            "description": "Current phase type: 'minimum' or 'hybrid'"
           },
           "latency_warning": {
             "anyOf": [
@@ -3049,7 +3049,7 @@
               }
             ],
             "title": "Latency Warning",
-            "description": "Warning message for linear phase (high latency ~1 second)"
+            "description": "Info/warning message for hybrid phase (10ms alignment above 100 Hz)"
           }
         },
         "type": "object",
@@ -3065,10 +3065,10 @@
             "type": "string",
             "enum": [
               "minimum",
-              "linear"
+              "hybrid"
             ],
             "title": "Phase Type",
-            "description": "Target phase type: 'minimum' or 'linear'"
+            "description": "Target phase type: 'minimum' or 'hybrid'"
           }
         },
         "type": "object",

--- a/src/alsa_daemon.cpp
+++ b/src/alsa_daemon.cpp
@@ -69,7 +69,7 @@ constexpr const char* PID_FILE_PATH = "/tmp/gpu_upsampler_alsa.pid";
 
 static void enforce_phase_partition_constraints(AppConfig& config) {
     if (config.partitionedConvolution.enabled && config.phaseType == PhaseType::Linear) {
-        std::cout << "[Partition] Linear phase is incompatible with low-latency mode. "
+        std::cout << "[Partition] Hybrid phase is incompatible with low-latency mode. "
                   << "Switching to minimum phase." << std::endl;
         config.phaseType = PhaseType::Minimum;
     }
@@ -2410,7 +2410,7 @@ static void zeromq_listener_thread() {
                     response = "ERR:Upsampler not initialized";
                 }
             } else if (cmd.rfind("PHASE_TYPE_SET:", 0) == 0) {
-                // Set phase type: PHASE_TYPE_SET:minimum or PHASE_TYPE_SET:linear
+                // Set phase type: PHASE_TYPE_SET:minimum or PHASE_TYPE_SET:hybrid
                 // Requires quad-phase mode to be enabled (4 filter variants preloaded)
                 std::string phaseStr = cmd.substr(15);  // Extract after "PHASE_TYPE_SET:"
                 if (!g_upsampler) {
@@ -2466,7 +2466,7 @@ static void zeromq_listener_thread() {
                         if (switch_success) {
                             if (newPhase == PhaseType::Linear &&
                                 g_config.partitionedConvolution.enabled) {
-                                std::cout << "[Partition] Linear phase selected, disabling "
+                                std::cout << "[Partition] Hybrid phase selected, disabling "
                                              "low-latency partitioned convolution."
                                           << std::endl;
                                 g_config.partitionedConvolution.enabled = false;
@@ -3595,7 +3595,7 @@ int main(int argc, char* argv[]) {
         // Log latency warning for linear phase
         if (g_config.phaseType == PhaseType::Linear) {
             double latencySec = g_upsampler->getLatencySeconds();
-            std::cout << "  WARNING: Linear phase latency: " << latencySec << " seconds ("
+            std::cout << "  WARNING: Hybrid phase latency: " << latencySec << " seconds ("
                       << g_upsampler->getLatencySamples() << " samples)" << std::endl;
         }
 

--- a/src/config_loader.cpp
+++ b/src/config_loader.cpp
@@ -8,7 +8,7 @@
 #include <nlohmann/json.hpp>
 
 PhaseType parsePhaseType(const std::string& str) {
-    if (str == "linear") {
+    if (str == "linear" || str == "hybrid") {
         return PhaseType::Linear;
     }
     // Default to Minimum for "minimum" or any invalid value
@@ -18,7 +18,7 @@ PhaseType parsePhaseType(const std::string& str) {
 const char* phaseTypeToString(PhaseType type) {
     switch (type) {
     case PhaseType::Linear:
-        return "linear";
+        return "hybrid";
     case PhaseType::Minimum:
     default:
         return "minimum";

--- a/src/pipewire_daemon.cpp
+++ b/src/pipewire_daemon.cpp
@@ -25,7 +25,7 @@ static AppConfig g_config;
 
 static void enforce_phase_partition_constraints(AppConfig& config) {
     if (config.partitionedConvolution.enabled && config.phaseType == PhaseType::Linear) {
-        std::cout << "[Partition] Linear phase is incompatible with low-latency mode. "
+        std::cout << "[Partition] Hybrid phase is incompatible with low-latency mode. "
                   << "Switching to minimum phase." << std::endl;
         config.phaseType = PhaseType::Minimum;
     }
@@ -505,7 +505,7 @@ int main(int argc, char* argv[]) {
         // Log latency warning for linear phase
         if (appConfig.phaseType == PhaseType::Linear) {
             double latencySec = g_upsampler->getLatencySeconds();
-            std::cout << "  WARNING: Linear phase latency: " << latencySec << " seconds ("
+            std::cout << "  WARNING: Hybrid phase latency: " << latencySec << " seconds ("
                       << g_upsampler->getLatencySamples() << " samples)" << std::endl;
         }
     } else {

--- a/tests/cpp/test_config_loader.cpp
+++ b/tests/cpp/test_config_loader.cpp
@@ -181,6 +181,10 @@ TEST_F(ConfigLoaderTest, ParsePhaseTypeLinear) {
     EXPECT_EQ(parsePhaseType("linear"), PhaseType::Linear);
 }
 
+TEST_F(ConfigLoaderTest, ParsePhaseTypeHybridAlias) {
+    EXPECT_EQ(parsePhaseType("hybrid"), PhaseType::Linear);
+}
+
 TEST_F(ConfigLoaderTest, ParsePhaseTypeInvalidDefaultsToMinimum) {
     EXPECT_EQ(parsePhaseType("invalid"), PhaseType::Minimum);
     EXPECT_EQ(parsePhaseType(""), PhaseType::Minimum);
@@ -192,7 +196,7 @@ TEST_F(ConfigLoaderTest, PhaseTypeToStringMinimum) {
 }
 
 TEST_F(ConfigLoaderTest, PhaseTypeToStringLinear) {
-    EXPECT_STREQ(phaseTypeToString(PhaseType::Linear), "linear");
+    EXPECT_STREQ(phaseTypeToString(PhaseType::Linear), "hybrid");
 }
 
 TEST_F(ConfigLoaderTest, AppConfigDefaultPhaseType) {
@@ -264,6 +268,16 @@ TEST_F(ConfigLoaderTest, LoadConfigWithPhaseTypeMinimum) {
 
 TEST_F(ConfigLoaderTest, LoadConfigWithPhaseTypeLinear) {
     writeConfig(R"({"phaseType": "linear"})");
+
+    AppConfig config;
+    bool result = loadAppConfig(testConfigPath, config, false);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(config.phaseType, PhaseType::Linear);
+}
+
+TEST_F(ConfigLoaderTest, LoadConfigWithPhaseTypeHybridAlias) {
+    writeConfig(R"({"phaseType": "hybrid"})");
 
     AppConfig config;
     bool result = loadAppConfig(testConfigPath, config, false);

--- a/tests/python/test_filter_switch_soft_mute.py
+++ b/tests/python/test_filter_switch_soft_mute.py
@@ -26,13 +26,13 @@ class TestPhaseTypeSwitchSoftMute:
         """Test that phase type switch triggers soft mute sequence."""
         with patch.object(daemon_client, "send_command") as mock_send:
             # Mock successful phase type switch
-            mock_send.return_value = (True, "OK:Phase type set to linear")
+            mock_send.return_value = (True, "OK:Phase type set to hybrid")
 
             # Switch phase type
-            success, message = daemon_client.set_phase_type("linear")
+            success, message = daemon_client.set_phase_type("hybrid")
 
             # Verify command was sent
-            mock_send.assert_called_once_with("PHASE_TYPE_SET:linear")
+            mock_send.assert_called_once_with("PHASE_TYPE_SET:hybrid")
             assert success is True
             assert "Phase type set" in message
 
@@ -57,7 +57,7 @@ class TestPhaseTypeSwitchSoftMute:
                 "ERR:Quad-phase mode not enabled (runtime switching unavailable)",
             )
 
-            success, message = daemon_client.set_phase_type("linear")
+            success, message = daemon_client.set_phase_type("hybrid")
 
             assert success is False
             assert "Quad-phase mode not enabled" in message
@@ -113,10 +113,10 @@ class TestFilterSwitchSoftMuteIntegration:
     def test_soft_mute_timing_phase_type_switch(self, daemon_client):
         """Test that phase type switch includes soft mute timing."""
         with patch.object(daemon_client, "send_command") as mock_send:
-            mock_send.return_value = (True, "OK:Phase type set to linear")
+            mock_send.return_value = (True, "OK:Phase type set to hybrid")
 
             start_time = time.time()
-            success, _ = daemon_client.set_phase_type("linear")
+            success, _ = daemon_client.set_phase_type("hybrid")
             elapsed = time.time() - start_time
 
             # Command should complete quickly (soft mute happens in daemon)
@@ -171,9 +171,9 @@ class TestFilterSwitchSoftMuteEdgeCases:
             mock_send.return_value = (True, "OK:Phase type set")
 
             # Rapid switches
-            daemon_client.set_phase_type("linear")
+            daemon_client.set_phase_type("hybrid")
             daemon_client.set_phase_type("minimum")
-            daemon_client.set_phase_type("linear")
+            daemon_client.set_phase_type("hybrid")
 
             # Should handle gracefully (daemon manages soft mute state)
             assert mock_send.call_count == 3
@@ -184,7 +184,7 @@ class TestFilterSwitchSoftMuteEdgeCases:
             mock_send.return_value = (True, "OK:Phase type set")
 
             # Start first switch
-            daemon_client.set_phase_type("linear")
+            daemon_client.set_phase_type("hybrid")
 
             # Immediately start second switch (before first completes)
             # In real implementation, daemon should handle this gracefully

--- a/tests/python/test_phase_type_api.py
+++ b/tests/python/test_phase_type_api.py
@@ -33,8 +33,8 @@ class TestPhaseTypeGet:
             assert data["phase_type"] == "minimum"
             assert data["latency_warning"] is None
 
-    def test_get_phase_type_linear_with_warning(self):
-        """Test getting linear phase type includes latency warning."""
+    def test_get_phase_type_hybrid_with_warning(self):
+        """Test getting hybrid phase type includes latency warning."""
         with patch("web.routers.daemon.get_daemon_client") as mock_client:
             mock_instance = MagicMock()
             mock_instance.__enter__ = MagicMock(return_value=mock_instance)
@@ -48,9 +48,9 @@ class TestPhaseTypeGet:
 
             assert response.status_code == 200
             data = response.json()
-            assert data["phase_type"] == "linear"
+            assert data["phase_type"] == "hybrid"
             assert data["latency_warning"] is not None
-            assert "latency" in data["latency_warning"].lower()
+            assert "10ms" in data["latency_warning"]
 
     def test_get_phase_type_daemon_error(self):
         """Test error handling when daemon communication fails."""
@@ -106,8 +106,8 @@ class TestPhaseTypeSet:
             mock_save_phase.assert_called_once_with("minimum")
             mock_save_partition.assert_not_called()
 
-    def test_set_phase_type_linear(self):
-        """Test setting phase type to linear."""
+    def test_set_phase_type_hybrid(self):
+        """Test setting phase type to hybrid."""
         with patch("web.routers.daemon.get_daemon_client") as mock_client, patch(
             "web.routers.daemon.save_phase_type"
         ) as mock_save_phase, patch(
@@ -132,15 +132,15 @@ class TestPhaseTypeSet:
 
             response = client.put(
                 "/daemon/phase-type",
-                json={"phase_type": "linear"},
+                json={"phase_type": "hybrid"},
             )
 
             assert response.status_code == 200
             data = response.json()
             assert data["success"] is True
-            assert data["data"]["phase_type"] == "linear"
+            assert data["data"]["phase_type"] == "hybrid"
             assert data["data"]["partition_disabled"] is True
-            mock_save_phase.assert_called_once_with("linear")
+            mock_save_phase.assert_called_once_with("hybrid")
             mock_save_partition.assert_called_once()
 
     def test_set_phase_type_invalid(self):
@@ -174,7 +174,7 @@ class TestPhaseTypeSet:
 
             response = client.put(
                 "/daemon/phase-type",
-                json={"phase_type": "linear"},
+                json={"phase_type": "hybrid"},
             )
 
             assert response.status_code == 503
@@ -191,13 +191,13 @@ class TestDaemonClientPhaseType:
         client = DaemonClient()
         with patch.object(client, "send_command_v2") as mock_send:
             mock_send.return_value = DaemonResponse(
-                success=True, data={"phase_type": "minimum"}
+                success=True, data={"phase_type": "linear"}
             )
 
             success, result = client.get_phase_type()
 
             assert success is True
-            assert result == {"phase_type": "minimum"}
+            assert result == {"phase_type": "hybrid"}
 
     def test_get_phase_type_invalid_json(self):
         """Test that get_phase_type handles daemon error."""
@@ -236,6 +236,6 @@ class TestDaemonClientPhaseType:
         with patch.object(client, "send_command") as mock_send:
             mock_send.return_value = (True, "Phase type set")
 
-            client.set_phase_type("linear")
+            client.set_phase_type("hybrid")
 
-            mock_send.assert_called_once_with("PHASE_TYPE_SET:linear")
+            mock_send.assert_called_once_with("PHASE_TYPE_SET:hybrid")

--- a/tests/python/test_rest_api_design.py
+++ b/tests/python/test_rest_api_design.py
@@ -266,7 +266,7 @@ class TestPhaseTypeEndpoints:
 
         # Should have PhaseTypeResponse model fields
         assert "phase_type" in data, "Missing field: phase_type"
-        assert data["phase_type"] in ["minimum", "linear"], "Invalid phase_type value"
+        assert data["phase_type"] in ["minimum", "hybrid"], "Invalid phase_type value"
         # latency_warning is optional (null for minimum phase)
         assert "latency_warning" in data
 

--- a/web/constants.py
+++ b/web/constants.py
@@ -16,6 +16,18 @@ PID_FILE_PATH = Path("/tmp/gpu_upsampler_alsa.pid")
 STATS_FILE_PATH = Path("/tmp/gpu_upsampler_stats.json")
 
 # ============================================================================
+# Phase Type Options
+# ============================================================================
+
+PHASE_TYPE_MINIMUM = "minimum"
+PHASE_TYPE_HYBRID = "hybrid"
+DAEMON_PHASE_LINEAR = "linear"  # Runtime daemon string (kept for backwards compat)
+HYBRID_PHASE_DESCRIPTION = "100Hz以下は最小位相 / 100Hz以上は線形位相（10ms整列）"
+HYBRID_PHASE_WARNING = (
+    f"ハイブリッド: {HYBRID_PHASE_DESCRIPTION}。約10msの整列ディレイが発生します。"
+)
+
+# ============================================================================
 # ZeroMQ
 # ============================================================================
 

--- a/web/models.py
+++ b/web/models.py
@@ -159,18 +159,18 @@ class ZmqPingResponse(BaseModel):
     daemon_running: bool
 
 
-PhaseType = Literal["minimum", "linear"]
+PhaseType = Literal["minimum", "hybrid"]
 
 
 class PhaseTypeResponse(BaseModel):
     """Phase type response model."""
 
     phase_type: PhaseType = Field(
-        description="Current phase type: 'minimum' or 'linear'"
+        description="Current phase type: 'minimum' or 'hybrid'"
     )
     latency_warning: Optional[str] = Field(
         default=None,
-        description="Warning message for linear phase (high latency ~1 second)",
+        description="Info/warning message for hybrid phase (10ms alignment above 100 Hz)",
     )
 
 
@@ -178,7 +178,7 @@ class PhaseTypeUpdateRequest(BaseModel):
     """Phase type update request model."""
 
     phase_type: PhaseType = Field(
-        description="Target phase type: 'minimum' or 'linear'"
+        description="Target phase type: 'minimum' or 'hybrid'"
     )
 
 

--- a/web/services/config.py
+++ b/web/services/config.py
@@ -6,7 +6,13 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from ..constants import CONFIG_PATH, EQ_PROFILES_DIR
+from ..constants import (
+    CONFIG_PATH,
+    DAEMON_PHASE_LINEAR,
+    EQ_PROFILES_DIR,
+    PHASE_TYPE_HYBRID,
+    PHASE_TYPE_MINIMUM,
+)
 from ..models import (
     CrossfeedSettings,
     InputMode,
@@ -155,7 +161,12 @@ def save_partitioned_convolution_settings(
 
 def save_phase_type(phase_type: str) -> bool:
     """Persist phaseType field in config.json."""
-    normalized = "linear" if phase_type == "linear" else "minimum"
+    phase = str(phase_type).lower()
+    normalized = (
+        PHASE_TYPE_HYBRID
+        if phase in (DAEMON_PHASE_LINEAR, PHASE_TYPE_HYBRID)
+        else PHASE_TYPE_MINIMUM
+    )
     try:
         existing = load_raw_config()
         existing["phaseType"] = normalized

--- a/web/services/daemon_client.py
+++ b/web/services/daemon_client.py
@@ -7,7 +7,12 @@ from typing import Any
 
 import zmq
 
-from ..constants import ZEROMQ_IPC_PATH
+from ..constants import (
+    DAEMON_PHASE_LINEAR,
+    PHASE_TYPE_HYBRID,
+    PHASE_TYPE_MINIMUM,
+    ZEROMQ_IPC_PATH,
+)
 from ..error_codes import ErrorCode, get_error_mapping
 
 
@@ -272,16 +277,30 @@ class DaemonClient:
         Get current phase type from daemon.
 
         Returns:
-            (success, {"phase_type": "minimum"|"linear"}) on success
+            (success, {"phase_type": "minimum"|"hybrid"}) on success
             (False, error_message) on failure
         """
         result = self.send_command_v2("PHASE_TYPE_GET")
         if result.success:
             if isinstance(result.data, dict):
+                phase = result.data.get("phase_type")
+                if isinstance(phase, str):
+                    if phase in (DAEMON_PHASE_LINEAR, PHASE_TYPE_HYBRID):
+                        result.data["phase_type"] = PHASE_TYPE_HYBRID
+                    else:
+                        result.data["phase_type"] = PHASE_TYPE_MINIMUM
                 return True, result.data
             if isinstance(result.data, str):
                 try:
-                    return True, json.loads(result.data)
+                    data = json.loads(result.data)
+                    if isinstance(data, dict):
+                        phase = data.get("phase_type")
+                        if isinstance(phase, str):
+                            if phase in (DAEMON_PHASE_LINEAR, PHASE_TYPE_HYBRID):
+                                data["phase_type"] = PHASE_TYPE_HYBRID
+                            else:
+                                data["phase_type"] = PHASE_TYPE_MINIMUM
+                    return True, data
                 except json.JSONDecodeError:
                     return False, f"Invalid JSON response: {result.data}"
             return True, {}
@@ -292,14 +311,21 @@ class DaemonClient:
         Set phase type on daemon.
 
         Args:
-            phase_type: "minimum" or "linear"
+            phase_type: "minimum" or "hybrid"
 
         Returns:
             (success, message) tuple
         """
-        if phase_type not in ("minimum", "linear"):
+        normalized = str(phase_type).lower()
+        allowed = {PHASE_TYPE_MINIMUM, PHASE_TYPE_HYBRID, DAEMON_PHASE_LINEAR}
+        if normalized not in allowed:
             return False, f"Invalid phase type: {phase_type}"
-        return self.send_command(f"PHASE_TYPE_SET:{phase_type}")
+        daemon_value = (
+            PHASE_TYPE_HYBRID
+            if normalized in (PHASE_TYPE_HYBRID, DAEMON_PHASE_LINEAR)
+            else PHASE_TYPE_MINIMUM
+        )
+        return self.send_command(f"PHASE_TYPE_SET:{daemon_value}")
 
     # ========== JSON Command Methods (#150) ==========
 


### PR DESCRIPTION
## 概要
- Web UI/APIからlinear表記を一掃し、minimum/hybridの二択に統一
- ZeroMQ/daemonレスポンスをhybrid表記に正規化し、設定書き込みも新名称に更新
- OpenAPI/テスト/ドキュメントを新仕様に合わせて整備

## テスト
- uv run pytest tests/python/test_phase_type_api.py tests/python/test_filter_switch_soft_mute.py
