### PR TITLE
#623 ジッタ吸収リングバッファ導入

### DIFF
--- a/jetson_pcm_receiver/README.md
+++ b/jetson_pcm_receiver/README.md
@@ -24,12 +24,15 @@ cmake --build jetson_pcm_receiver/build -j$(nproc)
 ./jetson_pcm_receiver/build/jetson_pcm_receiver \
   --port 46001 \
   --device hw:Loopback,0,0 \
-  --log-level info      # error / warn / info / debug
+  --log-level info \        # error / warn / info / debug
+  --ring-buffer-frames 8192 # 0で無効（デフォルト 8192）
+  --ring-buffer-watermark 0 # 0で自動(75%)
 ```
 
 - 受信ヘッダが `PCMA` / version 1 かつ 44.1kHz or 48kHz の {1,2,4,8,16} 倍、2ch、フォーマットが `S16_LE(1)` / `S24_3LE(2)` / `S32_LE(4)` の場合に再生します。
 - フォーマットやレートが未対応の場合はエラーログを出して接続を閉じます。
 - XRUN (`-EPIPE`) が発生した場合は `snd_pcm_prepare()` で復旧を試み、結果をログします。
+- ジッタ吸収リングバッファ（デフォルト有効）。溢れた場合は古いフレームをドロップし、ウォーターマーク到達・ドロップ数をログします。
 - SIGINT/SIGTERM で停止要求を検出し、接続待受ループを抜けて終了します。
 
 ## ディレクトリ構成

--- a/jetson_pcm_receiver/include/pcm_stream_handler.h
+++ b/jetson_pcm_receiver/include/pcm_stream_handler.h
@@ -7,10 +7,16 @@
 class AlsaPlayback;
 class TcpServer;
 
+struct PcmStreamConfig {
+    std::size_t ringBufferFrames{0};  // 0で無効
+    std::size_t watermarkFrames{0};   // 0なら自動設定
+};
+
 // PCM ストリームの受信と再生を橋渡しする雛形。
 class PcmStreamHandler {
    public:
-    PcmStreamHandler(AlsaPlayback &playback, TcpServer &server, std::atomic_bool &stopFlag);
+    PcmStreamHandler(AlsaPlayback &playback, TcpServer &server, std::atomic_bool &stopFlag,
+                     PcmStreamConfig config);
 
     void run();
     bool handleClientForTest(int fd) const;
@@ -22,4 +28,5 @@ class PcmStreamHandler {
     AlsaPlayback &playback_;
     TcpServer &server_;
     std::atomic_bool &stopFlag_;
+    PcmStreamConfig config_;
 };

--- a/jetson_pcm_receiver/src/main.cpp
+++ b/jetson_pcm_receiver/src/main.cpp
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <csignal>
+#include <cstddef>
 #include <cstdlib>
 #include <iostream>
 #include <string>
@@ -23,6 +24,8 @@ struct AppOptions {
     int port = 46001;
     std::string device = "hw:Loopback,0,0";
     LogLevel logLevel = LogLevel::Info;
+    std::size_t ringBufferFrames = 8192;  // 0で無効
+    std::size_t watermarkFrames = 0;      // 0で自動 (75%)
 };
 
 void printHelp(const char *exeName) {
@@ -32,6 +35,10 @@ void printHelp(const char *exeName) {
     std::cout << "  -p, --port <number>     TCP listen port (default: 46001)\n";
     std::cout << "  -d, --device <name>     ALSA playback device (default: hw:Loopback,0,0)\n";
     std::cout << "  -l, --log-level <lvl>   error/warn/info/debug (default: info)\n";
+    std::cout << "  --ring-buffer-frames N  enable jitter buffer with N frames (default: 8192)\n";
+    std::cout
+        << "  --ring-buffer-watermark N  watermark frames for warning (default: 75% of buffer)\n";
+    std::cout << "  --no-ring-buffer        disable jitter buffer\n";
     std::cout << "  -h, --help              Show this help\n";
     std::cout << std::endl;
 }
@@ -54,6 +61,20 @@ bool parseArgs(int argc, char **argv, AppOptions &options, bool &showHelp) {
         }
         if ((arg == "-l" || arg == "--log-level") && i + 1 < argc) {
             options.logLevel = parseLogLevel(argv[++i]);
+            continue;
+        }
+        if (arg == "--ring-buffer-frames" && i + 1 < argc) {
+            options.ringBufferFrames =
+                static_cast<std::size_t>(std::strtoul(argv[++i], nullptr, 10));
+            continue;
+        }
+        if (arg == "--ring-buffer-watermark" && i + 1 < argc) {
+            options.watermarkFrames =
+                static_cast<std::size_t>(std::strtoul(argv[++i], nullptr, 10));
+            continue;
+        }
+        if (arg == "--no-ring-buffer") {
+            options.ringBufferFrames = 0;
             continue;
         }
 
@@ -88,10 +109,21 @@ int main(int argc, char **argv) {
     logInfo("[jetson-pcm-receiver] start");
     logInfo("  - port:   " + std::to_string(options.port));
     logInfo("  - device: " + options.device);
+    if (options.ringBufferFrames == 0) {
+        logInfo("  - ring buffer: disabled");
+    } else {
+        logInfo("  - ring buffer: " + std::to_string(options.ringBufferFrames) + " frames");
+        if (options.watermarkFrames > 0) {
+            logInfo("  - watermark:   " + std::to_string(options.watermarkFrames) + " frames");
+        }
+    }
 
     TcpServer server(options.port);
     AlsaPlayback playback(options.device);
-    PcmStreamHandler handler(playback, server, stopRequested);
+    PcmStreamConfig cfg;
+    cfg.ringBufferFrames = options.ringBufferFrames;
+    cfg.watermarkFrames = options.watermarkFrames;
+    PcmStreamHandler handler(playback, server, stopRequested, cfg);
 
     if (!server.start()) {
         logError("[jetson-pcm-receiver] failed to start TCP server");


### PR DESCRIPTION
## Summary
- 受信と再生の間に可否切替可能なリングバッファを追加し、ウォーターマークとドロップをログ出力
- CLIに --ring-buffer-frames / --ring-buffer-watermark / --no-ring-buffer を追加し、起動時に設定内容をログ表示
- 停止フラグをヘッダ受信中にも監視し、リングバッファオーバーフローや統計（最大蓄積・ドロップ数）を記録

## Test plan
- /usr/bin/cmake -S /home/michihito/Working/gpu_os/worktrees/623-jitter-buffer/jetson_pcm_receiver -B /home/michihito/Working/gpu_os/worktrees/623-jitter-buffer/jetson_pcm_receiver/build -DCMAKE_BUILD_TYPE=Debug
- /usr/bin/cmake --build /home/michihito/Working/gpu_os/worktrees/623-jitter-buffer/jetson_pcm_receiver/build -j$(nproc)
- /usr/bin/ctest --test-dir /home/michihito/Working/gpu_os/worktrees/623-jitter-buffer/jetson_pcm_receiver/build --output-on-failure