### PR TITLE
#677 XRUN storm検知で切断・自動復帰

### DIFF
--- a/jetson_pcm_receiver/CMakeLists.txt
+++ b/jetson_pcm_receiver/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(jetson_pcm_receiver_lib
     src/logging.cpp
     src/tcp_server.cpp
     src/alsa_playback.cpp
+    src/xrun_detector.cpp
     src/pcm_stream_handler.cpp
     src/pcm_header.cpp
     src/status_tracker.cpp
@@ -130,6 +131,7 @@ if(BUILD_TESTING)
         tests/test_alsa_playback.cpp
         tests/test_zmq_status_server.cpp
         tests/test_output_device.cpp
+        tests/test_xrun_detector.cpp
     )
 
     target_link_libraries(jetson_pcm_receiver_tests

--- a/jetson_pcm_receiver/include/alsa_playback.h
+++ b/jetson_pcm_receiver/include/alsa_playback.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "xrun_detector.h"
+
 #include <alsa/asoundlib.h>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -17,6 +20,7 @@ class AlsaPlayback {
     virtual bool open(uint32_t sampleRate, uint16_t channels, uint16_t format);
     virtual bool write(const void *data, std::size_t frames);
     virtual void close();
+    virtual bool wasXrunStorm() const;
     void setStatusTracker(StatusTracker *tracker) {
         statusTracker_ = tracker;
     }
@@ -34,6 +38,8 @@ class AlsaPlayback {
     snd_pcm_uframes_t periodSize_{0};
     snd_pcm_uframes_t bufferSize_{0};
     StatusTracker *statusTracker_{nullptr};
+    XrunDetector xrunDetector_{std::chrono::milliseconds(1000)};
+    bool xrunStormDetected_{false};
 
     bool configureHardware(uint32_t sampleRate, uint16_t channels, snd_pcm_format_t format);
     bool validateCapabilities(uint32_t sampleRate, uint16_t channels, snd_pcm_format_t format);

--- a/jetson_pcm_receiver/include/xrun_detector.h
+++ b/jetson_pcm_receiver/include/xrun_detector.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <chrono>
+#include <optional>
+
+// XRUNの連続時間を監視し、一定時間継続した場合にストームと判定する単純な監視クラス。
+class XrunDetector {
+   public:
+    using Clock = std::chrono::steady_clock;
+    using TimePoint = Clock::time_point;
+
+    explicit XrunDetector(std::chrono::milliseconds window);
+
+    // XRUN発生を記録し、ストームが検知されたらtrueを返す。
+    bool onXrun(TimePoint now);
+
+    // 正常書き込みができたらストーム状態と連続時間をリセットする。
+    void onSuccess(TimePoint now);
+
+    // 手動リセット（open直後など）。
+    void reset();
+
+    bool storm() const {
+        return storm_;
+    }
+
+    std::chrono::milliseconds window() const {
+        return window_;
+    }
+
+   private:
+    std::chrono::milliseconds window_;
+    std::optional<TimePoint> streakStart_{};
+    bool storm_{false};
+};

--- a/jetson_pcm_receiver/src/xrun_detector.cpp
+++ b/jetson_pcm_receiver/src/xrun_detector.cpp
@@ -1,0 +1,27 @@
+#include "xrun_detector.h"
+
+XrunDetector::XrunDetector(std::chrono::milliseconds window) : window_(window) {}
+
+bool XrunDetector::onXrun(TimePoint now) {
+    if (!streakStart_) {
+        streakStart_ = now;
+    }
+    if (storm_) {
+        return true;
+    }
+    const auto elapsed = now - *streakStart_;
+    if (elapsed >= window_) {
+        storm_ = true;
+    }
+    return storm_;
+}
+
+void XrunDetector::onSuccess(TimePoint /*now*/) {
+    streakStart_.reset();
+    storm_ = false;
+}
+
+void XrunDetector::reset() {
+    streakStart_.reset();
+    storm_ = false;
+}

--- a/jetson_pcm_receiver/tests/test_xrun_detector.cpp
+++ b/jetson_pcm_receiver/tests/test_xrun_detector.cpp
@@ -1,0 +1,41 @@
+#include "xrun_detector.h"
+
+#include <chrono>
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+TEST(XrunDetector, DetectsStormAfterWindow) {
+    XrunDetector detector(1000ms);
+    const auto t0 = XrunDetector::Clock::now();
+
+    EXPECT_FALSE(detector.onXrun(t0));
+    EXPECT_FALSE(detector.onXrun(t0 + 500ms));
+    EXPECT_TRUE(detector.onXrun(t0 + 1001ms));
+}
+
+TEST(XrunDetector, SuccessResetsStreak) {
+    XrunDetector detector(1000ms);
+    const auto t0 = XrunDetector::Clock::now();
+
+    EXPECT_FALSE(detector.onXrun(t0));
+    EXPECT_FALSE(detector.onXrun(t0 + 900ms));
+
+    detector.onSuccess(t0 + 950ms);
+
+    EXPECT_FALSE(detector.onXrun(t0 + 1100ms));
+    EXPECT_TRUE(detector.onXrun(t0 + 2101ms));
+}
+
+TEST(XrunDetector, ResetClearsStorm) {
+    XrunDetector detector(1000ms);
+    const auto t0 = XrunDetector::Clock::now();
+
+    detector.onXrun(t0);
+    detector.onXrun(t0 + 1200ms);
+    EXPECT_TRUE(detector.storm());
+
+    detector.reset();
+    EXPECT_FALSE(detector.storm());
+    EXPECT_FALSE(detector.onXrun(t0 + 1500ms));
+}


### PR DESCRIPTION
## Summary
- 1秒超の連続XRUNを検知するウォッチドッグを追加し、ストリームを強制切断
- ALSA書き込み失敗時にxrun_stormをSTATUS/ログへ反映し再ヘッダ待ちへ復帰
- XrunDetectorとPCMハンドラのxrun_storm経路をユニットテストで検証

## Test plan
- /usr/bin/ctest --test-dir /home/michihito/Working/gpu_os/worktrees/677-xrun-storm/jetson_pcm_receiver/build --output-on-failure