### PR TITLE
Fix #573: ストリーミングキャッシュ初期グレースとフェード

### DIFF
--- a/src/alsa_daemon.cpp
+++ b/src/alsa_daemon.cpp
@@ -402,6 +402,7 @@ static void initialize_streaming_cache_manager() {
     deps.streamingMutex = &g_streaming_mutex;
 
     deps.upsamplerPtr = &g_upsampler;
+    deps.softMute = &g_soft_mute;
     deps.onCrossfeedReset = []() {
         std::lock_guard<std::mutex> cf_lock(g_crossfeed_mutex);
         reset_crossfeed_stream_state_locked();


### PR DESCRIPTION
## Summary\n- ストリーミング入力の初期1.5sはstall判定をスキップして曲頭のflush発火を防止\n- flush時にSoftMuteのfade-out/inを開始してゼロクリア由来のポップを緩和\n- StreamingCacheManagerにSoftMute参照を渡せるよう依存関係を拡張\n\n## Testing\n- not run (not requested)\n\nFixes #573