### PR TITLE
#471 EQ再起動中にWeb UIが落ちないように

### DIFF
--- a/systemd/jetson/magicbox-web.service
+++ b/systemd/jetson/magicbox-web.service
@@ -6,10 +6,6 @@ Documentation=https://github.com/michihitoTakami/gpu_os
 After=network.target gpu-upsampler.service
 Requires=gpu-upsampler.service
 
-# If daemon stops, stop web UI too
-BindsTo=gpu-upsampler.service
-PartOf=gpu-upsampler.service
-
 [Service]
 Type=simple
 

--- a/web/templates/admin.py
+++ b/web/templates/admin.py
@@ -474,6 +474,10 @@ def get_admin_html() -> str:
         let wsReconnectAttempts = 0;
         const MAX_RECONNECT_ATTEMPTS = 5;
 
+        async function restartDaemon() {
+            await fetch(API + '/daemon/restart', { method: 'POST' });
+        }
+
         function connectWebSocket() {
             const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
             const wsUrl = protocol + '//' + window.location.host + '/ws/stats';
@@ -1170,7 +1174,7 @@ def get_admin_html() -> str:
                 showUploadMessage(data.message, data.success);
                 if (data.success && data.restart_required) {
                     btn.textContent = '再起動中...';
-                    await fetch(API + '/restart', { method: 'POST' });
+                    await restartDaemon();
                     setTimeout(() => {
                         fetchStatus();
                         fetchEqProfile();

--- a/web/templates/user.py
+++ b/web/templates/user.py
@@ -553,6 +553,10 @@ def get_embedded_html() -> str:
             return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
         }
 
+        async function restartDaemon() {
+            await fetch(API + '/daemon/restart', { method: 'POST' });
+        }
+
         /**
          * Convert RTP session metrics (from daemon telemetry) to discovery stream format.
          * This enables auto-started sessions to appear in the UI alongside scanned streams.
@@ -1095,7 +1099,7 @@ def get_embedded_html() -> str:
 
                 if (data.success && data.restart_required) {
                     btn.textContent = 'Restarting...';
-                    await fetch(API + '/restart', { method: 'POST' });
+                    await restartDaemon();
                     showMessage('Daemon restarting...', true);
                     setTimeout(fetchStatus, 2000);
                 } else {
@@ -1234,7 +1238,7 @@ def get_embedded_html() -> str:
                 showOpraMessage(data.message, data.success);
                 if (data.success && data.restart_required) {
                     btn.textContent = 'Restarting...';
-                    await fetch(API + '/restart', { method: 'POST' });
+                    await restartDaemon();
                     setTimeout(fetchStatus, 2000);
                 }
             } catch (e) {
@@ -1251,7 +1255,7 @@ def get_embedded_html() -> str:
                 const data = await res.json();
                 showOpraMessage(data.message, data.success);
                 if (data.success && data.restart_required) {
-                    await fetch(API + '/restart', { method: 'POST' });
+                    await restartDaemon();
                     setTimeout(fetchStatus, 2000);
                 }
             } catch (e) {


### PR DESCRIPTION
## Summary
- Replace the legacy /restart calls with /daemon/restart and share a restart helper in both UI templates.
- Remove BindsTo/PartOf from the Jetson magicbox-web.service so the web UI stays up while the GPU daemon restarts.

## Testing
- pre-commit