### PR TITLE
#624 ステータスAPI（ZeroMQ）実装

### DIFF
--- a/jetson_pcm_receiver/CMakeLists.txt
+++ b/jetson_pcm_receiver/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(PkgConfig REQUIRED)
 find_package(Threads REQUIRED)
 
 pkg_check_modules(ALSA REQUIRED alsa)
+pkg_check_modules(ZMQ REQUIRED libzmq)
 
 include(CheckIncludeFileCXX)
 include(CheckCXXSymbolExists)
@@ -40,6 +41,9 @@ add_library(jetson_pcm_receiver_lib
     src/alsa_playback.cpp
     src/pcm_stream_handler.cpp
     src/pcm_header.cpp
+    src/status_tracker.cpp
+    src/zmq_status_server.cpp
+    ../src/daemon/control/zmq_server.cpp
 )
 
 add_executable(jetson_pcm_receiver
@@ -49,13 +53,19 @@ add_executable(jetson_pcm_receiver
 target_include_directories(jetson_pcm_receiver_lib
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/..
+        ${CMAKE_CURRENT_SOURCE_DIR}/../include
         ${ALSA_INCLUDE_DIRS}
+        ${ZMQ_INCLUDE_DIRS}
 )
 
 target_link_libraries(jetson_pcm_receiver_lib
     PUBLIC
         ${ALSA_LIBRARIES}
         Threads::Threads
+        ${ZMQ_LIBRARIES}
+        cppzmq
+        nlohmann_json::nlohmann_json
 )
 
 target_link_libraries(jetson_pcm_receiver PRIVATE jetson_pcm_receiver_lib)
@@ -83,18 +93,31 @@ message(STATUS "ALSA libraries: ${ALSA_LIBRARIES}")
 enable_testing()
 
 FetchContent_Declare(
+    cppzmq
+    GIT_REPOSITORY https://github.com/zeromq/cppzmq.git
+    GIT_TAG v4.10.0
+)
+
+FetchContent_Declare(
+    nlohmann_json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG v3.11.3
+)
+
+FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG v1.14.0
 )
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+FetchContent_MakeAvailable(googletest cppzmq nlohmann_json)
 
 add_executable(jetson_pcm_receiver_tests
     tests/test_pcm_header.cpp
     tests/test_tcp_server.cpp
     tests/test_pcm_stream_handler.cpp
     tests/test_alsa_playback.cpp
+    tests/test_zmq_status_server.cpp
 )
 
 target_link_libraries(jetson_pcm_receiver_tests
@@ -105,6 +128,8 @@ target_link_libraries(jetson_pcm_receiver_tests
 
 target_include_directories(jetson_pcm_receiver_tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include
 )
 
 add_test(NAME jetson_pcm_receiver_tests COMMAND jetson_pcm_receiver_tests)

--- a/jetson_pcm_receiver/include/alsa_playback.h
+++ b/jetson_pcm_receiver/include/alsa_playback.h
@@ -5,6 +5,8 @@
 #include <cstdint>
 #include <string>
 
+class StatusTracker;
+
 // ALSA 再生デバイス操作。S16_LE/2ch/48k を初期ターゲットとし、
 // 今後拡張しやすいようにフォーマット変換とパラメータ設定を分離する。
 class AlsaPlayback {
@@ -15,6 +17,9 @@ class AlsaPlayback {
     virtual bool open(uint32_t sampleRate, uint16_t channels, uint16_t format);
     virtual bool write(const void *data, std::size_t frames);
     virtual void close();
+    void setStatusTracker(StatusTracker *tracker) {
+        statusTracker_ = tracker;
+    }
 
     const std::string &device() const {
         return device_;
@@ -28,6 +33,7 @@ class AlsaPlayback {
     uint16_t channels_{0};
     snd_pcm_uframes_t periodSize_{0};
     snd_pcm_uframes_t bufferSize_{0};
+    StatusTracker *statusTracker_{nullptr};
 
     bool configureHardware(uint32_t sampleRate, uint16_t channels, snd_pcm_format_t format);
     bool recoverFromXrun();

--- a/jetson_pcm_receiver/include/pcm_stream_handler.h
+++ b/jetson_pcm_receiver/include/pcm_stream_handler.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "pcm_header.h"
+#include "status_tracker.h"
 
 #include <atomic>
+#include <mutex>
 
 class AlsaPlayback;
 class TcpServer;
@@ -16,17 +18,20 @@ struct PcmStreamConfig {
 class PcmStreamHandler {
    public:
     PcmStreamHandler(AlsaPlayback &playback, TcpServer &server, std::atomic_bool &stopFlag,
-                     PcmStreamConfig config);
+                     PcmStreamConfig &config, std::mutex *configMutex = nullptr,
+                     StatusTracker *status = nullptr);
 
     void run();
-    bool handleClientForTest(int fd) const;
+    bool handleClientForTest(int fd);
 
    private:
     bool receiveHeader(int fd, PcmHeader &header) const;
-    bool handleClient(int fd) const;
+    bool handleClient(int fd);
 
     AlsaPlayback &playback_;
     TcpServer &server_;
     std::atomic_bool &stopFlag_;
-    PcmStreamConfig config_;
+    PcmStreamConfig &config_;
+    std::mutex *configMutex_{nullptr};
+    StatusTracker *status_{nullptr};
 };

--- a/jetson_pcm_receiver/include/status_tracker.h
+++ b/jetson_pcm_receiver/include/status_tracker.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "pcm_header.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+
+struct RingBufferSnapshot {
+    std::size_t configuredFrames{0};
+    std::size_t watermarkFrames{0};
+    std::size_t bufferedFrames{0};
+    std::size_t maxBufferedFrames{0};
+    std::size_t droppedFrames{0};
+};
+
+struct HeaderSnapshot {
+    bool present{false};
+    PcmHeader header{};
+};
+
+struct StatusSnapshot {
+    bool listening{false};
+    uint16_t boundPort{0};
+    bool clientConnected{false};
+    bool streaming{false};
+    std::size_t xrunCount{0};
+    RingBufferSnapshot ring;
+    HeaderSnapshot header;
+};
+
+// ストリーミング状態を集約し、ZMQレスポンスなどで使えるスナップショットを提供する。
+class StatusTracker {
+   public:
+    void setListening(uint16_t port);
+    void clearListening();
+    void setClientConnected(bool connected);
+    void setStreaming(bool streaming);
+    void setHeader(const PcmHeader& header);
+    void updateRingConfig(std::size_t ringFrames, std::size_t watermarkFrames);
+    void updateRingBuffer(std::size_t bufferedFrames, std::size_t maxBufferedFrames,
+                          std::size_t droppedFrames);
+    void incrementXrun();
+
+    StatusSnapshot snapshot() const;
+
+   private:
+    mutable std::mutex mutex_;
+    StatusSnapshot status_;
+};

--- a/jetson_pcm_receiver/include/zmq_status_server.h
+++ b/jetson_pcm_receiver/include/zmq_status_server.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "pcm_stream_handler.h"
+#include "status_tracker.h"
+
+#include <atomic>
+#include <daemon/control/zmq_server.h>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <thread>
+
+class ZmqStatusServer {
+   public:
+    struct Options {
+        bool enabled{true};
+        std::string endpoint;
+        std::string token;
+        int publishIntervalMs{1000};
+    };
+
+    ZmqStatusServer(StatusTracker& status, PcmStreamConfig& config, std::mutex& configMutex,
+                    std::atomic_bool& stopFlag);
+    ~ZmqStatusServer();
+
+    bool start(const Options& options);
+    void stop();
+
+    std::string endpoint() const;
+    std::string pubEndpoint() const;
+    bool running() const {
+        return server_ && server_->isRunning();
+    }
+    bool restartRequested() const {
+        return restartRequested_.load();
+    }
+
+   private:
+    bool checkToken(const daemon_ipc::ZmqRequest& request, std::string& error) const;
+    std::string buildError(const daemon_ipc::ZmqRequest& request, const std::string& code,
+                           const std::string& message) const;
+    std::string handleStatus(const daemon_ipc::ZmqRequest& request);
+    std::string handleSetCache(const daemon_ipc::ZmqRequest& request);
+    std::string handleRestart(const daemon_ipc::ZmqRequest& request);
+    std::string handlePing(const daemon_ipc::ZmqRequest& request);
+    nlohmann::json buildStatusJson() const;
+    void startPublisher();
+    void stopPublisher();
+    void publisherLoop();
+
+    StatusTracker& status_;
+    PcmStreamConfig& config_;
+    std::mutex& configMutex_;
+    std::atomic_bool& stopFlag_;
+    std::unique_ptr<daemon_ipc::ZmqCommandServer> server_;
+    Options options_;
+    std::thread publisherThread_;
+    std::atomic<bool> publisherRunning_{false};
+    std::atomic<bool> restartRequested_{false};
+};

--- a/jetson_pcm_receiver/src/alsa_playback.cpp
+++ b/jetson_pcm_receiver/src/alsa_playback.cpp
@@ -1,6 +1,7 @@
 #include "alsa_playback.h"
 
 #include "logging.h"
+#include "status_tracker.h"
 
 #include <iostream>
 #include <memory>
@@ -195,6 +196,9 @@ bool AlsaPlayback::write(const void *data, std::size_t frames) {
     snd_pcm_sframes_t written = snd_pcm_writei(handle_, data, frames);
     if (written == -EPIPE) {
         logWarn("[AlsaPlayback] XRUN detected (EPIPE)");
+        if (statusTracker_) {
+            statusTracker_->incrementXrun();
+        }
         if (!recoverFromXrun()) {
             return false;
         }

--- a/jetson_pcm_receiver/src/status_tracker.cpp
+++ b/jetson_pcm_receiver/src/status_tracker.cpp
@@ -1,0 +1,56 @@
+#include "status_tracker.h"
+
+void StatusTracker::setListening(uint16_t port) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    status_.listening = true;
+    status_.boundPort = port;
+}
+
+void StatusTracker::clearListening() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    status_.listening = false;
+    status_.boundPort = 0;
+}
+
+void StatusTracker::setClientConnected(bool connected) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    status_.clientConnected = connected;
+    if (!connected) {
+        status_.streaming = false;
+    }
+}
+
+void StatusTracker::setStreaming(bool streaming) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    status_.streaming = streaming;
+}
+
+void StatusTracker::setHeader(const PcmHeader& header) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    status_.header.present = true;
+    status_.header.header = header;
+}
+
+void StatusTracker::updateRingConfig(std::size_t ringFrames, std::size_t watermarkFrames) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    status_.ring.configuredFrames = ringFrames;
+    status_.ring.watermarkFrames = watermarkFrames;
+}
+
+void StatusTracker::updateRingBuffer(std::size_t bufferedFrames, std::size_t maxBufferedFrames,
+                                     std::size_t droppedFrames) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    status_.ring.bufferedFrames = bufferedFrames;
+    status_.ring.maxBufferedFrames = maxBufferedFrames;
+    status_.ring.droppedFrames = droppedFrames;
+}
+
+void StatusTracker::incrementXrun() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++status_.xrunCount;
+}
+
+StatusSnapshot StatusTracker::snapshot() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return status_;
+}

--- a/jetson_pcm_receiver/src/zmq_status_server.cpp
+++ b/jetson_pcm_receiver/src/zmq_status_server.cpp
@@ -1,0 +1,270 @@
+#include "zmq_status_server.h"
+
+#include "logging.h"
+
+#include <chrono>
+#include <iostream>
+
+namespace {
+
+constexpr const char* kDefaultEndpoint = "ipc:///tmp/jetson_pcm_receiver.sock";
+
+std::string okResponse(const daemon_ipc::ZmqRequest& request, const nlohmann::json& data) {
+    if (request.isJson) {
+        nlohmann::json resp;
+        resp["status"] = "ok";
+        if (!data.is_null() && !data.empty()) {
+            resp["data"] = data;
+        }
+        return resp.dump();
+    }
+    if (data.is_null() || data.empty()) {
+        return "OK";
+    }
+    return "OK:" + data.dump();
+}
+
+std::string extractToken(const daemon_ipc::ZmqRequest& request) {
+    if (!request.json) {
+        return {};
+    }
+    if (request.json->contains("token") && (*request.json)["token"].is_string()) {
+        return (*request.json)["token"].get<std::string>();
+    }
+    if (request.json->contains("params") && (*request.json)["params"].is_object()) {
+        const auto& params = (*request.json)["params"];
+        if (params.contains("token") && params["token"].is_string()) {
+            return params["token"].get<std::string>();
+        }
+    }
+    return {};
+}
+
+}  // namespace
+
+ZmqStatusServer::ZmqStatusServer(StatusTracker& status, PcmStreamConfig& config,
+                                 std::mutex& configMutex, std::atomic_bool& stopFlag)
+    : status_(status), config_(config), configMutex_(configMutex), stopFlag_(stopFlag) {}
+
+ZmqStatusServer::~ZmqStatusServer() {
+    stop();
+}
+
+bool ZmqStatusServer::start(const Options& options) {
+    options_ = options;
+    if (!options_.enabled) {
+        return true;
+    }
+
+    const std::string endpoint =
+        options_.endpoint.empty() ? std::string(kDefaultEndpoint) : options_.endpoint;
+
+    server_ = std::make_unique<daemon_ipc::ZmqCommandServer>(endpoint);
+    server_->registerCommand("PING", [this](const auto& req) { return handlePing(req); });
+    server_->registerCommand("STATUS", [this](const auto& req) { return handleStatus(req); });
+    server_->registerCommand("SET_CACHE", [this](const auto& req) { return handleSetCache(req); });
+    server_->registerCommand("SET_RING_BUFFER",
+                             [this](const auto& req) { return handleSetCache(req); });
+    server_->registerCommand("RESTART", [this](const auto& req) { return handleRestart(req); });
+    server_->registerCommand("SHUTDOWN", [this](const auto& req) { return handleRestart(req); });
+
+    if (!server_->start()) {
+        server_.reset();
+        return false;
+    }
+
+    startPublisher();
+    std::cout << "[ZMQ] REP=" << server_->endpoint() << " PUB=" << server_->pubEndpoint()
+              << std::endl;
+    return true;
+}
+
+void ZmqStatusServer::stop() {
+    stopPublisher();
+    if (server_) {
+        server_->stop();
+        server_.reset();
+    }
+}
+
+std::string ZmqStatusServer::endpoint() const {
+    static std::string empty;
+    if (!server_) {
+        return empty;
+    }
+    return server_->endpoint();
+}
+
+std::string ZmqStatusServer::pubEndpoint() const {
+    static std::string empty;
+    if (!server_) {
+        return empty;
+    }
+    return server_->pubEndpoint();
+}
+
+bool ZmqStatusServer::checkToken(const daemon_ipc::ZmqRequest& request, std::string& error) const {
+    if (options_.token.empty()) {
+        return true;
+    }
+    const std::string provided = extractToken(request);
+    if (provided.empty()) {
+        error = "Missing token";
+        return false;
+    }
+    if (provided != options_.token) {
+        error = "Invalid token";
+        return false;
+    }
+    return true;
+}
+
+std::string ZmqStatusServer::buildError(const daemon_ipc::ZmqRequest& request,
+                                        const std::string& code, const std::string& message) const {
+    if (request.isJson) {
+        nlohmann::json resp;
+        resp["status"] = "error";
+        resp["error_code"] = code;
+        resp["message"] = message;
+        return resp.dump();
+    }
+    return "ERR:" + message;
+}
+
+std::string ZmqStatusServer::handlePing(const daemon_ipc::ZmqRequest& request) {
+    std::string error;
+    if (!checkToken(request, error)) {
+        return buildError(request, "IPC_UNAUTHORIZED", error);
+    }
+    return okResponse(request, {});
+}
+
+std::string ZmqStatusServer::handleStatus(const daemon_ipc::ZmqRequest& request) {
+    std::string error;
+    if (!checkToken(request, error)) {
+        return buildError(request, "IPC_UNAUTHORIZED", error);
+    }
+
+    nlohmann::json data = buildStatusJson();
+    if (server_) {
+        data["rep_endpoint"] = server_->endpoint();
+        data["pub_endpoint"] = server_->pubEndpoint();
+    }
+    return okResponse(request, data);
+}
+
+std::string ZmqStatusServer::handleSetCache(const daemon_ipc::ZmqRequest& request) {
+    std::string error;
+    if (!checkToken(request, error)) {
+        return buildError(request, "IPC_UNAUTHORIZED", error);
+    }
+    if (!request.json || !request.json->contains("params")) {
+        return buildError(request, "IPC_INVALID_PARAMS", "params object is required");
+    }
+    const auto& params = (*request.json)["params"];
+    if (!params.is_object()) {
+        return buildError(request, "IPC_INVALID_PARAMS", "params must be an object");
+    }
+
+    std::size_t newRing = config_.ringBufferFrames;
+    std::size_t newWatermark = config_.watermarkFrames;
+    if (params.contains("ring_buffer_frames")) {
+        if (!params["ring_buffer_frames"].is_number_unsigned()) {
+            return buildError(request, "IPC_INVALID_PARAMS",
+                              "ring_buffer_frames must be an unsigned integer");
+        }
+        newRing = params["ring_buffer_frames"].get<std::size_t>();
+    }
+    if (params.contains("watermark_frames")) {
+        if (!params["watermark_frames"].is_number_unsigned()) {
+            return buildError(request, "IPC_INVALID_PARAMS",
+                              "watermark_frames must be an unsigned integer");
+        }
+        newWatermark = params["watermark_frames"].get<std::size_t>();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(configMutex_);
+        config_.ringBufferFrames = newRing;
+        config_.watermarkFrames = newWatermark;
+    }
+    status_.updateRingConfig(newRing, newWatermark);
+
+    nlohmann::json data;
+    data["ring_buffer_frames"] = newRing;
+    data["watermark_frames"] = newWatermark;
+    return okResponse(request, data);
+}
+
+std::string ZmqStatusServer::handleRestart(const daemon_ipc::ZmqRequest& request) {
+    std::string error;
+    if (!checkToken(request, error)) {
+        return buildError(request, "IPC_UNAUTHORIZED", error);
+    }
+    restartRequested_.store(true);
+    stopFlag_.store(true, std::memory_order_relaxed);
+    nlohmann::json data;
+    data["message"] = "Restart requested";
+    return okResponse(request, data);
+}
+
+nlohmann::json ZmqStatusServer::buildStatusJson() const {
+    auto snap = status_.snapshot();
+    nlohmann::json data;
+    data["listening"] = snap.listening;
+    data["bound_port"] = snap.boundPort;
+    data["client_connected"] = snap.clientConnected;
+    data["streaming"] = snap.streaming;
+    data["xrun_count"] = snap.xrunCount;
+    data["ring_buffer_frames"] = snap.ring.configuredFrames;
+    data["watermark_frames"] = snap.ring.watermarkFrames;
+    data["buffered_frames"] = snap.ring.bufferedFrames;
+    data["max_buffered_frames"] = snap.ring.maxBufferedFrames;
+    data["dropped_frames"] = snap.ring.droppedFrames;
+    if (snap.header.present) {
+        nlohmann::json hdr;
+        hdr["sample_rate"] = snap.header.header.sample_rate;
+        hdr["channels"] = snap.header.header.channels;
+        hdr["format"] = snap.header.header.format;
+        hdr["version"] = snap.header.header.version;
+        data["last_header"] = hdr;
+    } else {
+        data["last_header"] = nullptr;
+    }
+    return data;
+}
+
+void ZmqStatusServer::startPublisher() {
+    if (!server_ || options_.publishIntervalMs <= 0) {
+        return;
+    }
+    if (publisherRunning_.exchange(true)) {
+        return;
+    }
+    publisherThread_ = std::thread([this]() { publisherLoop(); });
+}
+
+void ZmqStatusServer::stopPublisher() {
+    if (!publisherRunning_.exchange(false)) {
+        return;
+    }
+    if (publisherThread_.joinable()) {
+        publisherThread_.join();
+    }
+}
+
+void ZmqStatusServer::publisherLoop() {
+    using namespace std::chrono_literals;
+    while (publisherRunning_.load()) {
+        if (server_ && server_->isRunning()) {
+            try {
+                nlohmann::json payload = buildStatusJson();
+                payload["event"] = "status";
+                server_->publish(payload.dump());
+            } catch (const std::exception& e) {
+                logWarn(std::string("[ZMQ] publish failed: ") + e.what());
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(options_.publishIntervalMs));
+    }
+}

--- a/jetson_pcm_receiver/tests/test_zmq_status_server.cpp
+++ b/jetson_pcm_receiver/tests/test_zmq_status_server.cpp
@@ -1,0 +1,168 @@
+#include "status_tracker.h"
+#include "zmq_status_server.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <unistd.h>
+#include <zmq.hpp>
+
+namespace {
+
+std::string makeEndpoint() {
+    std::ostringstream oss;
+    static std::atomic<int> counter{0};
+    oss << "ipc:///tmp/jetson_pcm_zmq_status_" << ::getpid() << "_" << counter++ << ".sock";
+    return oss.str();
+}
+
+class ZmqStatusServerTest : public ::testing::Test {
+   protected:
+    void TearDown() override {
+        server.stop();
+    }
+
+    void startServer(int pubIntervalMs = 0, const std::string& token = "") {
+        options.enabled = true;
+        options.endpoint = makeEndpoint();
+        options.publishIntervalMs = pubIntervalMs;
+        options.token = token;
+        ASSERT_TRUE(server.start(options));
+    }
+
+    std::string sendCommand(const nlohmann::json& payload) {
+        zmq::context_t ctx(1);
+        zmq::socket_t req(ctx, zmq::socket_type::req);
+        req.connect(server.endpoint());
+        std::string raw = payload.dump();
+        req.send(zmq::buffer(raw), zmq::send_flags::none);
+        zmq::message_t reply;
+        auto res = req.recv(reply, zmq::recv_flags::none);
+        if (!res) {
+            return {};
+        }
+        return std::string(static_cast<char*>(reply.data()), reply.size());
+    }
+
+    StatusTracker status;
+    PcmStreamConfig config{};
+    std::mutex configMutex;
+    std::atomic_bool stopFlag{false};
+    ZmqStatusServer server{status, config, configMutex, stopFlag};
+    ZmqStatusServer::Options options{};
+};
+
+}  // namespace
+
+TEST_F(ZmqStatusServerTest, ReturnsStatusSnapshot) {
+    startServer();
+
+    PcmHeader hdr{};
+    std::memcpy(hdr.magic, "PCMA", 4);
+    hdr.version = 1;
+    hdr.sample_rate = 48000;
+    hdr.channels = 2;
+    hdr.format = 1;
+
+    status.setListening(5555);
+    status.setClientConnected(true);
+    status.setHeader(hdr);
+    status.updateRingConfig(64, 48);
+    status.updateRingBuffer(32, 48, 1);
+    status.incrementXrun();
+
+    nlohmann::json cmd;
+    cmd["cmd"] = "STATUS";
+    auto reply = sendCommand(cmd);
+    auto resp = nlohmann::json::parse(reply);
+    ASSERT_EQ(resp["status"], "ok");
+    auto data = resp["data"];
+    EXPECT_TRUE(data["listening"]);
+    EXPECT_EQ(data["bound_port"], 5555);
+    EXPECT_TRUE(data["client_connected"]);
+    EXPECT_EQ(data["ring_buffer_frames"], 64);
+    EXPECT_EQ(data["buffered_frames"], 32);
+    EXPECT_EQ(data["dropped_frames"], 1);
+    EXPECT_EQ(data["xrun_count"], 1);
+    EXPECT_EQ(data["last_header"]["sample_rate"], 48000);
+}
+
+TEST_F(ZmqStatusServerTest, UpdatesRingConfigFromSetCache) {
+    startServer();
+    config.ringBufferFrames = 8;
+    config.watermarkFrames = 0;
+
+    nlohmann::json cmd;
+    cmd["cmd"] = "SET_CACHE";
+    cmd["params"]["ring_buffer_frames"] = 512;
+    cmd["params"]["watermark_frames"] = 256;
+
+    auto reply = sendCommand(cmd);
+    auto resp = nlohmann::json::parse(reply);
+    ASSERT_EQ(resp["status"], "ok");
+    EXPECT_EQ(resp["data"]["ring_buffer_frames"], 512);
+    EXPECT_EQ(resp["data"]["watermark_frames"], 256);
+
+    std::lock_guard<std::mutex> lock(configMutex);
+    EXPECT_EQ(config.ringBufferFrames, 512u);
+    EXPECT_EQ(config.watermarkFrames, 256u);
+
+    auto snap = status.snapshot();
+    EXPECT_EQ(snap.ring.configuredFrames, 512u);
+    EXPECT_EQ(snap.ring.watermarkFrames, 256u);
+}
+
+TEST_F(ZmqStatusServerTest, RejectsInvalidToken) {
+    startServer(0, "secret");
+
+    nlohmann::json cmd;
+    cmd["cmd"] = "STATUS";
+    auto reply = sendCommand(cmd);
+    auto resp = nlohmann::json::parse(reply);
+    ASSERT_EQ(resp["status"], "error");
+    EXPECT_EQ(resp["error_code"], "IPC_UNAUTHORIZED");
+
+    cmd["token"] = "secret";
+    reply = sendCommand(cmd);
+    resp = nlohmann::json::parse(reply);
+    EXPECT_EQ(resp["status"], "ok");
+}
+
+TEST_F(ZmqStatusServerTest, RestartSetsStopFlagAndPublishes) {
+    startServer(50);
+
+    nlohmann::json cmd;
+    cmd["cmd"] = "RESTART";
+    auto reply = sendCommand(cmd);
+    auto resp = nlohmann::json::parse(reply);
+    ASSERT_EQ(resp["status"], "ok");
+    EXPECT_TRUE(stopFlag.load());
+    EXPECT_TRUE(server.restartRequested());
+
+    zmq::context_t ctx(1);
+    zmq::socket_t sub(ctx, zmq::socket_type::sub);
+    sub.set(zmq::sockopt::subscribe, "");
+    sub.set(zmq::sockopt::rcvtimeo, 500);
+    sub.connect(server.pubEndpoint());
+
+    bool received = false;
+    for (int i = 0; i < 5 && !received; ++i) {
+        zmq::message_t msg;
+        if (sub.recv(msg, zmq::recv_flags::none)) {
+            auto payload =
+                nlohmann::json::parse(std::string(static_cast<char*>(msg.data()), msg.size()));
+            if (payload.contains("event") && payload["event"] == "status") {
+                received = true;
+                break;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    EXPECT_TRUE(received);
+}


### PR DESCRIPTION
## Summary
- Jetson PCM receiverにZeroMQベースのステータス/制御APIを追加し、リングバッファ・XRUN・最後のヘッダ情報を公開
- キャッシュサイズ(リングバッファ/ウォーターマーク)更新と安全な再起動トリガをトークン付きコマンドで提供し、無効化オプションも追加
- ZeroMQサーバのスナップショットと制御をテスト追加、READMEに利用手順を追記

## Test plan
- cmake -S jetson_pcm_receiver -B jetson_pcm_receiver/build -DCMAKE_BUILD_TYPE=Debug
- cmake --build jetson_pcm_receiver/build -j$(nproc)
- ctest --test-dir jetson_pcm_receiver/build --output-on-failure