### PR TITLE
#679 jetson-pcm-receiver 再起動検知の強化

### DIFF
--- a/jetson_pcm_receiver/include/status_tracker.h
+++ b/jetson_pcm_receiver/include/status_tracker.h
@@ -38,6 +38,7 @@ class StatusTracker {
     void setClientConnected(bool connected);
     void setStreaming(bool streaming);
     void setHeader(const PcmHeader& header);
+    void clearHeader();
     void updateRingConfig(std::size_t ringFrames, std::size_t watermarkFrames);
     void updateRingBuffer(std::size_t bufferedFrames, std::size_t maxBufferedFrames,
                           std::size_t droppedFrames);

--- a/jetson_pcm_receiver/src/status_tracker.cpp
+++ b/jetson_pcm_receiver/src/status_tracker.cpp
@@ -31,6 +31,11 @@ void StatusTracker::setHeader(const PcmHeader& header) {
     status_.header.header = header;
 }
 
+void StatusTracker::clearHeader() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    status_.header.present = false;
+}
+
 void StatusTracker::updateRingConfig(std::size_t ringFrames, std::size_t watermarkFrames) {
     std::lock_guard<std::mutex> lock(mutex_);
     status_.ring.configuredFrames = ringFrames;


### PR DESCRIPTION
## Summary
- PCMクライアントの切断/タイムアウト/受信エラーを明示的に検知し、再ネゴシエート用に切断理由とヘッダ状態をリセット
- StatusTrackerにヘッダクリアAPIを追加し、ZMQステータスにも再接続を促す理由を反映
- PCM再起動シナリオとタイムアウト検知の単体テストを拡充

関連EPIC: #50

## Test plan
- /usr/bin/ctest --test-dir build/jetson_pcm_receiver --output-on-failure