### PR TITLE
#644 Loopback capture path to GPU

### DIFF
--- a/include/config_loader.h
+++ b/include/config_loader.h
@@ -50,6 +50,15 @@ struct AppConfig {
     // PipeWire input (disable for Docker/RTP-only mode)
     bool pipewireEnabled = true;  // Set to false for RTP-only mode (Docker)
 
+    struct LoopbackInputConfig {
+        bool enabled = false;
+        std::string device = "hw:Loopback,1,0";
+        uint32_t sampleRate = 44100;  // 0 = auto/detected (if available)
+        uint8_t channels = 2;
+        std::string format = "S16_LE";  // Supported: S16_LE, S24_3LE, S32_LE
+        uint32_t periodFrames = 1024;
+    } loopback;
+
     // EQ settings
     bool eqEnabled = false;
     std::string eqProfilePath = "";  // Path to EQ profile file (empty = disabled)


### PR DESCRIPTION
## Summary
- add loopback input config/validation and capture thread feeding AudioPipeline
- support S16/S24_3/S32 conversion and disable pipewire/rtp when loopback is enabled
- add readiness wait/fail-fast for loopback capture startup

## Test plan
- pre-commit (clang-format/clang-tidy/diff-based tests) via pre-push