### PR TITLE
#614 ALSA capture with XRUN recovery

### DIFF
--- a/raspberry_pi/README.md
+++ b/raspberry_pi/README.md
@@ -36,3 +36,20 @@ cmake --build raspberry_pi/build
 
 現状はスタブ実装のため、ヘルプとプレースホルダーのログのみを出力します。
 
+## ALSA キャプチャ簡易テスト
+
+実機のALSAデバイスを指定して数周期分を読み取ります（TCP送信は未実装）。
+
+```bash
+./raspberry_pi/build/rpi_pcm_bridge \
+  --device hw:0,0 \
+  --rate 48000 \
+  --format S16_LE \
+  --frames 4096 \
+  --iterations 3
+```
+
+- 対応フォーマット: `S16_LE`, `S24_3LE`, `S32_LE`
+- XRUN発生時は `snd_pcm_prepare()` でリカバリし、ログへ出力します。
+- 未対応フォーマットを指定すると即エラー終了します。
+

--- a/raspberry_pi/include/AlsaCapture.h
+++ b/raspberry_pi/include/AlsaCapture.h
@@ -1,17 +1,47 @@
 #pragma once
 
+#include <alsa/asoundlib.h>
+
+#include <cstdint>
 #include <string>
+#include <vector>
 
 class AlsaCapture {
 public:
+    enum class SampleFormat {
+        S16_LE,
+        S24_3LE,
+        S32_LE,
+    };
+
+    struct Config {
+        std::string deviceName{"hw:0,0"};
+        unsigned int sampleRate{48000};
+        unsigned int channels{2};
+        SampleFormat format{SampleFormat::S16_LE};
+        snd_pcm_uframes_t periodFrames{4096};
+    };
+
     AlsaCapture();
     ~AlsaCapture();
 
-    bool initialize(const std::string &deviceName);
+    bool open(const Config &config);
     bool start();
+    /**
+     * 読み取り結果: 正常時は読み取ったバイト数、0 は無音（タイムアウト等）、負数はエラー。
+     */
+    int read(std::vector<std::uint8_t> &buffer);
     void stop();
+    void close();
+
+    bool isOpen() const;
 
 private:
-    std::string deviceName_;
+    snd_pcm_format_t toAlsaFormat(SampleFormat format) const;
+    std::size_t bytesPerFrame() const;
+
+    Config config_{};
+    snd_pcm_t *handle_{nullptr};
+    std::size_t frameBytes_{0};
 };
 

--- a/raspberry_pi/src/AlsaCapture.cpp
+++ b/raspberry_pi/src/AlsaCapture.cpp
@@ -1,29 +1,188 @@
 #include "AlsaCapture.h"
 
 #include <iostream>
+#include <stdexcept>
+
+namespace {
+
+void logError(const std::string &prefix, int err)
+{
+    std::clog << prefix << ": " << snd_strerror(err) << std::endl;
+}
+
+} // namespace
 
 AlsaCapture::AlsaCapture() = default;
 
-AlsaCapture::~AlsaCapture() = default;
-
-bool AlsaCapture::initialize(const std::string &deviceName)
+AlsaCapture::~AlsaCapture()
 {
-    deviceName_ = deviceName;
-    std::clog << "[AlsaCapture] initialize called for device: " << deviceName_
-              << " (not implemented yet)" << std::endl;
-    return false;
+    close();
+}
+
+bool AlsaCapture::open(const Config &config)
+{
+    close();
+
+    config_ = config;
+    frameBytes_ = bytesPerFrame();
+
+    int rc = snd_pcm_open(&handle_, config_.deviceName.c_str(),
+        SND_PCM_STREAM_CAPTURE, 0);
+    if(rc < 0) {
+        logError("[AlsaCapture] snd_pcm_open failed", rc);
+        handle_ = nullptr;
+        return false;
+    }
+
+    snd_pcm_hw_params_t *hwParams = nullptr;
+    snd_pcm_hw_params_alloca(&hwParams);
+    snd_pcm_hw_params_any(handle_, hwParams);
+
+    rc = snd_pcm_hw_params_set_access(
+        handle_, hwParams, SND_PCM_ACCESS_RW_INTERLEAVED);
+    if(rc < 0) {
+        logError("[AlsaCapture] set_access failed", rc);
+        return false;
+    }
+
+    const snd_pcm_format_t alsaFormat = toAlsaFormat(config_.format);
+    rc = snd_pcm_hw_params_set_format(handle_, hwParams, alsaFormat);
+    if(rc < 0) {
+        logError("[AlsaCapture] set_format failed", rc);
+        return false;
+    }
+
+    rc = snd_pcm_hw_params_set_channels(handle_, hwParams, config_.channels);
+    if(rc < 0) {
+        logError("[AlsaCapture] set_channels failed", rc);
+        return false;
+    }
+
+    unsigned int rate = config_.sampleRate;
+    rc = snd_pcm_hw_params_set_rate_near(handle_, hwParams, &rate, nullptr);
+    if(rc < 0 || rate != config_.sampleRate) {
+        logError("[AlsaCapture] set_rate_near failed or mismatched rate", rc);
+        return false;
+    }
+
+    snd_pcm_uframes_t period = config_.periodFrames;
+    rc = snd_pcm_hw_params_set_period_size_near(
+        handle_, hwParams, &period, nullptr);
+    if(rc < 0) {
+        logError("[AlsaCapture] set_period_size failed", rc);
+        return false;
+    }
+
+    rc = snd_pcm_hw_params(handle_, hwParams);
+    if(rc < 0) {
+        logError("[AlsaCapture] apply hw_params failed", rc);
+        return false;
+    }
+
+    std::clog << "[AlsaCapture] opened device=" << config_.deviceName
+              << " rate=" << config_.sampleRate
+              << " ch=" << config_.channels
+              << " fmt=" << snd_pcm_format_name(alsaFormat)
+              << " period_frames=" << period << std::endl;
+    return true;
 }
 
 bool AlsaCapture::start()
 {
-    std::clog << "[AlsaCapture] start requested (not implemented yet)"
-              << std::endl;
-    return false;
+    if(!handle_) {
+        std::clog << "[AlsaCapture] start requested without open" << std::endl;
+        return false;
+    }
+    int rc = snd_pcm_prepare(handle_);
+    if(rc < 0) {
+        logError("[AlsaCapture] snd_pcm_prepare failed", rc);
+        return false;
+    }
+    rc = snd_pcm_start(handle_);
+    if(rc < 0) {
+        logError("[AlsaCapture] snd_pcm_start failed", rc);
+        return false;
+    }
+    return true;
+}
+
+int AlsaCapture::read(std::vector<std::uint8_t> &buffer)
+{
+    if(!handle_) {
+        std::clog << "[AlsaCapture] read called before open" << std::endl;
+        return -1;
+    }
+
+    const std::size_t bytesPerPeriod = static_cast<std::size_t>(
+        config_.periodFrames) * frameBytes_;
+    if(buffer.size() < bytesPerPeriod) {
+        buffer.resize(bytesPerPeriod);
+    }
+
+    const snd_pcm_sframes_t frames = snd_pcm_readi(
+        handle_, buffer.data(), config_.periodFrames);
+    if(frames == -EPIPE) {
+        std::clog << "[AlsaCapture] XRUN detected, recovering..." << std::endl;
+        int rc = snd_pcm_prepare(handle_);
+        if(rc < 0) {
+            logError("[AlsaCapture] snd_pcm_prepare failed after XRUN", rc);
+            return -1;
+        }
+        return -EPIPE;
+    }
+    if(frames < 0) {
+        logError("[AlsaCapture] snd_pcm_readi failed", static_cast<int>(frames));
+        return static_cast<int>(frames);
+    }
+    return static_cast<int>(frames * frameBytes_);
 }
 
 void AlsaCapture::stop()
 {
-    std::clog << "[AlsaCapture] stop requested (not implemented yet)"
-              << std::endl;
+    if(handle_) {
+        snd_pcm_drop(handle_);
+        snd_pcm_drain(handle_);
+        std::clog << "[AlsaCapture] stopped" << std::endl;
+    }
+}
+
+void AlsaCapture::close()
+{
+    if(handle_) {
+        snd_pcm_close(handle_);
+        handle_ = nullptr;
+        std::clog << "[AlsaCapture] closed" << std::endl;
+    }
+}
+
+bool AlsaCapture::isOpen() const
+{
+    return handle_ != nullptr;
+}
+
+snd_pcm_format_t AlsaCapture::toAlsaFormat(SampleFormat format) const
+{
+    switch(format) {
+    case SampleFormat::S16_LE:
+        return SND_PCM_FORMAT_S16_LE;
+    case SampleFormat::S24_3LE:
+        return SND_PCM_FORMAT_S24_3LE;
+    case SampleFormat::S32_LE:
+        return SND_PCM_FORMAT_S32_LE;
+    }
+    return SND_PCM_FORMAT_UNKNOWN;
+}
+
+std::size_t AlsaCapture::bytesPerFrame() const
+{
+    switch(config_.format) {
+    case SampleFormat::S16_LE:
+        return static_cast<std::size_t>(config_.channels) * 2U;
+    case SampleFormat::S24_3LE:
+        return static_cast<std::size_t>(config_.channels) * 3U;
+    case SampleFormat::S32_LE:
+        return static_cast<std::size_t>(config_.channels) * 4U;
+    }
+    throw std::runtime_error("Unsupported sample format");
 }
 

--- a/raspberry_pi/src/main.cpp
+++ b/raspberry_pi/src/main.cpp
@@ -1,19 +1,83 @@
 #include "AlsaCapture.h"
 #include "TcpClient.h"
 
+#include <alsa/asoundlib.h>
+
 #include <cstdlib>
 #include <iostream>
+#include <optional>
+#include <string>
 #include <string_view>
+#include <vector>
 
 namespace {
 
+struct Options {
+    std::string device{"hw:0,0"};
+    unsigned int rate{48000};
+    AlsaCapture::SampleFormat format{AlsaCapture::SampleFormat::S16_LE};
+    snd_pcm_uframes_t frames{4096};
+    int iterations{3};
+};
+
+std::optional<AlsaCapture::SampleFormat> parseFormat(std::string_view value)
+{
+    if(value == "S16_LE") {
+        return AlsaCapture::SampleFormat::S16_LE;
+    }
+    if(value == "S24_3LE") {
+        return AlsaCapture::SampleFormat::S24_3LE;
+    }
+    if(value == "S32_LE") {
+        return AlsaCapture::SampleFormat::S32_LE;
+    }
+    return std::nullopt;
+}
+
 void printHelp(std::string_view programName)
 {
-    std::cout << "Usage: " << programName << " [--help]" << std::endl
+    std::cout << "Usage: " << programName
+              << " [--device hw:0,0] [--rate 48000]"
+              << " [--format S16_LE|S24_3LE|S32_LE] [--frames 4096]"
+              << " [--iterations 3] [--help]" << std::endl
               << std::endl
-              << "Prototype PCM bridge entrypoint for Raspberry Pi." << std::endl
-              << "Functionality is not implemented yet; this binary currently"
-              << " serves as a build test placeholder." << std::endl;
+              << "Prototype ALSA capture test entrypoint." << std::endl
+              << "Opens the given ALSA device, reads a few periods, and exits."
+              << std::endl;
+}
+
+std::optional<Options> parseOptions(int argc, char **argv,
+    std::string_view programName)
+{
+    Options opt{};
+    for(int i = 1; i < argc; ++i) {
+        const std::string_view arg{argv[i]};
+        if(arg == "-h" || arg == "--help") {
+            printHelp(programName);
+            return std::nullopt;
+        } else if(arg == "--device" && i + 1 < argc) {
+            opt.device = argv[++i];
+        } else if(arg == "--rate" && i + 1 < argc) {
+            opt.rate = static_cast<unsigned int>(std::strtoul(argv[++i], nullptr, 10));
+        } else if(arg == "--format" && i + 1 < argc) {
+            auto fmt = parseFormat(argv[++i]);
+            if(!fmt) {
+                std::cerr << "Unsupported format. Use one of: "
+                          << "S16_LE | S24_3LE | S32_LE" << std::endl;
+                return std::nullopt;
+            }
+            opt.format = *fmt;
+        } else if(arg == "--frames" && i + 1 < argc) {
+            opt.frames = static_cast<snd_pcm_uframes_t>(
+                std::strtoul(argv[++i], nullptr, 10));
+        } else if(arg == "--iterations" && i + 1 < argc) {
+            opt.iterations = std::atoi(argv[++i]);
+        } else {
+            std::cerr << "Unknown argument: " << arg << std::endl;
+            return std::nullopt;
+        }
+    }
+    return opt;
 }
 
 } // namespace
@@ -24,22 +88,46 @@ int main(int argc, char **argv)
         ? std::string_view{argv[0]}
         : "rpi_pcm_bridge";
 
-    for(int i = 1; i < argc; ++i) {
-        const std::string_view arg{argv[i]};
-        if(arg == "-h" || arg == "--help") {
-            printHelp(programName);
-            return EXIT_SUCCESS;
-        }
+    auto parsed = parseOptions(argc, argv, programName);
+    if(!parsed) {
+        return EXIT_SUCCESS;
     }
-
-    std::cout << "[rpi_pcm_bridge] Prototype build - functionality not"
-              << " implemented yet." << std::endl;
+    const Options opt = *parsed;
 
     AlsaCapture capture;
-    TcpClient client;
+    AlsaCapture::Config cfg;
+    cfg.deviceName = opt.device;
+    cfg.sampleRate = opt.rate;
+    cfg.channels = 2;
+    cfg.format = opt.format;
+    cfg.periodFrames = opt.frames;
 
-    std::clog << "[rpi_pcm_bridge] Created AlsaCapture and TcpClient stubs."
-              << std::endl;
+    if(!capture.open(cfg)) {
+        std::cerr << "[rpi_pcm_bridge] Failed to open device" << std::endl;
+        return EXIT_FAILURE;
+    }
+    if(!capture.start()) {
+        std::cerr << "[rpi_pcm_bridge] Failed to start capture" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::vector<std::uint8_t> buffer;
+    for(int i = 0; i < opt.iterations; ++i) {
+        int bytes = capture.read(buffer);
+        if(bytes == -EPIPE) {
+            std::clog << "[rpi_pcm_bridge] XRUN recovered, continuing"
+                      << std::endl;
+            continue;
+        }
+        if(bytes < 0) {
+            std::clog << "[rpi_pcm_bridge] Read failed: " << bytes << std::endl;
+            break;
+        }
+        std::clog << "[rpi_pcm_bridge] Read " << bytes << " bytes" << std::endl;
+    }
+
+    capture.stop();
+    capture.close();
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary\n- implement AlsaCapture with device open/config/start/read/close, format & rate validation, XRUN recovery via snd_pcm_prepare\n- add CLI options in rpi_pcm_bridge to exercise ALSA capture (device/rate/format/frames/iterations)\n- document ALSA quick test usage and supported formats in raspberry_pi/README\n\n## Testing\n- 未実施（macOS環境でALSAデバイスなしのためビルド/実行不可）\n\n## Notes / Open Points\n- 実機で set_rate_near が指定レートと一致しない場合は現在エラー終了にしています。必要なら近似許容に変更します。\n- 初期対応フォーマットは S16_LE / S24_3LE / S32_LE のみです。追加が必要なら enum に追記してください。