### PR TITLE
#613 Raspberry Pi PCM bridge scaffold

### DIFF
--- a/raspberry_pi/CMakeLists.txt
+++ b/raspberry_pi/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(raspberry_pi_pcm_bridge LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+endif()
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+include(CheckSymbolExists)
+check_symbol_exists(socket "sys/socket.h" HAVE_SOCKET)
+if(NOT HAVE_SOCKET)
+    message(FATAL_ERROR "POSIX sockets are required but were not found.")
+endif()
+
+find_package(ALSA REQUIRED)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+add_subdirectory(src)
+

--- a/raspberry_pi/README.md
+++ b/raspberry_pi/README.md
@@ -1,0 +1,38 @@
+# Raspberry Pi PCM Bridge (prototype)
+
+Raspberry Pi向けのPCMブリッジ雛形です。ALSAキャプチャとTCPクライアントのスタブを含み、リンクが通る最小構成を提供します。
+
+## 必要パッケージ
+
+Raspberry Pi OS / Debian系:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential cmake pkg-config libasound2-dev
+```
+
+## ビルド手順
+
+```bash
+cmake -S raspberry_pi -B raspberry_pi/build -DCMAKE_BUILD_TYPE=Release
+cmake --build raspberry_pi/build
+```
+
+Debugビルド例:
+
+```bash
+cmake -S raspberry_pi -B raspberry_pi/build -DCMAKE_BUILD_TYPE=Debug
+cmake --build raspberry_pi/build
+```
+
+生成物:
+- バイナリ: `raspberry_pi/build/rpi_pcm_bridge`
+
+## 実行
+
+```bash
+./raspberry_pi/build/rpi_pcm_bridge --help
+```
+
+現状はスタブ実装のため、ヘルプとプレースホルダーのログのみを出力します。
+

--- a/raspberry_pi/include/AlsaCapture.h
+++ b/raspberry_pi/include/AlsaCapture.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+class AlsaCapture {
+public:
+    AlsaCapture();
+    ~AlsaCapture();
+
+    bool initialize(const std::string &deviceName);
+    bool start();
+    void stop();
+
+private:
+    std::string deviceName_;
+};
+

--- a/raspberry_pi/include/TcpClient.h
+++ b/raspberry_pi/include/TcpClient.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+class TcpClient {
+public:
+    TcpClient();
+    ~TcpClient();
+
+    bool connect(const std::string &host, std::uint16_t port);
+    bool send(const std::vector<std::uint8_t> &payload);
+    void disconnect();
+
+private:
+    std::string host_;
+    std::uint16_t port_{0};
+};
+

--- a/raspberry_pi/src/AlsaCapture.cpp
+++ b/raspberry_pi/src/AlsaCapture.cpp
@@ -1,0 +1,29 @@
+#include "AlsaCapture.h"
+
+#include <iostream>
+
+AlsaCapture::AlsaCapture() = default;
+
+AlsaCapture::~AlsaCapture() = default;
+
+bool AlsaCapture::initialize(const std::string &deviceName)
+{
+    deviceName_ = deviceName;
+    std::clog << "[AlsaCapture] initialize called for device: " << deviceName_
+              << " (not implemented yet)" << std::endl;
+    return false;
+}
+
+bool AlsaCapture::start()
+{
+    std::clog << "[AlsaCapture] start requested (not implemented yet)"
+              << std::endl;
+    return false;
+}
+
+void AlsaCapture::stop()
+{
+    std::clog << "[AlsaCapture] stop requested (not implemented yet)"
+              << std::endl;
+}
+

--- a/raspberry_pi/src/CMakeLists.txt
+++ b/raspberry_pi/src/CMakeLists.txt
@@ -1,0 +1,37 @@
+add_library(rpi_pcm_bridge
+    AlsaCapture.cpp
+    TcpClient.cpp
+)
+
+target_include_directories(rpi_pcm_bridge
+    PUBLIC
+        ${PROJECT_SOURCE_DIR}/include
+)
+
+target_link_libraries(rpi_pcm_bridge
+    PUBLIC
+        ALSA::ALSA
+        Threads::Threads
+)
+
+target_compile_options(rpi_pcm_bridge
+    PRIVATE
+        $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wall -Wextra -Wpedantic>
+)
+
+add_executable(rpi_pcm_bridge_app
+    main.cpp
+)
+
+target_link_libraries(rpi_pcm_bridge_app
+    PRIVATE
+        rpi_pcm_bridge
+)
+
+target_compile_options(rpi_pcm_bridge_app
+    PRIVATE
+        $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wall -Wextra -Wpedantic>
+)
+
+set_target_properties(rpi_pcm_bridge_app PROPERTIES OUTPUT_NAME "rpi_pcm_bridge")
+

--- a/raspberry_pi/src/TcpClient.cpp
+++ b/raspberry_pi/src/TcpClient.cpp
@@ -1,0 +1,30 @@
+#include "TcpClient.h"
+
+#include <iostream>
+
+TcpClient::TcpClient() = default;
+
+TcpClient::~TcpClient() = default;
+
+bool TcpClient::connect(const std::string &host, std::uint16_t port)
+{
+    host_ = host;
+    port_ = port;
+    std::clog << "[TcpClient] connect requested to " << host_ << ":" << port_
+              << " (not implemented yet)" << std::endl;
+    return false;
+}
+
+bool TcpClient::send(const std::vector<std::uint8_t> &payload)
+{
+    std::clog << "[TcpClient] send requested (" << payload.size()
+              << " bytes, not implemented yet)" << std::endl;
+    return false;
+}
+
+void TcpClient::disconnect()
+{
+    std::clog << "[TcpClient] disconnect requested (not implemented yet)"
+              << std::endl;
+}
+

--- a/raspberry_pi/src/main.cpp
+++ b/raspberry_pi/src/main.cpp
@@ -1,0 +1,46 @@
+#include "AlsaCapture.h"
+#include "TcpClient.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <string_view>
+
+namespace {
+
+void printHelp(std::string_view programName)
+{
+    std::cout << "Usage: " << programName << " [--help]" << std::endl
+              << std::endl
+              << "Prototype PCM bridge entrypoint for Raspberry Pi." << std::endl
+              << "Functionality is not implemented yet; this binary currently"
+              << " serves as a build test placeholder." << std::endl;
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    const std::string_view programName = (argc > 0 && argv[0] != nullptr)
+        ? std::string_view{argv[0]}
+        : "rpi_pcm_bridge";
+
+    for(int i = 1; i < argc; ++i) {
+        const std::string_view arg{argv[i]};
+        if(arg == "-h" || arg == "--help") {
+            printHelp(programName);
+            return EXIT_SUCCESS;
+        }
+    }
+
+    std::cout << "[rpi_pcm_bridge] Prototype build - functionality not"
+              << " implemented yet." << std::endl;
+
+    AlsaCapture capture;
+    TcpClient client;
+
+    std::clog << "[rpi_pcm_bridge] Created AlsaCapture and TcpClient stubs."
+              << std::endl;
+
+    return EXIT_SUCCESS;
+}
+


### PR DESCRIPTION
## Summary\n- raspberry_pi配下に独立したCMake雛形を追加しALSA/pthread依存を解決\n- AlsaCapture/TcpClientスタブとプレースホルダmainを配置\n- Raspberry Pi向けビルド手順のREADMEを作成\n\n## Testing\n- 未実施 (macOS環境でALSA未導入のため)\n