### PR TITLE
#672 ALSAキャプチャのフォーマット自動フォールバック

### DIFF
--- a/raspberry_pi/include/AlsaCapture.h
+++ b/raspberry_pi/include/AlsaCapture.h
@@ -2,6 +2,7 @@
 
 #include <alsa/asoundlib.h>
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <string>
 #include <vector>
@@ -43,6 +44,8 @@ class AlsaCapture {
     static snd_pcm_format_t toAlsaFormat(SampleFormat format);
     static std::optional<SampleFormat> fromAlsaFormat(snd_pcm_format_t format);
     static std::size_t bytesPerFrame(const Config &config);
+    static std::optional<SampleFormat> selectSupportedFormat(
+        SampleFormat requested, const std::function<bool(SampleFormat)> &isSupported);
 
    private:
     Config config_{};

--- a/raspberry_pi/src/main.cpp
+++ b/raspberry_pi/src/main.cpp
@@ -69,6 +69,12 @@ bool openCaptureWithRetry(AlsaCapture &capture, AlsaCapture::Config &cfg) {
             if (auto currentRate = capture.currentSampleRate()) {
                 cfg.sampleRate = *currentRate;
             }
+            if (auto currentCh = capture.currentChannels()) {
+                cfg.channels = *currentCh;
+            }
+            if (auto currentFmt = capture.currentFormat()) {
+                cfg.format = *currentFmt;
+            }
             return true;
         }
         logWarn("[rpi_pcm_bridge] Failed to open/start ALSA device, retrying in " +


### PR DESCRIPTION
## Summary
- ALSAデバイスの対応フォーマットをopen前に走査し、非対応時はフォールバック
- 交渉結果を設定値に反映しフレームサイズ計算を実際のフォーマットに同期
- フォーマット選択ヘルパーのユニットテストを追加

## Test plan
- /usr/bin/ctest --test-dir /home/michihito/Working/gpu_os/worktrees/672-alsa-format-fallback/build/raspberry_pi --output-on-failure