### PR TITLE
Fix: Make data/EQ directory writable in Docker for EQ profile generation

### DIFF
--- a/docker/jetson/docker-compose.jetson.yml
+++ b/docker/jetson/docker-compose.jetson.yml
@@ -42,8 +42,11 @@ services:
     shm_size: '256m'
 
     # Mount data directory (EQ profiles, coefficients, OPRA database)
+    # Static data (coefficients, OPRA database) is read-only for protection
+    # EQ profiles directory is writable for dynamic profile generation
     volumes:
       - ../../data:/opt/magicbox/data:ro
+      - ../../data/EQ:/opt/magicbox/data/EQ:rw
 
     # Environment (NVIDIA)
     environment:


### PR DESCRIPTION
## Problem
EQ適応時に以下のエラーが発生していた:
```
OSError: [Errno 30] Read-only file system: '/opt/magicbox/data/EQ/...'
```

docker-compose.jetson.yml で data/ ディレクトリ全体が読み取り専用 (:ro) でマウントされていたため、 動的に生成されるEQプロファイルファイルの書き込みができなかった。

## Solution
静的データ（係数ファイル、OPRAデータベース）は読み取り専用のまま保護し、
動的に生成される data/EQ/ ディレクトリのみ書き込み可能 (:rw) にした:

```yaml
volumes:
  - ../../data:/opt/magicbox/data:ro        # ベース: 読み取り専用
  - ../../data/EQ:/opt/magicbox/data/EQ:rw  # 上書きマウント: 書き込み可能
```

## Benefits
- 係数ファイル（640kタップ）とOPRAデータベースは読み取り専用で保護される
- EQプロファイルの動的生成・書き込みが可能になる
- コード変更不要、Dockerマウント設定のみの変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)