### PR TITLE
#585 低遅延モードの入力バッファオーバーフローを防止

### DIFF
--- a/src/gpu/gpu_upsampler_streaming.cu
+++ b/src/gpu/gpu_upsampler_streaming.cu
@@ -216,12 +216,15 @@ bool GPUUpsampler::processStreamBlock(const float* inputData,
             return false;
         }
 
-        registerStreamInputBuffer(streamInputBuffer, stream);
-
-        if (streamInputAccumulated + inputFrames > streamInputBuffer.size()) {
-            std::cerr << "ERROR: Stream input buffer overflow" << std::endl;
-            return false;
+        size_t required = streamInputAccumulated + inputFrames;
+        if (required > streamInputBuffer.size()) {
+            // Upstream (RTP/PipeWire) may deliver larger bursts than the preallocated buffer.
+            size_t newSize = std::max(streamInputBuffer.size() * 2, required);
+            newSize = std::max(newSize, static_cast<size_t>(streamValidInputPerBlock_) * 2);
+            streamInputBuffer.resize(newSize, 0.0f);
         }
+
+        registerStreamInputBuffer(streamInputBuffer, stream);
 
         std::copy(inputData, inputData + inputFrames,
                   streamInputBuffer.begin() + streamInputAccumulated);
@@ -442,12 +445,15 @@ bool GPUUpsampler::processPartitionedStreamBlock(
             return false;
         }
 
-        registerStreamInputBuffer(streamInputBuffer, stream);
-
-        if (streamInputAccumulated + inputFrames > streamInputBuffer.size()) {
-            std::cerr << "ERROR: Stream input buffer overflow" << std::endl;
-            return false;
+        size_t required = streamInputAccumulated + inputFrames;
+        if (required > streamInputBuffer.size()) {
+            // Upstream (RTP/PipeWire) may deliver larger bursts than the preallocated buffer.
+            size_t newSize = std::max(streamInputBuffer.size() * 2, required);
+            newSize = std::max(newSize, static_cast<size_t>(streamValidInputPerBlock_) * 2);
+            streamInputBuffer.resize(newSize, 0.0f);
         }
+
+        registerStreamInputBuffer(streamInputBuffer, stream);
 
         std::copy(inputData, inputData + inputFrames,
                   streamInputBuffer.begin() + streamInputAccumulated);


### PR DESCRIPTION
## 概要\n- Low Latency(Partitioned Convolution) 有効時に上流からのブロックが大きいと入力バッファが溢れて再生停止する問題を修正\n- 入力バッファを必要サイズまで自動拡張し、RTP/PipeWire からのバーストでも安全に処理\n\n## テスト\n- 未実施（依頼者側で実行予定）