### PR TITLE
#680 PCM受信: frameバイト不一致をフェイルファスト

### DIFF
--- a/jetson_pcm_receiver/tests/test_pcm_stream_handler.cpp
+++ b/jetson_pcm_receiver/tests/test_pcm_stream_handler.cpp
@@ -6,6 +6,7 @@
 
 #include <arpa/inet.h>
 #include <atomic>
+#include <chrono>
 #include <cstring>
 #include <gtest/gtest.h>
 #include <netinet/in.h>
@@ -328,6 +329,46 @@ TEST(PcmStreamHandler, DisconnectsOnFrameBytesMismatch) {
     ::close(fds[0]);
 
     EXPECT_FALSE(handler.handleClientForTest(fds[1]));
+    auto snap = status.snapshot();
+    EXPECT_EQ(snap.disconnectReason, "frame_bytes_mismatch");
+    EXPECT_TRUE(playback.openCalled);
+    EXPECT_FALSE(playback.writeCalled);
+    EXPECT_TRUE(playback.closeCalled);
+    EXPECT_FALSE(snap.header.present);
+
+    ::close(fds[1]);
+}
+
+TEST(PcmStreamHandler, DisconnectsOnRepeatedMisalignedSmallChunks) {
+    FakeAlsaPlayback playback;
+    TcpServer server(0);
+    std::atomic_bool stop{false};
+    PcmStreamConfig cfg{};
+    StatusTracker status;
+    PcmStreamHandler handler(playback, server, stop, cfg, nullptr, &status);
+
+    int fds[2]{-1, -1};
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+    auto header = makeValidHeader();
+    header.format = 2;  // expect 3 bytes/sample (6 bytes per frame for stereo)
+    std::thread handlerThread([&]() { EXPECT_FALSE(handler.handleClientForTest(fds[1])); });
+
+    ASSERT_EQ(::send(fds[0], &header, sizeof(header), 0), sizeof(header));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+    std::vector<std::uint8_t> pcmChunk(512, 0);  // not divisible by 6 bytes/frame
+    ASSERT_EQ(::send(fds[0], pcmChunk.data(), pcmChunk.size(), 0),
+              static_cast<ssize_t>(pcmChunk.size()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    ASSERT_EQ(::send(fds[0], pcmChunk.data(), pcmChunk.size(), 0),
+              static_cast<ssize_t>(pcmChunk.size()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    ASSERT_EQ(::send(fds[0], pcmChunk.data(), pcmChunk.size(), 0),
+              static_cast<ssize_t>(pcmChunk.size()));
+    ::close(fds[0]);
+
+    handlerThread.join();
     auto snap = status.snapshot();
     EXPECT_EQ(snap.disconnectReason, "frame_bytes_mismatch");
     EXPECT_TRUE(playback.openCalled);


### PR DESCRIPTION
## Summary
- 受信ペイロードのbyte数がヘッダのframeBytesと揃わない場合、一定閾値で即切断しログとZMQステータスに理由(frame_bytes_mismatch)を設定
- ヘッダ再待受に戻る際にheaderをクリアしつつdisconnect reasonを保持することで運用検知しやすくした
- ヘッダと実データの不一致パスをユニットテストに追加し、S24ヘッダ/S16データで切断されることを検証

## Related
- #680
- Epic: #314

## Test plan
- /usr/bin/cmake -S jetson_pcm_receiver -B build/jetson_pcm_receiver -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug
- /usr/bin/cmake --build build/jetson_pcm_receiver -j$(nproc)
- /usr/bin/ctest --test-dir build/jetson_pcm_receiver --output-on-failure
- /usr/bin/cmake -S jetson_pcm_receiver -B jetson_pcm_receiver/build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug
- /usr/bin/cmake --build jetson_pcm_receiver/build -j$(nproc)