### PR TITLE
#498 低遅延モード切替でデーモン再読込

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -273,7 +273,7 @@
           "daemon"
         ],
         "summary": "Get Phase Type",
-        "description": "Get current phase type from daemon.\n\nReturns the current filter phase type (minimum or hybrid).\nHybrid keeps bass (≤100 Hz) minimum phase while aligning higher bands to a constant ~10 ms delay\n(1 period of the crossover frequency) to retain imaging while keeping bass tight.",
+        "description": "Get current phase type from daemon.\n\nReturns the current filter phase type (minimum or hybrid).\nHybrid keeps bass (≤100 Hz) minimum phase while aligning higher bands\nto a constant ~10 ms group delay (1 period of the crossover frequency) to retain imaging.",
         "operationId": "get_phase_type_daemon_phase_type_get",
         "responses": {
           "200": {
@@ -293,7 +293,7 @@
           "daemon"
         ],
         "summary": "Set Phase Type",
-        "description": "Set phase type on daemon.\n\nAll filter variants (min/linear × rate families) are preloaded by default, so changes take effect immediately without daemon restart.\n\n- minimum: Minimum phase filter (recommended, no pre-ringing)\n- hybrid: Minimum phase below 100 Hz / constant-delay region above 100 Hz (~10 ms alignment, 1 period of crossover frequency)",
+        "description": "Set phase type on daemon.\n\nAll filter variants (min/linear × rate families) are preloaded by default, so changes take effect immediately without daemon restart.\n\n- minimum: Minimum phase filter (recommended, no pre-ringing)\n- hybrid: Minimum phase below 100 Hz / constant-delay region above 100 Hz (~10 ms alignment)",
         "operationId": "set_phase_type_daemon_phase_type_put",
         "requestBody": {
           "content": {


### PR DESCRIPTION
## Summary
- reload the daemon when partitioned convolution settings change so the new latency path comes online without manual restarts
- add API tests for daemon reload success and failure cases and keep the OpenAPI spec in sync

## Testing
- .venv/bin/python -m pytest tests/python/test_partitioned_convolution_api.py
- diff-based-tests (skipped; RTP/Crossfeed UI suite cannot run in this headless environment)