### PR TITLE
Fix #447: allow PID 1 when comm matches gpu_upsampler

### DIFF
--- a/web/services/daemon.py
+++ b/web/services/daemon.py
@@ -82,7 +82,7 @@ def _get_service_pid(service: str) -> Optional[int]:
 
 def _pid_looks_like_daemon(pid: int) -> bool:
     """Verify PID belongs to gpu_upsampler (avoid PID 1 or unrelated processes)."""
-    if pid <= 1:
+    if pid < 1:
         return False
     comm_path = f"/proc/{pid}/comm"
     try:


### PR DESCRIPTION
## Summary\n- PID判定で pid<=1 を弾いていたため、コンテナ内で PID=1 のデーモンを running と判定できなかった問題を修正\n-  が  であれば PID=1 でも有効と見なす\n\n## Testing\n- pre-push hook (Python + diff-based tests)\n