### PR TITLE
#565 UI component reuse guidelines in AI documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,17 @@ cmake --build build -j$(nproc)
 - **Naming:** `PascalCase` (types), `camelCase` (functions), `UPPER_SNAKE` (constants)
 - GPU arch: SM 7.5 (PC) or SM 8.7 (Jetson)
 
+### Web UI Component Reuse (Mandatory)
+
+以下のJinja2マクロ（またはHTMLパーツ）が `web/templates/components/` に既に存在します。
+**新しいUIを作る際は、必ずこれらをimportして再利用してください。ベタ書き禁止。**
+
+- `{% macro btn_primary(text, icon) %}` - プライマリボタン
+- `{% macro card_panel(title) %}` - カードパネル
+- `{% macro slider_input(value) %}` - スライダー入力
+
+**重複実装を避け、DRY原則を徹底すること。**
+
 ## Git Workflow
 
 **Never commit directly to main.** Use Git Worktree:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,6 +315,25 @@ gpu_os/
 └── build/                 # Build output
 ```
 
+## Web UI Development Guidelines
+
+### Jinja2テンプレートコンポーネントの再利用（必須）
+
+以下のJinja2マクロ（またはHTMLパーツ）が `web/templates/components/` に既に存在します。
+**新しいUIを作る際は、必ずこれらをimportして再利用してください。ベタ書き禁止。**
+
+- `{% macro btn_primary(text, icon) %}` - プライマリボタン
+- `{% macro card_panel(title) %}` - カードパネル
+- `{% macro slider_input(value) %}` - スライダー入力
+
+**重複実装は保守性の低下とバグの温床となります。DRY原則を徹底すること。**
+
+例：
+```jinja2
+{% from 'components/buttons.html' import btn_primary %}
+{{ btn_primary('Apply', 'check') }}
+```
+
 ## REST API Development Guidelines
 
 ### レスポンスモデル必須


### PR DESCRIPTION
## 概要
AGENTS.md と CLAUDE.md に Jinja2 テンプレートコンポーネントの再利用ルールを追加

## 背景
- #546 で OPRA 検索 UI の重複実装が問題となった
- dashboard.html と eq_settings.html で同じコードが重複していた
- 今後の AI による実装で同様の問題を防ぐため、ガイドラインを明文化

## 変更内容

### AGENTS.md
- **Coding Standards** セクション内に追加
- 既存コンポーネントの明示的なリスト
- ベタ書き禁止の強調

### CLAUDE.md
- 新規セクション「**Web UI Development Guidelines**」を作成
- REST API Guidelines の前に配置
- 既存コンポーネントのリストと説明
- 使用例のコードスニペット付き

## 追加したコンポーネントリスト
- `btn_primary` - プライマリボタン
- `card_panel` - カードパネル
- `slider_input` - スライダー入力

## 期待効果
✅ AI が新規 UI 実装時に既存コンポーネントを必ず使用  
✅ コードの重複を防止  
✅ 単一責任の原則に従った設計の維持  
✅ 保守性の向上  

## 関連 Issue
Closes #565
Related to #546 (OPRA 検索 UI 重複実装問題)