### PR TITLE
#507 Phase 5: 統合テストと検証 - ハイブリッド位相廃止対応

### DIFF
--- a/tests/python/test_crossfeed_ui.py
+++ b/tests/python/test_crossfeed_ui.py
@@ -133,6 +133,8 @@ class TestCrossfeedUITemplate:
         assert "width=device-width" in html
         assert "initial-scale=1.0" in html
 
-        assert "display: flex" in html
-        assert ".head-size-group" in html
-        assert ".toggle-container" in html
+        # Check that external CSS is properly linked
+        assert "/static/css/main.css" in html
+        # Check that head-size-group and toggle-container classes are used in HTML
+        assert 'class="head-size-group"' in html
+        assert 'class="toggle-container"' in html

--- a/tests/python/test_filter_switch_soft_mute.py
+++ b/tests/python/test_filter_switch_soft_mute.py
@@ -26,13 +26,13 @@ class TestPhaseTypeSwitchSoftMute:
         """Test that phase type switch triggers soft mute sequence."""
         with patch.object(daemon_client, "send_command") as mock_send:
             # Mock successful phase type switch
-            mock_send.return_value = (True, "OK:Phase type set to hybrid")
+            mock_send.return_value = (True, "OK:Phase type set to linear")
 
             # Switch phase type
-            success, message = daemon_client.set_phase_type("hybrid")
+            success, message = daemon_client.set_phase_type("linear")
 
             # Verify command was sent
-            mock_send.assert_called_once_with("PHASE_TYPE_SET:hybrid")
+            mock_send.assert_called_once_with("PHASE_TYPE_SET:linear")
             assert success is True
             assert "Phase type set" in message
 
@@ -51,16 +51,16 @@ class TestPhaseTypeSwitchSoftMute:
     def test_phase_type_switch_error_handling(self, daemon_client):
         """Test error handling during phase type switch."""
         with patch.object(daemon_client, "send_command") as mock_send:
-            # Mock error response
+            # Mock error response for invalid phase type
             mock_send.return_value = (
                 False,
-                "ERR:Runtime switching unavailable",
+                "ERR:Invalid phase type: invalid",
             )
 
-            success, message = daemon_client.set_phase_type("hybrid")
+            success, message = daemon_client.set_phase_type("invalid")
 
             assert success is False
-            assert "Runtime switching unavailable" in message
+            assert "Invalid phase type" in message
 
 
 class TestCrossfeedSwitchSoftMute:
@@ -113,10 +113,10 @@ class TestFilterSwitchSoftMuteIntegration:
     def test_soft_mute_timing_phase_type_switch(self, daemon_client):
         """Test that phase type switch includes soft mute timing."""
         with patch.object(daemon_client, "send_command") as mock_send:
-            mock_send.return_value = (True, "OK:Phase type set to hybrid")
+            mock_send.return_value = (True, "OK:Phase type set to linear")
 
             start_time = time.time()
-            success, _ = daemon_client.set_phase_type("hybrid")
+            success, _ = daemon_client.set_phase_type("linear")
             elapsed = time.time() - start_time
 
             # Command should complete quickly (soft mute happens in daemon)
@@ -171,9 +171,9 @@ class TestFilterSwitchSoftMuteEdgeCases:
             mock_send.return_value = (True, "OK:Phase type set")
 
             # Rapid switches
-            daemon_client.set_phase_type("hybrid")
+            daemon_client.set_phase_type("linear")
             daemon_client.set_phase_type("minimum")
-            daemon_client.set_phase_type("hybrid")
+            daemon_client.set_phase_type("linear")
 
             # Should handle gracefully (daemon manages soft mute state)
             assert mock_send.call_count == 3
@@ -184,7 +184,7 @@ class TestFilterSwitchSoftMuteEdgeCases:
             mock_send.return_value = (True, "OK:Phase type set")
 
             # Start first switch
-            daemon_client.set_phase_type("hybrid")
+            daemon_client.set_phase_type("linear")
 
             # Immediately start second switch (before first completes)
             # In real implementation, daemon should handle this gracefully


### PR DESCRIPTION
## 概要

Issue #502（ハイブリッド位相廃止）に伴う統合テストの修正です。

## 変更内容

### 1. `test_filter_switch_soft_mute.py`
- ❌ `hybrid` 位相タイプを削除
- ✅ `linear` 位相タイプに変更（全5箇所）
- ✅ エラーハンドリングテストを `invalid` 位相タイプに更新

修正箇所:
- `test_phase_type_switch_triggers_soft_mute`: `hybrid` → `linear`
- `test_phase_type_switch_error_handling`: エラーメッセージを更新
- `test_soft_mute_timing_phase_type_switch`: `hybrid` → `linear`
- `test_rapid_phase_type_switches`: `hybrid` → `linear` (2箇所)
- `test_switch_during_existing_transition`: `hybrid` → `linear`

### 2. `test_crossfeed_ui.py`
- ❌ インラインCSS検証（`display: flex`, `.head-size-group`, `.toggle-container`）を削除
- ✅ 外部CSSリンク検証に変更（`/static/css/main.css`）
- ✅ HTMLクラス名の存在確認に修正

理由: CSSが外部ファイル（`/static/css/main.css`）に分離されているため、HTML内にスタイル定義は含まれない

## テスト結果

```bash
$ uv run pytest tests/python/ -v
======================= 597 passed, 24 skipped in 41.69s =======================
```

- ✅ **597個のテストが成功**
- ⏭️  24個のテストがスキップ（Coming Soon機能）
- ❌ **失敗なし**

## Issue #502との関連

この修正は、Issue #502 "EPIC: ハイブリッド位相の廃止と線形位相への移行" の **Phase 5: 統合テストと検証** (#507) に該当します。

### 完了した項目
- [x] フィルタースイッチのソフトミュートテストを修正
- [x] UI関連テストを修正
- [x] 全Pythonテストが成功することを確認

### 残りの作業
- [ ] C++エンジンテスト（`gpu_tests`, `cpu_tests`）の確認（別途実施）
- [ ] E2Eテストの確認（別途実施）
- [ ] テストレポートの作成

## チェックリスト

- [x] テストがパスする
- [x] pre-commitフックが成功
- [x] コミットメッセージにIssue番号を含む
- [x] 関連Issue (#502, #507) にリンク

🤖 Generated with [Claude Code](https://claude.com/claude-code)