### PR TITLE
#627 PipeWire/RTP cleanup (WIP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 find_package(CUDAToolkit REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(SNDFILE REQUIRED sndfile)
-pkg_check_modules(PIPEWIRE REQUIRED libpipewire-0.3)
 pkg_check_modules(ALSA REQUIRED alsa)
 
 # ZeroMQ for IPC communication
@@ -95,7 +94,6 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/data/coefficients
     ${SNDFILE_INCLUDE_DIRS}
-    ${PIPEWIRE_INCLUDE_DIRS}
     ${ALSA_INCLUDE_DIRS}
 )
 
@@ -158,27 +156,6 @@ target_compile_options(gpu_upsampler PRIVATE
     $<$<COMPILE_LANGUAGE:CXX>:-Wall -Wextra -O3>
 )
 
-# PipeWire Daemon executable
-add_executable(gpu_upsampler_daemon
-    src/pipewire_daemon.cpp
-    src/config_loader.cpp
-    src/partition_runtime_utils.cpp
-)
-
-# Link against core library, PipeWire, SoftMute, and Logging
-target_link_libraries(gpu_upsampler_daemon
-    gpu_upsampler_core
-    soft_mute
-    logging
-    ${PIPEWIRE_LIBRARIES}
-    nlohmann_json::nlohmann_json
-)
-
-# Compiler flags for daemon
-target_compile_options(gpu_upsampler_daemon PRIVATE
-    $<$<COMPILE_LANGUAGE:CXX>:-Wall -Wextra -O3>
-)
-
 # ALSA Direct Output Daemon executable
 add_executable(gpu_upsampler_alsa
     src/alsa_daemon.cpp
@@ -190,9 +167,6 @@ add_executable(gpu_upsampler_alsa
     src/daemon/control/handlers/handler_registry.cpp
     src/daemon/pcm/dac_manager.cpp
     src/daemon/control/control_plane.cpp
-    src/daemon/rtp/rtp_engine_coordinator.cpp
-    src/daemon/input/pipewire_input.cpp
-    src/daemon/input/rtp_input_adapter.cpp
     src/daemon/output/alsa_output.cpp
     src/daemon/control/zmq_server.cpp
     src/daemon/metrics/runtime_stats.cpp
@@ -210,10 +184,8 @@ target_link_libraries(gpu_upsampler_alsa
     graceful_shutdown
     fallback_manager
     zeromq_interface
-    rtp_session
     dac_capability
     logging
-    ${PIPEWIRE_LIBRARIES}
     ${ALSA_LIBRARIES}
     ${ZMQ_LIBRARIES}
 )
@@ -488,14 +460,12 @@ add_executable(cpu_tests
     tests/cpp/test_eq_parser.cpp
     tests/cpp/test_eq_to_fir.cpp
     tests/cpp/test_config_loader.cpp
-    tests/cpp/test_rtp_discovery.cpp
     tests/cpp/test_partition_plan.cpp
     tests/cpp/test_phase_alignment.cpp
     tests/cpp/test_playback_buffer_threshold.cpp
     tests/cpp/test_runtime_stats.cpp
     tests/cpp/test_audio_pipeline.cpp
     tests/cpp/daemon/test_daemon_skeleton.cpp
-    src/daemon/rtp/rtp_engine_coordinator.cpp
     src/daemon/audio_pipeline/audio_pipeline.cpp
     src/daemon/audio_pipeline/filter_manager.cpp
     src/daemon/audio_pipeline/rate_switcher.cpp
@@ -503,15 +473,12 @@ add_executable(cpu_tests
     src/daemon/control/handlers/handler_registry.cpp
     src/daemon/metrics/runtime_stats.cpp
     src/daemon/pcm/dac_manager.cpp
-    src/daemon/input/pipewire_input.cpp
-    src/daemon/input/rtp_input_adapter.cpp
     src/daemon/output/alsa_output.cpp
 )
 target_link_libraries(cpu_tests
     GTest::gtest_main
     gpu_upsampler_core
     eq_support
-    rtp_session
     logging
     filter_headroom
     fallback_manager

--- a/include/config_loader.h
+++ b/include/config_loader.h
@@ -47,9 +47,6 @@ struct AppConfig {
     bool multiRateEnabled = false;  // Enable multi-rate mode with all 10 filter FFTs preloaded
     std::string coefficientDir = "data/coefficients";  // Directory containing filter files
 
-    // PipeWire input (disable for Docker/RTP-only mode)
-    bool pipewireEnabled = true;  // Set to false for RTP-only mode (Docker)
-
     struct LoopbackInputConfig {
         bool enabled = false;
         std::string device = "hw:Loopback,1,0";
@@ -89,44 +86,6 @@ struct AppConfig {
         bool xrunTriggersFallback = true;    // Whether XRUN triggers immediate fallback
         int monitorIntervalMs = 100;         // GPU monitoring interval (milliseconds)
     } fallback;
-
-    struct RtpInputConfig {
-        bool enabled = false;
-        bool autoStart = false;
-        std::string sessionId = "default";
-        std::string bindAddress = "0.0.0.0";
-        uint16_t port = 6000;
-        std::string sourceHost;
-        bool multicast = false;
-        std::string multicastGroup;
-        std::string interfaceName;
-        uint8_t ttl = 32;
-        int dscp = -1;
-        uint32_t sampleRate = 48000;
-        uint8_t channels = 2;
-        uint8_t bitsPerSample = 24;
-        bool bigEndian = true;
-        bool signedSamples = true;
-        uint8_t payloadType = 97;
-        size_t socketBufferBytes = 1 << 20;
-        size_t mtuBytes = 1500;
-        uint32_t targetLatencyMs = 5;
-        uint32_t watchdogTimeoutMs = 500;
-        uint32_t telemetryIntervalMs = 1000;
-        bool enableRtcp = true;
-        uint16_t rtcpPort = 0;
-        bool enablePtp = false;
-        std::string ptpInterface;
-        int ptpDomain = 0;
-        std::string sdp;
-        // Discovery scanner defaults (Issue #372)
-        std::vector<uint16_t> discoveryPorts = {5004, 6000};
-        uint32_t discoveryScanDurationMs = 250;
-        uint32_t discoveryCooldownMs = 1500;
-        size_t discoveryMaxStreams = 12;
-        bool discoveryEnableMulticast = true;
-        bool discoveryEnableUnicast = true;
-    } rtp;
 
     OutputConfig output;
 };

--- a/include/daemon/api/dependencies.h
+++ b/include/daemon/api/dependencies.h
@@ -21,15 +21,6 @@ namespace daemon_output {
 class AlsaOutput;
 }
 
-namespace daemon_input {
-class PipeWireInput;
-class RtpInputAdapter;
-}  // namespace daemon_input
-
-namespace rtp_engine {
-class RtpEngineCoordinator;
-}
-
 namespace dac {
 class DacManager;
 }
@@ -46,7 +37,6 @@ struct DaemonDependencies {
     SoftMute::Controller** softMute = nullptr;
     ConvolutionEngine::GPUUpsampler** upsampler = nullptr;
     audio_pipeline::AudioPipeline** audioPipeline = nullptr;
-    rtp_engine::RtpEngineCoordinator** rtpCoordinator = nullptr;
     dac::DacManager** dacManager = nullptr;
     std::mutex* streamingMutex = nullptr;
     std::function<void(const std::string&)> refreshHeadroom;

--- a/include/daemon/control/control_plane.h
+++ b/include/daemon/control/control_plane.h
@@ -5,7 +5,6 @@
 #include "daemon/control/zmq_server.h"
 #include "daemon/metrics/runtime_stats.h"
 #include "daemon/pcm/dac_manager.h"
-#include "daemon/rtp/rtp_engine_coordinator.h"
 #include "soft_mute.h"
 
 #include <atomic>
@@ -55,7 +54,6 @@ struct ControlPlaneDependencies {
     std::function<void(AppConfig&, const std::string&)> setPreferredOutputDevice;
 
     dac::DacManager* dacManager = nullptr;
-    rtp_engine::RtpEngineCoordinator* rtpCoordinator = nullptr;
     ConvolutionEngine::GPUUpsampler** upsampler = nullptr;
     CrossfeedControls crossfeed;
 

--- a/include/daemon/shutdown_manager.h
+++ b/include/daemon/shutdown_manager.h
@@ -22,21 +22,19 @@ class ShutdownManager {
     // Signal handling
     void installSignalHandlers();
 
-    // PipeWire-specific callbacks
+    // Shutdown callbacks
     void setQuitLoopCallback(std::function<void()> cb);
-    void setPipewireShutdownCallback(std::function<void()> cb);
-    void setRtpShutdownCallback(std::function<void()> cb);
 
     void setMainLoopRunning(bool running);
 
     // Notifications
-    void notifyReady(bool pipewireActive);
+    void notifyReady();
 
     // Periodic processing (called from main loops)
-    void tick(bool pipewireActive);
+    void tick();
 
-    // Shutdown execution (shared across PipeWire/RTP paths)
-    void runShutdownSequence(bool pipewireActive);
+    // Shutdown execution
+    void runShutdownSequence();
 
     // Reset manager state between restarts
     void reset();
@@ -49,15 +47,13 @@ class ShutdownManager {
     void waitForFadeOut();
     void sendWatchdog();
 #ifdef HAVE_SYSTEMD
-    void sendReadyNotify(bool pipewireActive);
+    void sendReadyNotify();
     void sendStoppingNotify();
 #endif
 
     Dependencies deps_;
     GracefulShutdown::Controller controller_;  // own signal controller
     std::function<void()> quitLoopCallback_;
-    std::function<void()> pipewireShutdownCallback_;
-    std::function<void()> rtpShutdownCallback_;
 
     bool readyNotified_{false};
     bool stoppingNotified_{false};

--- a/src/config_loader.cpp
+++ b/src/config_loader.cpp
@@ -149,10 +149,6 @@ bool loadAppConfig(const std::filesystem::path& configPath, AppConfig& outConfig
         if (j.contains("coefficientDir"))
             outConfig.coefficientDir = j["coefficientDir"].get<std::string>();
 
-        // PipeWire input toggle (Docker / RTP-only mode)
-        if (j.contains("pipewireEnabled"))
-            outConfig.pipewireEnabled = j["pipewireEnabled"].get<bool>();
-
         if (j.contains("loopback") && j["loopback"].is_object()) {
             auto lb = j["loopback"];
             try {
@@ -290,6 +286,7 @@ bool loadAppConfig(const std::filesystem::path& configPath, AppConfig& outConfig
             }
         }
 
+        /* RTP configuration removed (legacy path)
         if (j.contains("rtp") && j["rtp"].is_object()) {
             auto rtp = j["rtp"];
             try {
@@ -438,6 +435,7 @@ bool loadAppConfig(const std::filesystem::path& configPath, AppConfig& outConfig
                 }
             }
         }
+        */
 
         // Clamp derived floating-point values after parsing (ensures sane bounds)
         outConfig.gain = std::max(0.0f, outConfig.gain);

--- a/src/daemon/control/control_plane.cpp
+++ b/src/daemon/control/control_plane.cpp
@@ -199,13 +199,6 @@ void ControlPlane::registerHandlers() {
     zmqServer_->registerCommand("PHASE_TYPE_SET",
                                 [this](const auto& req) { return handlePhaseTypeSet(req); });
 
-    const std::vector<std::string> rtpCommands = {
-        "RTP_START_SESSION",    "RTP_STOP_SESSION", "RTP_LIST_SESSIONS", "RTP_GET_SESSION",
-        "RTP_DISCOVER_STREAMS", "StartSession",     "StopSession",       "ListSessions",
-        "GetSession",           "DiscoverStreams"};
-    for (const auto& cmd : rtpCommands) {
-        zmqServer_->registerCommand(cmd, [this](const auto& req) { return handleRtpCommand(req); });
-    }
 }
 
 void ControlPlane::startStatsThread() {
@@ -597,24 +590,6 @@ std::string ControlPlane::handleCrossfeedSetSize(const daemon_ipc::ZmqRequest& r
     nlohmann::json data;
     data["head_size"] = CrossfeedEngine::headSizeToString(targetSize);
     return buildOkResponse(request, "", data);
-}
-
-std::string ControlPlane::handleRtpCommand(const daemon_ipc::ZmqRequest& request) {
-    if (!request.json) {
-        return buildErrorResponse(request, "IPC_INVALID_COMMAND",
-                                  "RTP command requires JSON payload");
-    }
-    if (!deps_.rtpCoordinator) {
-        return buildErrorResponse(request, "IPC_INVALID_COMMAND",
-                                  "RTP coordinator not initialized");
-    }
-
-    std::string response;
-    if (deps_.rtpCoordinator->handleZeroMqCommand(request.command, *request.json, response)) {
-        return response;
-    }
-    return buildErrorResponse(request, "IPC_INVALID_COMMAND",
-                              "Unknown JSON command: " + request.command);
 }
 
 std::string ControlPlane::handleDacList(const daemon_ipc::ZmqRequest& request) {

--- a/src/daemon/shutdown_manager.cpp
+++ b/src/daemon/shutdown_manager.cpp
@@ -43,29 +43,20 @@ void ShutdownManager::setQuitLoopCallback(std::function<void()> cb) {
     quitLoopCallback_ = std::move(cb);
 }
 
-void ShutdownManager::setPipewireShutdownCallback(std::function<void()> cb) {
-    pipewireShutdownCallback_ = std::move(cb);
-}
-
-void ShutdownManager::setRtpShutdownCallback(std::function<void()> cb) {
-    rtpShutdownCallback_ = std::move(cb);
-}
-
 void ShutdownManager::setMainLoopRunning(bool running) {
     deps_.mainLoopRunningFlag->store(running);
     controller_.setMainLoopRunning(running);
 }
 
-void ShutdownManager::notifyReady(bool pipewireActive) {
+void ShutdownManager::notifyReady() {
 #ifdef HAVE_SYSTEMD
     if (!readyNotified_) {
-        sendReadyNotify(pipewireActive);
+        sendReadyNotify();
     }
 #endif
 }
 
-void ShutdownManager::tick(bool pipewireActive) {
-    (void)pipewireActive;
+void ShutdownManager::tick() {
     bool processed = controller_.processPendingSignals();
     if (processed) {
         deps_.runningFlag->store(controller_.isRunning());
@@ -78,7 +69,7 @@ void ShutdownManager::tick(bool pipewireActive) {
 #endif
 }
 
-void ShutdownManager::runShutdownSequence(bool pipewireActive) {
+void ShutdownManager::runShutdownSequence() {
     if (sequenceRan_) {
         return;
     }
@@ -91,14 +82,6 @@ void ShutdownManager::runShutdownSequence(bool pipewireActive) {
 #endif
 
     waitForFadeOut();
-
-    if (pipewireActive) {
-        if (pipewireShutdownCallback_) {
-            pipewireShutdownCallback_();
-        }
-    } else if (rtpShutdownCallback_) {
-        rtpShutdownCallback_();
-    }
 }
 
 void ShutdownManager::reset() {
@@ -156,9 +139,8 @@ void ShutdownManager::sendWatchdog() {
 }
 
 #ifdef HAVE_SYSTEMD
-void ShutdownManager::sendReadyNotify(bool pipewireActive) {
-    std::string status = pipewireActive ? "Processing audio..." : "Processing audio (RTP-only)...";
-    sd_notify(0, ("READY=1\nSTATUS=" + status + "\n").c_str());
+void ShutdownManager::sendReadyNotify() {
+    sd_notify(0, "READY=1\nSTATUS=Processing audio...\n");
     readyNotified_ = true;
     std::cout << "systemd: Notified READY=1" << std::endl;
 }


### PR DESCRIPTION
## Summary
- PipeWire/RTP依存を段階的に削除開始：CMakeからPipeWire/RTPリンク・テスト参照を除去し、制御/シャットダウン/設定周りのヘッダ参照を整理
- `alsa_daemon.cpp`でPipeWire/RTPのincludeを外し、一部コードを無効化（まだPipeWire/RTP本体ブロックが残存するため要後続作業）

## Status
- WIP: ビルド未確認・`alsa_daemon.cpp`にPipeWire/RTP処理が残存しコンパイル未保証

## Test plan
- 未実施（後続でビルド/テスト要）