### PR TITLE
#697 config rate handling: disable rtp defaults

### DIFF
--- a/config.json
+++ b/config.json
@@ -53,31 +53,9 @@
     "coloredOutput": true
   },
   "rtp": {
-    "enabled": true,
-    "autoStart": true,
-    "sessionId": "pc_stream",
-    "bindAddress": "0.0.0.0",
-    "port": 46000,
-    "payloadType": 127,
-    "sampleRate": 44100,
-    "channels": 2,
-    "bitsPerSample": 16,
-    "bigEndian": true,
-    "signedSamples": true,
-    "targetLatencyMs": 5,
-    "watchdogTimeoutMs": 500,
-    "enableRtcp": true,
-    "discovery": {
-      "scanDurationMs": 250,
-      "cooldownMs": 1500,
-      "maxStreams": 12,
-      "enableMulticast": true,
-      "enableUnicast": true,
-      "ports": [
-        5004,
-        6000
-      ]
-    }
+    "enabled": false,
+    "autoStart": false,
+    "_comment": "RTP入力は削除予定。入力レート/フォーマットはTCP経由でのヘッダ検出に委ねます。"
   },
   "statsFilePath": "/tmp/gpu_upsampler_stats.json"
 }

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,5 +21,11 @@ docker compose -f jetson_pcm_receiver/docker-compose.jetson.yml down
 - `--device /dev/snd` を必ず付与（Loopback/実デバイスをコンテナへ渡す）
 - 環境変数 `JPR_*` で CLI 相当の設定を上書き可能（ポート、デバイス、接続モード、ZeroMQ など）
 
+### 入力レート/フォーマットの扱い（TCPのみ）
+- Raspberry Pi 送信側が `PCMA` ヘッダで `sample_rate` / `channels` / `format` を通知し、Jetson 側 `jetson_pcm_receiver` がヘッダを検証して ALSA を開き直します。JSON で固定値を持たせるとミスマッチ時に無音になるため **config.docker.json では入力レート/フォーマットを設定しません**。
+- 受理するヘッダ: 44.1k / 48k 系の {×1,×2,×4,×8,×16}、チャンネル=2、フォーマット=`S16_LE(1)` / `S24_3LE(2)` / `S32_LE(4)`（`jetson_pcm_receiver` / `PcmFormatSet` に準拠）。
+- GPU パイプライン側の自動ネゴシエーションは受信した実レートを使って出力レート・アップサンプル比を決めます（固定値依存なし）。
+- `docker/jetson/config.docker.json` の `rtp` は削除予定のため `enabled: false` にしています。今後は TCP 経由のみを想定してください（PipeWire/RTP はデプリケート予定）。
+
 ## 既存 Magic Box Jetson コンテナ
 `docker/jetson/` は従来の Magic Box (Web/UI + Audio Daemon) 用です。今回の Issue では新規 `jetson_pcm_receiver/` を優先してください。

--- a/docker/jetson/config.docker.json
+++ b/docker/jetson/config.docker.json
@@ -53,28 +53,9 @@
     "coloredOutput": true
   },
   "rtp": {
-    "enabled": true,
-    "autoStart": true,
-    "sessionId": "pc_stream",
-    "bindAddress": "0.0.0.0",
-    "port": 46000,
-    "payloadType": 127,
-    "sampleRate": 44100,
-    "channels": 2,
-    "bitsPerSample": 16,
-    "bigEndian": true,
-    "signedSamples": true,
-    "targetLatencyMs": 5,
-    "watchdogTimeoutMs": 500,
-    "enableRtcp": true,
-    "discovery": {
-      "scanDurationMs": 250,
-      "cooldownMs": 1500,
-      "maxStreams": 12,
-      "enableMulticast": true,
-      "enableUnicast": true,
-      "ports": [5004, 6000]
-    }
+    "enabled": false,
+    "autoStart": false,
+    "_comment": "RTP入力は削除予定。TCP (jetson_pcm_receiver) 経由でヘッダからレート/フォーマットを自動検出するため、ここで固定値を設定しません。"
   },
   "statsFilePath": "/tmp/gpu_upsampler_stats.json"
 }

--- a/jetson_pcm_receiver/README.md
+++ b/jetson_pcm_receiver/README.md
@@ -50,6 +50,11 @@ cmake --build jetson_pcm_receiver/build -j$(nproc)
   - `--priority-client <IP>`（複数指定可 / カンマ区切り可）
     - `priority` モード時に奪取を許可する送信元 IP（数値表記一致のみ）
 
+### 運用指針 (Magic Box 連携)
+- 入力レート/フォーマットは Pi 送信側の `PCMA` ヘッダで伝達し、受信時に ALSA を開き直します。設定ファイルには固定値を持たせません。
+- 許容レート/フォーマットは `PcmFormatSet` に準拠（44.1k/48k 系 × {1,2,4,8,16}、2ch、`S16_LE` / `S24_3LE` / `S32_LE`）。外れたヘッダは拒否されます。
+- GPU デーモンの自動ネゴシエーション (`auto_negotiation`) もこの受信レートを入力として出力レート/アップサンプル比を決定します。Pi 側は上記許容範囲で送出してください。
+
 ## Docker (Jetson)
 `docker/jetson_pcm_receiver/` に Jetson 向けの Dockerfile / Compose を用意しています。ビルドと起動は以下で行えます。
 

--- a/tests/cpp/test_config_loader.cpp
+++ b/tests/cpp/test_config_loader.cpp
@@ -614,3 +614,43 @@ TEST_F(ConfigLoaderTest, Issue219_LoadConfigWithMultiRateAndFilterPaths) {
     EXPECT_EQ(config.filterPath48kLinear, "a/path48kLinear.bin");
     EXPECT_EQ(config.coefficientDir, "multi/coefficients");
 }
+
+// ============================================================
+// RTP settings (Issue #697)
+// ============================================================
+
+TEST_F(ConfigLoaderTest, RtpSectionOmittedKeepsDefaultsDisabled) {
+    writeConfig(R"({
+        "alsaDevice": "hw:Test"
+    })");
+
+    AppConfig config;
+    bool result = loadAppConfig(testConfigPath, config, false);
+
+    EXPECT_TRUE(result);
+    EXPECT_FALSE(config.rtp.enabled);
+    EXPECT_FALSE(config.rtp.autoStart);
+}
+
+TEST_F(ConfigLoaderTest, RtpWithoutRateFieldsFallsBackToDefaults) {
+    writeConfig(R"({
+        "rtp": {
+            "enabled": true,
+            "autoStart": true,
+            "port": 5004
+        }
+    })");
+
+    AppConfig config;
+    bool result = loadAppConfig(testConfigPath, config, false);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(config.rtp.enabled);
+    EXPECT_TRUE(config.rtp.autoStart);
+    EXPECT_EQ(config.rtp.port, 5004);
+    EXPECT_EQ(config.rtp.sampleRate, 48000);
+    EXPECT_EQ(config.rtp.channels, 2);
+    EXPECT_EQ(config.rtp.bitsPerSample, 24);
+    EXPECT_TRUE(config.rtp.bigEndian);
+    EXPECT_TRUE(config.rtp.signedSamples);
+}


### PR DESCRIPTION
## Summary
- docker用configのRTPセクションを無効化し、TCPヘッダによる動的レート/フォーマット検出前提に統一（固定値によるミスマッチを防止）
- docker/READMEとjetson_pcm_receiver/READMEにTCP受信の運用指針と許容レート/フォーマット、GPUパイプラインの自動ネゴシエーションとの整合を明記
- config_loaderのRTP設定まわりにデフォルト/フォールバック挙動のテストを追加

## Test plan
- /usr/bin/cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- /usr/bin/cmake --build build -j8
- /usr/bin/ctest --test-dir build -R "ConfigLoaderTest.RtpSectionOmittedKeepsDefaultsDisabled|ConfigLoaderTest.RtpWithoutRateFieldsFallsBackToDefaults" -VV