### PR TITLE
#676 フォーマット変更検知で切断し再ネゴシエート

### DIFF
--- a/jetson_pcm_receiver/include/status_tracker.h
+++ b/jetson_pcm_receiver/include/status_tracker.h
@@ -25,6 +25,7 @@ struct StatusSnapshot {
     bool clientConnected{false};
     bool streaming{false};
     std::size_t xrunCount{0};
+    std::string disconnectReason;
     RingBufferSnapshot ring;
     HeaderSnapshot header;
 };
@@ -41,6 +42,8 @@ class StatusTracker {
     void updateRingBuffer(std::size_t bufferedFrames, std::size_t maxBufferedFrames,
                           std::size_t droppedFrames);
     void incrementXrun();
+    void setDisconnectReason(const std::string& reason);
+    void clearDisconnectReason();
 
     StatusSnapshot snapshot() const;
 

--- a/jetson_pcm_receiver/src/status_tracker.cpp
+++ b/jetson_pcm_receiver/src/status_tracker.cpp
@@ -54,3 +54,13 @@ StatusSnapshot StatusTracker::snapshot() const {
     std::lock_guard<std::mutex> lock(mutex_);
     return status_;
 }
+
+void StatusTracker::setDisconnectReason(const std::string& reason) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    status_.disconnectReason = reason;
+}
+
+void StatusTracker::clearDisconnectReason() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    status_.disconnectReason.clear();
+}

--- a/jetson_pcm_receiver/src/zmq_status_server.cpp
+++ b/jetson_pcm_receiver/src/zmq_status_server.cpp
@@ -223,6 +223,11 @@ nlohmann::json ZmqStatusServer::buildStatusJson() {
     data["buffered_frames"] = snap.ring.bufferedFrames;
     data["max_buffered_frames"] = snap.ring.maxBufferedFrames;
     data["dropped_frames"] = snap.ring.droppedFrames;
+    if (snap.disconnectReason.empty()) {
+        data["disconnect_reason"] = nullptr;
+    } else {
+        data["disconnect_reason"] = snap.disconnectReason;
+    }
     {
         std::lock_guard<std::mutex> lock(configMutex_);
         data["connection_mode"] = toString(config_.connectionMode);

--- a/jetson_pcm_receiver/tests/test_zmq_status_server.cpp
+++ b/jetson_pcm_receiver/tests/test_zmq_status_server.cpp
@@ -76,6 +76,7 @@ TEST_F(ZmqStatusServerTest, ReturnsStatusSnapshot) {
     status.updateRingConfig(64, 48);
     status.updateRingBuffer(32, 48, 1);
     status.incrementXrun();
+    status.setDisconnectReason("format_changed");
 
     nlohmann::json cmd;
     cmd["cmd"] = "STATUS";
@@ -91,6 +92,7 @@ TEST_F(ZmqStatusServerTest, ReturnsStatusSnapshot) {
     EXPECT_EQ(data["dropped_frames"], 1);
     EXPECT_EQ(data["xrun_count"], 1);
     EXPECT_EQ(data["last_header"]["sample_rate"], 48000);
+    EXPECT_EQ(data["disconnect_reason"], "format_changed");
 }
 
 TEST_F(ZmqStatusServerTest, UpdatesRingConfigFromSetCache) {


### PR DESCRIPTION
## Summary
- PCMストリーム中に新しいPCMAヘッダを検出し、フォーマット差分があれば切断して再ヘッダ待ちへ戻すようにした
- 切断理由をStatusTrackerに保持し、ZMQ STATUSレスポンスで`disconnect_reason`として通知するよう拡張
- ミッドストリームのフォーマット変更検知テストとZMQステータスの検証テストを追加

## Test plan
- /usr/bin/ctest --output-on-failure (build-jetson)