### PR TITLE
#563 Phase 3: Size Selector コンポーネント実装

### DIFF
--- a/web/templates/components/size_selector.html
+++ b/web/templates/components/size_selector.html
@@ -6,11 +6,12 @@
    - alpine_disabled (optional): Alpine.js expression for disabled state (default: "false")
    - alpine_show (optional): Alpine.js expression for x-show directive
    - sizes (optional): Array of size values (default: ['xs', 's', 'm', 'l', 'xl'])
+   - form_group_style (optional): Inline style string for form-group div
 #}
 {% set alpine_disabled = alpine_disabled | default("false") %}
 {% set sizes = sizes | default(['xs', 's', 'm', 'l', 'xl']) %}
 
-<div class="form-group" style="margin-top: 16px;" {% if alpine_show %}x-show="{{ alpine_show }}"{% endif %}>
+<div class="form-group" {% if form_group_style %}style="{{ form_group_style }}"{% endif %} {% if alpine_show %}x-show="{{ alpine_show }}"{% endif %}>
     <label>{{ selector_label }}</label>
     <div class="head-size-group">
         {% for size in sizes %}

--- a/web/templates/pages/dashboard.html
+++ b/web/templates/pages/dashboard.html
@@ -150,6 +150,7 @@
             {% set alpine_click = "setHeadSize" %}
             {% set alpine_disabled = "!crossfeed.enabled" %}
             {% set alpine_show = "crossfeed.enabled" %}
+            {% set form_group_style = "margin-top: 16px;" %}
             {% include 'components/size_selector.html' %}
 
             {% set alert_type = "warning" %}

--- a/web/tests/test_components.py
+++ b/web/tests/test_components.py
@@ -522,6 +522,7 @@ class TestPhase3ComponentDocumentation:
             assert "alpine_click" in content
             assert "alpine_disabled" in content
             assert "alpine_show" in content
+            assert "form_group_style" in content
 
 
 class TestPhase2ComponentDocumentation:


### PR DESCRIPTION
## 概要
Web UIコンポーネント化のPhase 3として、サイズセレクターコンポーネントを実装しました。

## 実装内容

### 新規作成
- `web/templates/components/size_selector.html` (26行)
  - XS/S/M/L/XL の5サイズをサポートするボタングループコンポーネント
  - Alpine.js統合（モデルバインディング、クリックハンドラ）
  - 条件付き表示（x-show）とdisabled状態をサポート
  - サイズ配列をカスタマイズ可能（デフォルト: xs-xl）

### 変更内容
- `web/templates/pages/dashboard.html`
  - クロスフィード頭サイズセレクター（148-187行）をコンポーネント化
  - **39行 → 6行に削減（33行削減、85%減）**

### テスト追加
- `web/tests/test_components.py`
  - `TestSizeSelectorComponent`: 5テスト追加
    - コンポーネントレンダリングテスト
    - 5サイズボタンの存在確認
    - Alpine.jsバインディング検証
    - x-show条件付き表示検証
    - インライン実装の置き換え確認
  - `TestPhase3ComponentDocumentation`: 1テスト追加
    - コンポーネントドキュメント完全性検証

## テスト結果
全41テスト合格（6テスト追加）

```
web/tests/test_components.py::TestSizeSelectorComponent ............... PASSED
web/tests/test_components.py::TestPhase3ComponentDocumentation ....... PASSED
================================ 41 passed ================================
```

## コード削減効果
- **削減行数**: 33行（dashboard.html）
- **テスト追加**: +6テスト
- **保守性向上**: DRY原則遵守、単一責任原則適用

## 関連Issue
- Relates to #563
- Part of Epic #548: Web UI componentization

🤖 Generated with [Claude Code](https://claude.com/claude-code)