### PR TITLE
#587 Low LatencyでCUDAリソース解放漏れを修正

### DIFF
--- a/src/alsa_daemon.cpp
+++ b/src/alsa_daemon.cpp
@@ -2177,6 +2177,9 @@ int main(int argc, char* argv[]) {
         delete g_hrtf_processor;
         g_hrtf_processor = nullptr;
         g_crossfeed_enabled.store(false);
+        if (g_audio_pipeline) {
+            g_audio_pipeline.reset();  // Tear down pipeline before deleting GPU upsampler
+        }
         delete g_upsampler;
         g_upsampler = nullptr;
         if (g_dac_manager) {


### PR DESCRIPTION
## 概要\n- Low Latency切替後のデーモン再起動で GPUUpsampler を再構築する際、古い AudioPipeline が残存し CUDAストリーム/バッファを握ったままになることがあった\n- シャットダウン時に AudioPipeline を確実にリセットしてから GPUUpsampler を破棄するように変更\n\n## テスト\n- 未実施（依頼者側で実機確認予定）