### PR TITLE
#678 許容フォーマットを共通定義して橋渡し

### DIFF
--- a/include/audio/pcm_format_set.h
+++ b/include/audio/pcm_format_set.h
@@ -1,0 +1,90 @@
+/*
+ * Shared PCM format constraints between pcm receiver bridge and main daemon.
+ * Keeps the single source of truth for accepted sample rates / channels / formats.
+ */
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace PcmFormatSet {
+
+namespace detail {
+
+template <typename T, std::size_t N>
+constexpr bool contains(const std::array<T, N>& arr, T value) {
+    for (auto v : arr) {
+        if (v == value) {
+            return true;
+        }
+    }
+    return false;
+}
+
+template <std::size_t N1, std::size_t N2>
+constexpr std::array<uint32_t, N1 + N2> concat(const std::array<uint32_t, N1>& a,
+                                               const std::array<uint32_t, N2>& b) {
+    std::array<uint32_t, N1 + N2> result{};
+    for (std::size_t i = 0; i < N1; ++i) {
+        result[i] = a[i];
+    }
+    for (std::size_t i = 0; i < N2; ++i) {
+        result[N1 + i] = b[i];
+    }
+    return result;
+}
+
+}  // namespace detail
+
+// Format codes
+// 1 = S16_LE, 2 = S24_3LE, 4 = S32_LE
+constexpr std::array<uint16_t, 3> kAllowedFormats = {1, 2, 4};
+constexpr uint16_t kRequiredChannels = 2;
+
+// Allowed input sample rates (base × {1,2,4,8,16})
+constexpr std::array<uint32_t, 5> kRates44k = {44100, 88200, 176400, 352800, 705600};
+constexpr std::array<uint32_t, 5> kRates48k = {48000, 96000, 192000, 384000, 768000};
+constexpr auto kAllowedSampleRates = detail::concat(kRates44k, kRates48k);
+
+constexpr bool isAllowedFormat(uint16_t format) {
+    return detail::contains(kAllowedFormats, format);
+}
+
+constexpr bool isAllowedChannels(uint16_t channels) {
+    return channels == kRequiredChannels;
+}
+
+constexpr bool isAllowedSampleRate(uint32_t rate) {
+    return detail::contains(kAllowedSampleRates, rate);
+}
+
+constexpr bool is44kFamilyRate(uint32_t rate) {
+    return detail::contains(kRates44k, rate);
+}
+
+constexpr bool is48kFamilyRate(uint32_t rate) {
+    return detail::contains(kRates48k, rate);
+}
+
+inline std::vector<uint32_t> allowedSampleRatesVector() {
+    return std::vector<uint32_t>(kAllowedSampleRates.begin(), kAllowedSampleRates.end());
+}
+
+inline std::vector<uint16_t> allowedFormatsVector() {
+    return std::vector<uint16_t>(kAllowedFormats.begin(), kAllowedFormats.end());
+}
+
+inline std::string allowedSampleRatesString() {
+    std::string result;
+    for (std::size_t i = 0; i < kAllowedSampleRates.size(); ++i) {
+        result += std::to_string(kAllowedSampleRates[i]);
+        if (i + 1 < kAllowedSampleRates.size()) {
+            result += ", ";
+        }
+    }
+    return result;
+}
+
+}  // namespace PcmFormatSet

--- a/jetson_pcm_receiver/src/pcm_header.cpp
+++ b/jetson_pcm_receiver/src/pcm_header.cpp
@@ -1,12 +1,10 @@
 #include "pcm_header.h"
 
+#include "audio/pcm_format_set.h"
+
 #include <cstring>
 
 namespace {
-
-constexpr uint32_t BASE_RATES[] = {44100, 48000};
-constexpr uint32_t MULTIPLIERS[] = {1, 2, 4, 8, 16};
-constexpr uint16_t REQUIRED_CHANNELS = 2;
 
 bool hasValidMagic(const PcmHeader &h) {
     static constexpr char MAGIC[4] = {'P', 'C', 'M', 'A'};
@@ -14,25 +12,11 @@ bool hasValidMagic(const PcmHeader &h) {
 }
 
 bool isSupportedFormat(uint16_t format) {
-    switch (format) {
-    case 1:
-    case 2:
-    case 4:
-        return true;
-    default:
-        return false;
-    }
+    return PcmFormatSet::isAllowedFormat(format);
 }
 
 bool isSupportedRate(uint32_t rate) {
-    for (auto base : BASE_RATES) {
-        for (auto mul : MULTIPLIERS) {
-            if (base * mul == rate) {
-                return true;
-            }
-        }
-    }
-    return false;
+    return PcmFormatSet::isAllowedSampleRate(rate);
 }
 
 }  // namespace
@@ -47,7 +31,7 @@ HeaderValidationResult validateHeader(const PcmHeader &header) {
     if (!isSupportedRate(header.sample_rate)) {
         return {false, "sample_rate unsupported"};
     }
-    if (header.channels != REQUIRED_CHANNELS) {
+    if (!PcmFormatSet::isAllowedChannels(header.channels)) {
         return {false, "channels unsupported"};
     }
     if (!isSupportedFormat(header.format)) {

--- a/jetson_pcm_receiver/src/pcm_stream_handler.cpp
+++ b/jetson_pcm_receiver/src/pcm_stream_handler.cpp
@@ -112,6 +112,9 @@ bool PcmStreamHandler::handleClient(int fd) {
     auto validation = validateHeader(header);
     if (!validation.ok) {
         logWarn(std::string("[PcmStreamHandler] header invalid: ") + validation.reason);
+        if (status_) {
+            status_->setDisconnectReason(validation.reason);
+        }
         return false;
     }
 

--- a/jetson_pcm_receiver/tests/test_pcm_header.cpp
+++ b/jetson_pcm_receiver/tests/test_pcm_header.cpp
@@ -1,3 +1,4 @@
+#include "audio/pcm_format_set.h"
 #include "pcm_header.h"
 
 #include <cstring>
@@ -23,6 +24,15 @@ TEST(PcmHeaderValidation, AcceptsValidHeader) {
 
     EXPECT_TRUE(result.ok);
     EXPECT_TRUE(result.reason.empty());
+}
+
+TEST(PcmHeaderValidation, AcceptsAllAllowedSampleRates) {
+    for (auto rate : PcmFormatSet::allowedSampleRatesVector()) {
+        auto header = makeValidHeader();
+        header.sample_rate = rate;
+        auto result = validateHeader(header);
+        EXPECT_TRUE(result.ok) << "rate=" << rate;
+    }
 }
 
 TEST(PcmHeaderValidation, RejectsInvalidMagic) {

--- a/tests/cpp/test_rate_family.cpp
+++ b/tests/cpp/test_rate_family.cpp
@@ -3,9 +3,12 @@
  * @brief Unit tests for Rate Family detection logic (CPU-only, no GPU required)
  */
 
+#include "audio/pcm_format_set.h"
 #include "convolution_engine.h"
 
+#include <algorithm>
 #include <gtest/gtest.h>
+#include <vector>
 
 using namespace ConvolutionEngine;
 
@@ -178,4 +181,21 @@ TEST_F(RateFamilyTest, Issue238_MultiRateConfigs_BypassEntries) {
 // Test total config count is now 10
 TEST_F(RateFamilyTest, Issue238_MultiRateConfigCount) {
     EXPECT_EQ(MULTI_RATE_CONFIG_COUNT, 10);
+}
+
+TEST_F(RateFamilyTest, SharedFormatSetMatchesMultiRateConfigs) {
+    auto allowed = PcmFormatSet::allowedSampleRatesVector();
+    std::vector<int> fromConfigs;
+    fromConfigs.reserve(MULTI_RATE_CONFIG_COUNT);
+    for (const auto& cfg : MULTI_RATE_CONFIGS) {
+        fromConfigs.push_back(cfg.inputRate);
+    }
+
+    std::sort(allowed.begin(), allowed.end());
+    std::sort(fromConfigs.begin(), fromConfigs.end());
+
+    ASSERT_EQ(allowed.size(), fromConfigs.size());
+    for (std::size_t i = 0; i < allowed.size(); ++i) {
+        EXPECT_EQ(static_cast<int>(allowed[i]), fromConfigs[i]);
+    }
 }


### PR DESCRIPTION
## Summary
- PCM許容フォーマットを一元化する`PcmFormatSet`を追加し、受信ブリッジと本命デーモン双方で同じセットを参照するように更新
- ヘッダ検証/ALSAオープン/自動ネゴシエーションで共有セットを使い、非対応時はZMQステータスのdisconnect_reasonにも理由を残す
- テストを拡充（許容全レート受理・拒否時ステータス・共有セットとマルチレート定義の整合性）

## Test plan
- /usr/bin/cmake -S jetson_pcm_receiver -B build/jetson_pcm_receiver -DCMAKE_BUILD_TYPE=Debug
- /usr/bin/cmake --build build/jetson_pcm_receiver -j4 && build/jetson_pcm_receiver/jetson_pcm_receiver_tests
- /usr/bin/cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug && ./build/gpu_tests