### PR TITLE
Fix #589: ダッシュボード画面のバグ修正

### DIFF
--- a/web/templates/components/status_card.html
+++ b/web/templates/components/status_card.html
@@ -12,7 +12,8 @@
         <h3>{{ status_title }}</h3>
     </div>
     <div class="status-card-body">
-        <div class="status-indicator" :class="{{ status_class }}" x-text="{{ status_text }}">
+        <div class="status-indicator" :class="{{ status_class }}">
+            <span x-text="{{ status_text }}"></span>
         </div>
     </div>
 </div>

--- a/web/templates/pages/dashboard.html
+++ b/web/templates/pages/dashboard.html
@@ -94,7 +94,7 @@
             {% set form_input_id = "phaseType" %}
             {% set form_input_model = "phaseType.selected" %}
             {% set form_on_change = "changePhaseType" %}
-            {% set form_select_options = '<option value="minimum">{{ t.get(\'dashboard.phase_type.minimum\') }}</option><option value="linear">{{ t.get(\'dashboard.phase_type.linear\') }}</option>' %}
+            {% set form_select_options = '<option value="minimum">' + t.get('dashboard.phase_type.minimum') + '</option><option value="linear">' + t.get('dashboard.phase_type.linear') + '</option>' %}
             {% include 'components/form_group.html' %}
             <div class="info-text">
                 <span class="icon">ℹ️</span>


### PR DESCRIPTION
## 概要
Issue #589 で報告されたダッシュボード画面の2つのバグを修正しました。

## 修正内容

### 1. ステータスインジケーターのバグ修正
**問題**: インジケーター（デーモン、EQ、クロスフィード、低遅延モード）の文字が表示されない

**原因**: `status_card.html`コンポーネントで、`x-text`ディレクティブが親`div`要素に直接適用されていたため、Alpine.jsが正しくテキストを挿入できなかった

**修正**: 
- `x-text`を子`<span>`要素に移動
- これによりAlpine.jsが正しくテキストをレンダリングできるようになった

```html
<!-- Before -->
<div class="status-indicator" :class="{{ status_class }}" x-text="{{ status_text }}">
</div>

<!-- After -->
<div class="status-indicator" :class="{{ status_class }}">
    <span x-text="{{ status_text }}"></span>
</div>
```

### 2. 位相タイプのi18n適応
**問題**: 位相タイプのドロップダウンで「Minimum Phase」「Linear Phase」の文字がi18n対応されていない

**原因**: Jinja2テンプレート内で文字列内に`{{ t.get() }}`を埋め込んでいたため、サーバーサイドで翻訳が実行されなかった

**修正**:
- 文字列連結演算子（`+`）を使用して、Jinja2の翻訳関数を正しく評価
- サーバーサイドで翻訳されたテキストがHTMLに挿入されるようになった

```jinja2
<!-- Before -->
{% set form_select_options = '<option value="minimum">{{ t.get(\'dashboard.phase_type.minimum\') }}</option>...' %}

<!-- After -->
{% set form_select_options = '<option value="minimum">' + t.get('dashboard.phase_type.minimum') + '</option>...' %}
```

## テスト
- [ ] ダッシュボードでステータスインジケーターの文字が正しく表示されることを確認
- [ ] 位相タイプのドロップダウンが日本語で「Minimum Phase (推奨)」「Linear Phase (全帯域線形)」と表示されることを確認
- [ ] 低遅延モードのインジケーターが正しく表示されることを確認

## 関連Issue
Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)