### PR TITLE
#624 ステータスAPI（HTTP）実装

### DIFF
--- a/jetson_pcm_receiver/CMakeLists.txt
+++ b/jetson_pcm_receiver/CMakeLists.txt
@@ -36,6 +36,7 @@ endif()
 
 add_library(jetson_pcm_receiver_lib
     src/logging.cpp
+    src/status_server.cpp
     src/tcp_server.cpp
     src/alsa_playback.cpp
     src/pcm_stream_handler.cpp

--- a/jetson_pcm_receiver/include/alsa_playback.h
+++ b/jetson_pcm_receiver/include/alsa_playback.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <alsa/asoundlib.h>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -15,6 +16,9 @@ class AlsaPlayback {
     virtual bool open(uint32_t sampleRate, uint16_t channels, uint16_t format);
     virtual bool write(const void *data, std::size_t frames);
     virtual void close();
+    std::size_t xrunCount() const {
+        return xrunCount_.load(std::memory_order_relaxed);
+    }
 
     const std::string &device() const {
         return device_;
@@ -28,6 +32,7 @@ class AlsaPlayback {
     uint16_t channels_{0};
     snd_pcm_uframes_t periodSize_{0};
     snd_pcm_uframes_t bufferSize_{0};
+    std::atomic_size_t xrunCount_{0};
 
     bool configureHardware(uint32_t sampleRate, uint16_t channels, snd_pcm_format_t format);
     bool recoverFromXrun();

--- a/jetson_pcm_receiver/include/pcm_stream_handler.h
+++ b/jetson_pcm_receiver/include/pcm_stream_handler.h
@@ -1,11 +1,15 @@
 #pragma once
 
 #include "pcm_header.h"
+#include "status_server.h"
 
 #include <atomic>
+#include <mutex>
+#include <string>
 
 class AlsaPlayback;
 class TcpServer;
+class StatusServer;
 
 struct PcmStreamConfig {
     std::size_t ringBufferFrames{0};  // 0で無効
@@ -19,14 +23,23 @@ class PcmStreamHandler {
                      PcmStreamConfig config);
 
     void run();
-    bool handleClientForTest(int fd) const;
+    bool handleClientForTest(int fd);
+    PcmStatusSnapshot snapshot() const;
+    void setStatusServer(StatusServer *server);
 
    private:
     bool receiveHeader(int fd, PcmHeader &header) const;
-    bool handleClient(int fd) const;
+    bool handleClient(int fd);
 
     AlsaPlayback &playback_;
     TcpServer &server_;
     std::atomic_bool &stopFlag_;
     PcmStreamConfig config_;
+    StatusServer *statusServer_{nullptr};
+    std::atomic_bool connected_{false};
+    std::string lastHeaderSummary_;
+    mutable std::mutex mutex_;
+    std::size_t bufferedFrames_{0};
+    std::size_t maxBufferedFrames_{0};
+    std::size_t droppedFrames_{0};
 };

--- a/jetson_pcm_receiver/include/status_server.h
+++ b/jetson_pcm_receiver/include/status_server.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <atomic>
+#include <string>
+#include <thread>
+
+struct PcmStatusSnapshot {
+    bool connected{false};
+    std::string lastHeaderSummary;
+    std::size_t bufferedFrames{0};
+    std::size_t maxBufferedFrames{0};
+    std::size_t droppedFrames{0};
+    std::size_t xrunCount{0};
+};
+
+// 非常に簡易なHTTPステータスサーバ。ローカルバインドのみ。
+class StatusServer {
+   public:
+    StatusServer(int port, std::atomic_bool &stopFlag);
+    ~StatusServer();
+
+    void start();
+    void stop();
+
+    // 最新状態をセット（呼び出し側で定期的に更新）
+    void setSnapshot(const PcmStatusSnapshot &snapshot);
+
+   private:
+    int port_;
+    int fd_{-1};
+    std::atomic_bool &stopFlag_;
+    std::atomic_bool running_{false};
+    std::thread worker_;
+    PcmStatusSnapshot snapshot_;
+
+    void serveLoop();
+};

--- a/jetson_pcm_receiver/src/alsa_playback.cpp
+++ b/jetson_pcm_receiver/src/alsa_playback.cpp
@@ -180,6 +180,7 @@ bool AlsaPlayback::recoverFromXrun() {
         return false;
     }
     logWarn("[AlsaPlayback] XRUN recovered with snd_pcm_prepare()");
+    xrunCount_.fetch_add(1, std::memory_order_relaxed);
     return true;
 }
 

--- a/jetson_pcm_receiver/src/status_server.cpp
+++ b/jetson_pcm_receiver/src/status_server.cpp
@@ -1,0 +1,110 @@
+#include "status_server.h"
+
+#include "logging.h"
+
+#include <arpa/inet.h>
+#include <cerrno>
+#include <cstring>
+#include <netinet/in.h>
+#include <sstream>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace {
+std::string buildResponse(const PcmStatusSnapshot &snap) {
+    std::ostringstream oss;
+    oss << "{";
+    oss << "\"connected\":" << (snap.connected ? "true" : "false") << ",";
+    oss << "\"last_header\":\"" << snap.lastHeaderSummary << "\",";
+    oss << "\"buffered_frames\":" << snap.bufferedFrames << ",";
+    oss << "\"max_buffered_frames\":" << snap.maxBufferedFrames << ",";
+    oss << "\"dropped_frames\":" << snap.droppedFrames << ",";
+    oss << "\"xrun_count\":" << snap.xrunCount;
+    oss << "}";
+    return oss.str();
+}
+}  // namespace
+
+StatusServer::StatusServer(int port, std::atomic_bool &stopFlag)
+    : port_(port), stopFlag_(stopFlag) {}
+
+StatusServer::~StatusServer() {
+    stop();
+}
+
+void StatusServer::setSnapshot(const PcmStatusSnapshot &snapshot) {
+    snapshot_ = snapshot;
+}
+
+void StatusServer::start() {
+    if (running_.load(std::memory_order_relaxed) || port_ <= 0) {
+        return;
+    }
+    running_.store(true, std::memory_order_relaxed);
+    worker_ = std::thread([this]() { serveLoop(); });
+}
+
+void StatusServer::stop() {
+    running_.store(false, std::memory_order_relaxed);
+    if (fd_ >= 0) {
+        ::close(fd_);
+        fd_ = -1;
+    }
+    if (worker_.joinable()) {
+        worker_.join();
+    }
+}
+
+void StatusServer::serveLoop() {
+    fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd_ < 0) {
+        logWarn(std::string("[StatusServer] socket failed: ") + std::strerror(errno));
+        return;
+    }
+    int opt = 1;
+    setsockopt(fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);  // ローカルバインド
+    addr.sin_port = htons(static_cast<uint16_t>(port_));
+    if (::bind(fd_, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0) {
+        logWarn(std::string("[StatusServer] bind failed: ") + std::strerror(errno));
+        ::close(fd_);
+        fd_ = -1;
+        return;
+    }
+    if (::listen(fd_, 4) < 0) {
+        logWarn(std::string("[StatusServer] listen failed: ") + std::strerror(errno));
+        ::close(fd_);
+        fd_ = -1;
+        return;
+    }
+
+    logInfo("[StatusServer] listening on 127.0.0.1:" + std::to_string(port_));
+
+    while (running_.load(std::memory_order_relaxed) && !stopFlag_.load(std::memory_order_relaxed)) {
+        int cfd = ::accept(fd_, nullptr, nullptr);
+        if (cfd < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            if (!running_.load(std::memory_order_relaxed)) {
+                break;
+            }
+            logWarn(std::string("[StatusServer] accept failed: ") + std::strerror(errno));
+            continue;
+        }
+
+        const std::string body = buildResponse(snapshot_);
+        std::ostringstream oss;
+        oss << "HTTP/1.1 200 OK\r\n";
+        oss << "Content-Type: application/json\r\n";
+        oss << "Content-Length: " << body.size() << "\r\n";
+        oss << "Connection: close\r\n\r\n";
+        oss << body;
+        const auto resp = oss.str();
+        ::send(cfd, resp.data(), resp.size(), 0);
+        ::close(cfd);
+    }
+}


### PR DESCRIPTION
## Summary
- PCM処理の状態を返す簡易HTTPステータスAPIを追加（127.0.0.1バインド、デフォルト無効）
- 接続状態/最後のヘッダ情報/リングバッファ水位・ドロップ/最大蓄積/XRUNカウントをスナップショットで返却
- CLIに --status-port を追加し、リングバッファ有効時の統計をステータスへ反映

## Test plan
- /usr/bin/cmake -S /home/michihito/Working/gpu_os/worktrees/624-status-api/jetson_pcm_receiver -B /home/michihito/Working/gpu_os/worktrees/624-status-api/jetson_pcm_receiver/build -DCMAKE_BUILD_TYPE=Debug
- /usr/bin/cmake --build /home/michihito/Working/gpu_os/worktrees/624-status-api/jetson_pcm_receiver/build -j$(nproc)
- /usr/bin/ctest --test-dir /home/michihito/Working/gpu_os/worktrees/624-status-api/jetson_pcm_receiver/build --output-on-failure