### PR TITLE
#429 Shutdown manager refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,7 @@ add_executable(gpu_upsampler_alsa
     src/daemon/rtp_engine_coordinator.cpp
     src/daemon/zmq_server.cpp
     src/daemon/runtime_stats.cpp
+    src/daemon/shutdown_manager.cpp
 )
 
 target_include_directories(gpu_upsampler_alsa PRIVATE src)

--- a/include/daemon/shutdown_manager.h
+++ b/include/daemon/shutdown_manager.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "graceful_shutdown.h"
+#include "soft_mute.h"
+
+#include <atomic>
+#include <functional>
+
+namespace shutdown_manager {
+
+class ShutdownManager {
+   public:
+    struct Dependencies {
+        SoftMute::Controller** softMute = nullptr;
+        std::atomic<bool>* runningFlag = nullptr;
+        std::atomic<bool>* reloadFlag = nullptr;
+        std::atomic<bool>* mainLoopRunningFlag = nullptr;
+    };
+
+    explicit ShutdownManager(Dependencies deps);
+
+    // Signal handling
+    void installSignalHandlers();
+
+    // PipeWire-specific callbacks
+    void setQuitLoopCallback(std::function<void()> cb);
+    void setPipewireShutdownCallback(std::function<void()> cb);
+    void setRtpShutdownCallback(std::function<void()> cb);
+
+    void setMainLoopRunning(bool running);
+
+    // Notifications
+    void notifyReady(bool pipewireActive);
+
+    // Periodic processing (called from main loops)
+    void tick(bool pipewireActive);
+
+    // Shutdown execution (shared across PipeWire/RTP paths)
+    void runShutdownSequence(bool pipewireActive);
+
+    // Reset manager state between restarts
+    void reset();
+
+    bool isRunning() const;
+    bool isReloadRequested() const;
+
+   private:
+    SoftMute::Controller* activeSoftMute() const;
+    void waitForFadeOut();
+    void sendWatchdog();
+#ifdef HAVE_SYSTEMD
+    void sendReadyNotify(bool pipewireActive);
+    void sendStoppingNotify();
+#endif
+
+    Dependencies deps_;
+    GracefulShutdown::Controller controller_;  // own signal controller
+    std::function<void()> quitLoopCallback_;
+    std::function<void()> pipewireShutdownCallback_;
+    std::function<void()> rtpShutdownCallback_;
+
+    bool readyNotified_{false};
+    bool stoppingNotified_{false};
+    bool sequenceRan_{false};
+};
+
+}  // namespace shutdown_manager

--- a/src/alsa_daemon.cpp
+++ b/src/alsa_daemon.cpp
@@ -7,6 +7,7 @@
 #include "daemon/dac_manager.h"
 #include "daemon/rtp_engine_coordinator.h"
 #include "daemon/runtime_stats.h"
+#include "daemon/shutdown_manager.h"
 #include "daemon/streaming_cache_manager.h"
 #include "daemon/zmq_server.h"
 #include "daemon_constants.h"
@@ -31,7 +32,6 @@
 #include <chrono>
 #include <cmath>
 #include <condition_variable>
-#include <csignal>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -152,13 +152,6 @@ static ConvolutionEngine::RateFamily g_active_rate_family = ConvolutionEngine::R
 static PhaseType g_active_phase_type = PhaseType::Minimum;
 static std::atomic<float> g_limiter_gain{1.0f};
 static std::atomic<float> g_effective_gain{1.0f};
-
-// ========== Signal Handling (Async-Signal-Safe) ==========
-// These flags are set by the signal handler and polled by the main loop.
-// Using volatile sig_atomic_t ensures async-signal-safe access.
-static volatile sig_atomic_t g_signal_shutdown = 0;  // SIGTERM, SIGINT
-static volatile sig_atomic_t g_signal_reload = 0;    // SIGHUP
-static volatile sig_atomic_t g_signal_received = 0;  // Last signal number (for logging)
 
 // Global state
 static std::atomic<bool> g_running{true};
@@ -1503,85 +1496,18 @@ struct Data {
     struct pw_stream* input_stream;
     struct spa_source* signal_check_timer;  // Timer for checking signal flags
     bool gpu_ready;
+    shutdown_manager::ShutdownManager* shutdownManager;
 };
-
-// ========== Async-Signal-Safe Signal Handler ==========
-// This handler ONLY sets flags. All other processing is done in the main loop.
-// POSIX async-signal-safe: only sig_atomic_t writes are safe here.
-static void signal_handler(int sig) {
-    g_signal_received = sig;
-    if (sig == SIGHUP) {
-        g_signal_reload = 1;
-    } else {
-        g_signal_shutdown = 1;
-    }
-}
-
-// Process pending signals (called from main loop context, NOT from signal handler)
-// This function is safe to call with non-async-signal-safe code.
-// IMPORTANT: Shutdown (SIGTERM/SIGINT) takes priority over reload (SIGHUP).
-// If both signals arrive in the same cycle, shutdown wins.
-static void process_pending_signals() {
-    // Check for shutdown request FIRST (SIGTERM, SIGINT) - takes priority over reload
-    if (g_signal_shutdown) {
-        g_signal_shutdown = 0;
-        g_signal_reload = 0;  // Clear any pending reload - shutdown takes priority
-        int sig = g_signal_received;
-        std::cout << "\nReceived signal " << sig << ", shutting down..." << std::endl;
-
-        // Clear reload flag to ensure clean shutdown (not restart)
-        // This prevents do { ... } while (g_reload_requested) from restarting
-        g_reload_requested = false;
-
-        // Start fade-out for glitch-free shutdown
-        if (g_soft_mute) {
-            g_soft_mute->startFadeOut();
-        }
-
-        // Quit main loop to trigger shutdown sequence
-        if (g_main_loop_running.load() && g_pw_loop) {
-            pw_main_loop_quit(g_pw_loop);
-        } else {
-            g_running = false;
-        }
-        return;  // Don't process reload if shutdown was requested
-    }
-
-    // Check for reload request (SIGHUP) - only if no shutdown pending
-    if (g_signal_reload) {
-        g_signal_reload = 0;
-        int sig = g_signal_received;
-        std::cout << "\nReceived SIGHUP (signal " << sig << "), restarting for config reload..."
-                  << std::endl;
-        g_reload_requested = true;
-
-        // Start fade-out for glitch-free reload
-        if (g_soft_mute) {
-            g_soft_mute->startFadeOut();
-        }
-
-        // Quit main loop to trigger reload sequence
-        if (g_main_loop_running.load() && g_pw_loop) {
-            pw_main_loop_quit(g_pw_loop);
-        } else {
-            g_running = false;
-        }
-    }
-}
 
 // PipeWire timer callback to check for pending signals
 // Called periodically (every 100ms) from the PipeWire main loop.
 static void on_signal_check_timer(void* userdata, uint64_t expirations) {
-    (void)userdata;
     (void)expirations;
 
-    // Process any pending signals
-    process_pending_signals();
-
-#ifdef HAVE_SYSTEMD
-    // Send watchdog heartbeat to systemd
-    sd_notify(0, "WATCHDOG=1");
-#endif
+    auto* context = reinterpret_cast<Data*>(userdata);
+    if (context && context->shutdownManager) {
+        context->shutdownManager->tick(true);
+    }
 }
 
 // Input stream process callback (44.1kHz audio from PipeWire)
@@ -2399,21 +2325,27 @@ int main(int argc, char* argv[]) {
     LOG_INFO("========================================");
     LOG_INFO("PID: {} (file: {})", getpid(), PID_FILE_PATH);
 
-    // Install signal handlers (SIGHUP for restart, SIGINT/SIGTERM for shutdown)
-    std::signal(SIGINT, signal_handler);
-    std::signal(SIGTERM, signal_handler);
-    std::signal(SIGHUP, signal_handler);
+    shutdown_manager::ShutdownManager::Dependencies shutdownDeps{
+        &g_soft_mute,
+        &g_running,
+        &g_reload_requested,
+        &g_main_loop_running,
+    };
+    shutdown_manager::ShutdownManager shutdownManager(shutdownDeps);
+    shutdownManager.installSignalHandlers();
+    shutdownManager.setQuitLoopCallback([]() {
+        if (g_main_loop_running.load() && g_pw_loop) {
+            pw_main_loop_quit(g_pw_loop);
+        }
+    });
 
     int exitCode = 0;
 
     do {
+        shutdownManager.reset();
         g_running = true;
         g_reload_requested = false;
         g_zmq_bind_failed.store(false);
-        // Reset signal flags for clean restart
-        g_signal_shutdown = 0;
-        g_signal_reload = 0;
-        g_signal_received = 0;
         reset_runtime_state();
 
         // Load configuration from config.json (if exists)
@@ -2947,26 +2879,12 @@ int main(int argc, char* argv[]) {
         std::cout << "Press Ctrl+C to stop." << std::endl;
         std::cout << "========================================" << std::endl;
 
-#ifdef HAVE_SYSTEMD
-        if (pipewireActive) {
-            sd_notify(0,
-                      "READY=1\n"
-                      "STATUS=Processing audio...\n");
-        } else {
-            sd_notify(0,
-                      "READY=1\n"
-                      "STATUS=Processing audio (RTP-only)...\n");
-        }
-        std::cout << "systemd: Notified READY=1" << std::endl;
-#endif
+        shutdownManager.notifyReady(pipewireActive);
 
         auto runRtpOnlyMainLoop = [&]() {
             while (g_running.load() && !g_reload_requested.load() && !g_zmq_bind_failed.load()) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
-                process_pending_signals();
-#ifdef HAVE_SYSTEMD
-                sd_notify(0, "WATCHDOG=1");
-#endif
+                shutdownManager.tick(false);
             }
         };
 
@@ -2986,48 +2904,7 @@ int main(int argc, char* argv[]) {
             runRtpOnlyMainLoop();
         }
 
-        // ========== Shutdown Sequence ==========
-        // Order: Stop input → Fade out → Flush buffers → Close ALSA → Release resources
-        std::cout << "Shutting down..." << std::endl;
-
-#ifdef HAVE_SYSTEMD
-        // Notify systemd that we're stopping
-        sd_notify(0, "STOPPING=1\nSTATUS=Shutting down...\n");
-#endif
-
-        // Step 1: Stop signal check timer
-        if (data.signal_check_timer && loop) {
-            pw_loop_destroy_source(loop, data.signal_check_timer);
-            data.signal_check_timer = nullptr;
-        }
-
-        // Step 2: Wait for soft mute fade-out to complete (with 100ms timeout)
-        // This ensures glitch-free audio shutdown
-        if (g_soft_mute && g_soft_mute->isTransitioning()) {
-            std::cout << "  Step 2: Waiting for fade-out to complete..." << std::endl;
-            auto fade_start = std::chrono::steady_clock::now();
-            while (g_soft_mute->isTransitioning()) {
-                std::this_thread::sleep_for(std::chrono::milliseconds(5));
-                if (std::chrono::steady_clock::now() - fade_start >
-                    std::chrono::milliseconds(100)) {
-                    std::cout << "  Step 2: Fade-out timeout, forcing shutdown" << std::endl;
-                    break;
-                }
-            }
-        }
-
-        // Step 3: Destroy PipeWire stream (stops audio input)
-        if (data.input_stream) {
-            std::cout << "  Step 3: Destroying PipeWire stream..." << std::endl;
-            pw_stream_destroy(data.input_stream);
-        }
-
-        // Step 4: Destroy PipeWire main loop
-        if (data.loop) {
-            std::cout << "  Step 4: Destroying PipeWire main loop..." << std::endl;
-            pw_main_loop_destroy(data.loop);
-            g_pw_loop = nullptr;
-        }
+        shutdownManager.runShutdownSequence(pipewireActive);
 
         // Step 5: Signal worker threads to stop and wait for them
         std::cout << "  Step 5: Stopping worker threads..." << std::endl;

--- a/src/daemon/shutdown_manager.cpp
+++ b/src/daemon/shutdown_manager.cpp
@@ -1,0 +1,175 @@
+#include "daemon/shutdown_manager.h"
+
+#include <chrono>
+#include <csignal>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+
+#ifdef HAVE_SYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
+namespace shutdown_manager {
+
+ShutdownManager::ShutdownManager(Dependencies deps) : deps_(std::move(deps)) {
+    if (!deps_.runningFlag || !deps_.reloadFlag || !deps_.mainLoopRunningFlag) {
+        throw std::invalid_argument("ShutdownManager requires running/reload/mainLoop flags");
+    }
+
+    controller_.setSignalState(&GracefulShutdown::getGlobalSignalState());
+    controller_.setFadeOutCallback([this]() {
+        if (auto* softMute = activeSoftMute()) {
+            softMute->startFadeOut();
+        }
+    });
+    controller_.setLogCallback([](const char* message) { std::cout << message << std::endl; });
+    controller_.setQuitLoopCallback([this]() {
+        if (deps_.mainLoopRunningFlag && deps_.mainLoopRunningFlag->load() && quitLoopCallback_) {
+            quitLoopCallback_();
+        }
+    });
+}
+
+void ShutdownManager::installSignalHandlers() {
+    std::signal(SIGINT, GracefulShutdown::signalHandler);
+    std::signal(SIGTERM, GracefulShutdown::signalHandler);
+    std::signal(SIGHUP, GracefulShutdown::signalHandler);
+}
+
+void ShutdownManager::setQuitLoopCallback(std::function<void()> cb) {
+    quitLoopCallback_ = std::move(cb);
+}
+
+void ShutdownManager::setPipewireShutdownCallback(std::function<void()> cb) {
+    pipewireShutdownCallback_ = std::move(cb);
+}
+
+void ShutdownManager::setRtpShutdownCallback(std::function<void()> cb) {
+    rtpShutdownCallback_ = std::move(cb);
+}
+
+void ShutdownManager::setMainLoopRunning(bool running) {
+    deps_.mainLoopRunningFlag->store(running);
+    controller_.setMainLoopRunning(running);
+}
+
+void ShutdownManager::notifyReady(bool pipewireActive) {
+#ifdef HAVE_SYSTEMD
+    if (!readyNotified_) {
+        sendReadyNotify(pipewireActive);
+    }
+#endif
+}
+
+void ShutdownManager::tick(bool pipewireActive) {
+    (void)pipewireActive;
+    bool processed = controller_.processPendingSignals();
+    if (processed) {
+        deps_.runningFlag->store(controller_.isRunning());
+        deps_.reloadFlag->store(controller_.isReloadRequested());
+    }
+#ifdef HAVE_SYSTEMD
+    if (readyNotified_ && controller_.isRunning()) {
+        sendWatchdog();
+    }
+#endif
+}
+
+void ShutdownManager::runShutdownSequence(bool pipewireActive) {
+    if (sequenceRan_) {
+        return;
+    }
+    sequenceRan_ = true;
+
+    std::cout << "Shutting down..." << std::endl;
+
+#ifdef HAVE_SYSTEMD
+    sendStoppingNotify();
+#endif
+
+    waitForFadeOut();
+
+    if (pipewireActive) {
+        if (pipewireShutdownCallback_) {
+            pipewireShutdownCallback_();
+        }
+    } else if (rtpShutdownCallback_) {
+        rtpShutdownCallback_();
+    }
+}
+
+void ShutdownManager::reset() {
+    sequenceRan_ = false;
+    readyNotified_ = false;
+    stoppingNotified_ = false;
+    deps_.runningFlag->store(true);
+    deps_.reloadFlag->store(false);
+    deps_.mainLoopRunningFlag->store(false);
+    controller_.setRunning(true);
+    controller_.clearReloadRequest();
+    GracefulShutdown::getGlobalSignalState().reset();
+}
+
+bool ShutdownManager::isRunning() const {
+    return controller_.isRunning();
+}
+
+bool ShutdownManager::isReloadRequested() const {
+    return controller_.isReloadRequested();
+}
+
+SoftMute::Controller* ShutdownManager::activeSoftMute() const {
+    if (!deps_.softMute) {
+        return nullptr;
+    }
+    return *deps_.softMute;
+}
+
+void ShutdownManager::waitForFadeOut() {
+    auto* softMute = activeSoftMute();
+    if (!softMute) {
+        return;
+    }
+
+    if (!softMute->isTransitioning()) {
+        return;
+    }
+
+    std::cout << "  Step 2: Waiting for fade-out to complete..." << std::endl;
+    auto fadeStart = std::chrono::steady_clock::now();
+    while (softMute->isTransitioning()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        if (std::chrono::steady_clock::now() - fadeStart > std::chrono::milliseconds(100)) {
+            std::cout << "  Step 2: Fade-out timeout, forcing shutdown" << std::endl;
+            break;
+        }
+    }
+}
+
+void ShutdownManager::sendWatchdog() {
+#ifdef HAVE_SYSTEMD
+    sd_notify(0, "WATCHDOG=1");
+#endif
+}
+
+#ifdef HAVE_SYSTEMD
+void ShutdownManager::sendReadyNotify(bool pipewireActive) {
+    std::string status = pipewireActive ? "Processing audio..." : "Processing audio (RTP-only)...";
+    sd_notify(0, ("READY=1\nSTATUS=" + status + "\n").c_str());
+    readyNotified_ = true;
+    std::cout << "systemd: Notified READY=1" << std::endl;
+}
+
+void ShutdownManager::sendStoppingNotify() {
+    if (!stoppingNotified_) {
+        sd_notify(0, "STOPPING=1\nSTATUS=Shutting down...\n");
+        stoppingNotified_ = true;
+        std::cout << "systemd: Notified STOPPING=1" << std::endl;
+    }
+}
+#endif
+
+}  // namespace shutdown_manager


### PR DESCRIPTION
## Summary
- add a dedicated  to centralize signal handling, SoftMute fade-outs, and systemd notifications while offering callbacks for PipeWire/RTP shutdown steps
- simplify  so it just wires the manager into the signal timer, RTP-only loop, and shutdown path, while removing the old global signal flags
- hook the new module into CMake so it is built alongside the daemon

## Testing
- cmake -B build -DCMAKE_BUILD_TYPE=Release
- /usr/bin/cmake --build build -j8
- diff-based tests (includes the full GPU test suite and passed on the final attempt)