### PR TITLE
Fix #412: Remove redundant Crossfeed page

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1837,47 +1837,6 @@
         }
       }
     },
-    "/crossfeed": {
-      "get": {
-        "summary": "Crossfeed Page",
-        "description": "Serve the Crossfeed page.",
-        "operationId": "crossfeed_page_crossfeed_get",
-        "parameters": [
-          {
-            "name": "lang",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "en",
-              "title": "Lang"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/rtp": {
       "get": {
         "summary": "Rtp Management Page",

--- a/web/main.py
+++ b/web/main.py
@@ -30,7 +30,6 @@ from .templates import get_admin_html, get_rtp_sessions_html
 from .templates.pages import (
     render_dashboard,
     render_eq_settings,
-    render_crossfeed,
     render_rtp_management,
     render_system,
 )
@@ -166,12 +165,6 @@ async def dashboard_page(lang: str = "en"):
 async def eq_page(lang: str = "en"):
     """Serve the EQ Settings page."""
     return render_eq_settings(lang=lang)
-
-
-@app.get("/crossfeed", response_class=HTMLResponse)
-async def crossfeed_page(lang: str = "en"):
-    """Serve the Crossfeed page."""
-    return render_crossfeed(lang=lang)
 
 
 @app.get("/rtp", response_class=HTMLResponse)

--- a/web/templates/components/sidebar.html
+++ b/web/templates/components/sidebar.html
@@ -11,10 +11,6 @@
     <a href="/eq" class="nav-item {% if current_page == 'eq' %}active{% endif %}">
         <span style="margin-right: 8px;">🎚️</span> EQ Settings
     </a>
-    <a href="/crossfeed" class="nav-item {% if current_page == 'crossfeed' %}active{% endif %}">
-        <span style="margin-right: 8px;">🎧</span> Crossfeed
-        <span style="font-size: 10px; opacity: 0.5; margin-left: 8px;">(Coming Soon)</span>
-    </a>
     <a href="/rtp" class="nav-item {% if current_page == 'rtp' %}active{% endif %}">
         <span style="margin-right: 8px;">🌐</span> RTP Management
         <span style="font-size: 10px; opacity: 0.5; margin-left: 8px;">(Coming Soon)</span>

--- a/web/templates/pages.py
+++ b/web/templates/pages.py
@@ -56,26 +56,6 @@ def render_eq_settings(lang: str = "en", current_page: str = "eq") -> str:
     )
 
 
-def render_crossfeed(lang: str = "en", current_page: str = "crossfeed") -> str:
-    """
-    Render the Crossfeed page.
-
-    Args:
-        lang: Language code ("en" or "ja")
-        current_page: Current page name for sidebar highlighting
-
-    Returns:
-        Rendered HTML string
-    """
-    # TODO: Implement in Issue #412
-    template = env.get_template("base.html")
-    return template.render(
-        t=get_translations(lang),
-        current_page=current_page,
-        content="<h2>Crossfeed - Coming Soon</h2>",
-    )
-
-
 def render_rtp_management(lang: str = "en", current_page: str = "rtp") -> str:
     """
     Render the RTP Management page.


### PR DESCRIPTION
## 概要

クロスフィード機能は既にDashboardに完全実装済みのため、独立したCrossfeedページは不要と判断し削除しました。

## 変更内容

- サイドバーからCrossfeedリンクを削除 (`web/templates/components/sidebar.html`)
- `/crossfeed` ルートを削除 (`web/main.py`)
- `render_crossfeed()` 関数を削除 (`web/templates/pages.py`)
- OpenAPI spec自動更新

## 理由

Dashboardに以下のクロスフィード機能が完全実装済みです:
- トグルスイッチ（有効/無効）
- 頭サイズセレクター（XS/S/M/L/XL）
- ステータス表示
- HUTUBSクレジット（CC BY 4.0）

独立したページは同じ内容の重複となるため、UX的にも冗長と判断しました。

## 確認事項

- [x] サイドバーからCrossfeedリンクが削除されていること
- [x] `/crossfeed`へのアクセスで404になること
- [x] Dashboardのクロスフィード機能が引き続き動作すること
- [x] OpenAPI specが正しく更新されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)