### PR TITLE
#688 config.json TCP設定 & Dashboard統合

### DIFF
--- a/config.json
+++ b/config.json
@@ -52,5 +52,11 @@
     "consoleOutput": true,
     "coloredOutput": true
   },
+  "tcpInput": {
+    "enabled": true,
+    "bindAddress": "0.0.0.0",
+    "port": 46001,
+    "bufferSizeBytes": 262144
+  },
   "statsFilePath": "/tmp/gpu_upsampler_stats.json"
 }

--- a/web/i18n.py
+++ b/web/i18n.py
@@ -71,6 +71,8 @@ TRANSLATIONS = {
         # Dashboard cards
         "dashboard.crossfeed": "Crossfeed",
         "dashboard.low_latency": "Low Latency Mode",
+        "dashboard.tcp_input": "TCP Input",
+        "dashboard.tcp_input.manage": "View TCP Input",
         # Low Latency Mode section
         "dashboard.low_latency.title": "Low Latency Mode (Partitioned Convolution)",
         "dashboard.low_latency.toggle": "Low Latency Partition",
@@ -214,6 +216,8 @@ TRANSLATIONS = {
         # Dashboard cards
         "dashboard.crossfeed": "クロスフィード",
         "dashboard.low_latency": "低遅延モード",
+        "dashboard.tcp_input": "TCP入力",
+        "dashboard.tcp_input.manage": "TCP入力を開く",
         # Low Latency Mode section
         "dashboard.low_latency.title": "⚡ 低遅延モード (Partitioned Convolution)",
         "dashboard.low_latency.toggle": "低遅延パーティション",

--- a/web/static/css/main.css
+++ b/web/static/css/main.css
@@ -399,6 +399,90 @@ body::before {
     color: #80a0a0;
 }
 
+.status-card-body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+}
+
+.status-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 8px 12px;
+    border: 1px solid rgba(0, 255, 255, 0.25);
+    border-radius: 6px;
+    background: rgba(10, 14, 18, 0.8);
+    min-width: 160px;
+    transition: all 0.2s;
+}
+
+.status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #7a7a7a;
+    box-shadow: 0 0 6px rgba(255, 255, 255, 0.15);
+}
+
+.status-text {
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    color: #e0e0e0;
+    text-transform: uppercase;
+}
+
+.status-subtext {
+    font-size: 12px;
+    color: rgba(128, 160, 160, 0.8);
+}
+
+.status-link {
+    font-size: 12px;
+    color: #00d4ff;
+    text-decoration: none;
+}
+
+.status-link:hover {
+    color: #00ffff;
+    text-decoration: underline;
+}
+
+.status-indicator.status-ok {
+    border-color: #00ff88;
+    box-shadow: 0 0 12px rgba(0, 255, 136, 0.25);
+    background: rgba(0, 255, 136, 0.08);
+}
+
+.status-indicator.status-ok .status-dot {
+    background: #00ff88;
+    box-shadow: 0 0 10px rgba(0, 255, 136, 0.7);
+}
+
+.status-indicator.status-error {
+    border-color: #ff4d4d;
+    box-shadow: 0 0 12px rgba(255, 77, 77, 0.25);
+    background: rgba(255, 77, 77, 0.08);
+}
+
+.status-indicator.status-error .status-dot {
+    background: #ff4d4d;
+    box-shadow: 0 0 10px rgba(255, 77, 77, 0.7);
+}
+
+.status-indicator.status-off {
+    border-color: rgba(128, 160, 160, 0.3);
+    background: rgba(128, 160, 160, 0.08);
+}
+
+.status-indicator.status-off .status-dot {
+    background: #7a7a7a;
+    box-shadow: 0 0 6px rgba(255, 255, 255, 0.1);
+}
+
 .status-card.ok .card-value {
     color: #00ff88;
     text-shadow: 0 0 10px rgba(0, 255, 136, 0.5);

--- a/web/templates/components/status_card.html
+++ b/web/templates/components/status_card.html
@@ -6,14 +6,21 @@
    - status_text (required): Text to display for status
    - status_class (required): CSS class for status indicator ("status-ok", "status-error", "status-off")
 #}
-<div class="status-card">
+<div class="status-card" {% if status_testid is defined %}data-testid="{{ status_testid }}"{% endif %}>
     <div class="status-card-header">
         <span class="status-icon">{{ status_icon }}</span>
         <h3>{{ status_title }}</h3>
     </div>
     <div class="status-card-body">
         <div class="status-indicator" :class="{{ status_class }}">
-            <span x-text="{{ status_text }}"></span>
+            <span class="status-dot"></span>
+            <span class="status-text" x-text="{{ status_text }}"></span>
         </div>
+        {% if status_subtext is defined %}
+        <div class="status-subtext" x-text="{{ status_subtext }}"></div>
+        {% endif %}
+        {% if status_link is defined and status_link_label is defined %}
+        <a class="status-link" href="{{ status_link }}">{{ status_link_label }}</a>
+        {% endif %}
     </div>
 </div>

--- a/web/templates/pages/dashboard.html
+++ b/web/templates/pages/dashboard.html
@@ -39,6 +39,17 @@
         {% set status_class = "status.low_latency_enabled ? 'status-ok' : 'status-off'" %}
         {% set status_text = "status.low_latency_enabled ? '{{ t.get('dashboard.status.on') }}' : '{{ t.get('dashboard.status.off') }}'" %}
         {% include 'components/status_card.html' %}
+
+        <!-- TCP Input Status Card -->
+        {% set status_icon = "🌐" %}
+        {% set status_title = t.get('dashboard.tcp_input') %}
+        {% set status_class = "tcp.telemetry.listening ? (tcp.telemetry.client_connected ? 'status-ok' : 'status-off') : 'status-error'" %}
+        {% set status_text = "tcpConnectionText()" %}
+        {% set status_subtext = "tcpFormatText()" %}
+        {% set status_link = "/tcp-input" %}
+        {% set status_link_label = t.get('dashboard.tcp_input.manage') %}
+        {% set status_testid = "tcp-status-card" %}
+        {% include 'components/status_card.html' %}
     </div>
 
     <!-- Low Latency Mode -->
@@ -193,6 +204,25 @@ function dashboardData() {
             crossfeed_enabled: false,
             low_latency_enabled: false,
         },
+        tcp: {
+            settings: {
+                bind_address: '',
+                port: 0,
+                buffer_size_bytes: 0,
+            },
+            telemetry: {
+                listening: false,
+                client_connected: false,
+                last_header: null,
+            },
+            updatedAt: null,
+        },
+        tcpLabels: {
+            connected: "{{ t.get('tcp.status.connected') }}",
+            listening: "{{ t.get('tcp.status.listening') }}",
+            stopped: "{{ t.get('tcp.status.stopped') }}",
+            unknown: "{{ t.get('tcp.status.unknown') }}",
+        },
         lowLatency: {
             enabled: false,
             loading: false,
@@ -234,12 +264,14 @@ function dashboardData() {
             this.fetchLowLatencyStatus();
             this.fetchPhaseType();
             this.fetchCrossfeedStatus();
-             this.fetchOutputMode();
+            this.fetchTcpStatus();
+            this.fetchOutputMode();
             // Poll status every 3 seconds
             setInterval(() => {
                 this.fetchStatus();
                 this.fetchLowLatencyStatus();
                 this.fetchCrossfeedStatus();
+                this.fetchTcpStatus();
             }, 3000);
         },
 
@@ -256,6 +288,33 @@ function dashboardData() {
                 }
             } catch (error) {
                 console.error('Failed to fetch status:', error);
+            }
+        },
+
+        formatNumber(value) {
+            if (value === null || value === undefined) {
+                return '—';
+            }
+            const num = Number(value);
+            return Number.isFinite(num) ? num.toLocaleString() : '—';
+        },
+
+        async fetchTcpStatus() {
+            try {
+                const response = await fetch('/api/tcp-input/status');
+                if (!response.ok) throw new Error('Failed to fetch TCP input status');
+                const data = await response.json();
+                if (data.settings) {
+                    this.tcp.settings = data.settings;
+                }
+                if (data.telemetry) {
+                    this.tcp.telemetry = data.telemetry;
+                } else if (typeof data === 'object') {
+                    this.tcp.telemetry = data;
+                }
+                this.tcp.updatedAt = Date.now();
+            } catch (error) {
+                console.error('Failed to fetch TCP input status:', error);
             }
         },
 
@@ -340,6 +399,29 @@ function dashboardData() {
             } catch (error) {
                 console.error('Failed to fetch output mode:', error);
             }
+        },
+
+        tcpConnectionText() {
+            if (this.tcp.telemetry.listening) {
+                return this.tcp.telemetry.client_connected
+                    ? this.tcpLabels.connected
+                    : this.tcpLabels.listening;
+            }
+            return this.tcpLabels.stopped;
+        },
+
+        tcpFormatText() {
+            const header = this.tcp.telemetry?.last_header || {};
+            const rate = Number(header.sample_rate || 0);
+            const channels = Number(header.channels || 0);
+            const fmt = header.format;
+            if (rate > 0 && channels > 0 && fmt) {
+                return `${this.formatNumber(rate)} Hz · ${channels}ch · ${fmt}`;
+            }
+            if (rate > 0 && channels > 0) {
+                return `${this.formatNumber(rate)} Hz · ${channels}ch`;
+            }
+            return this.tcpLabels.unknown;
         },
 
         async toggleLowLatency() {

--- a/web/tests/test_components.py
+++ b/web/tests/test_components.py
@@ -191,6 +191,23 @@ class TestComponentIntegration:
         assert "<button" in response_ja.text
 
 
+class TestDashboardStatusCards:
+    """Dashboard status card rendering."""
+
+    def test_status_texts_are_rendered(self, client):
+        """Status indicators should expose text labels (ON/OFF etc.)."""
+        response = client.get("/")
+        assert response.status_code == 200
+        assert 'class="status-text"' in response.text
+
+    def test_tcp_status_card_present(self, client):
+        """TCP status card should exist with navigation link."""
+        response = client.get("/")
+        assert response.status_code == 200
+        assert 'data-testid="tcp-status-card"' in response.text
+        assert "/tcp-input" in response.text
+
+
 class TestComponentCodeQuality:
     """Test component code quality and best practices."""
 

--- a/web/tests/test_config_service.py
+++ b/web/tests/test_config_service.py
@@ -1,0 +1,90 @@
+"""Tests for config service TCP helpers."""
+
+import json
+
+import pytest
+
+from web.services import config
+from web.models import TcpInputSettings
+
+
+@pytest.fixture
+def temp_config_path(tmp_path, monkeypatch):
+    """Use a temporary config.json for each test."""
+    path = tmp_path / "config.json"
+    monkeypatch.setattr(config, "CONFIG_PATH", path)
+    return path
+
+
+def test_get_tcp_config_defaults_when_missing(temp_config_path):
+    """Missing section should return TcpInputSettings defaults."""
+    temp_config_path.write_text(json.dumps({"other": "value"}))
+
+    settings = config.get_tcp_config()
+
+    assert isinstance(settings, TcpInputSettings)
+    assert settings.enabled is True
+    assert settings.bind_address == "0.0.0.0"
+    assert settings.port == 46001
+    assert settings.buffer_size_bytes == 262144
+
+
+def test_get_tcp_config_parses_values(temp_config_path):
+    """Existing tcpInput section should be parsed with aliases."""
+    temp_config_path.write_text(
+        json.dumps(
+            {
+                "tcpInput": {
+                    "enabled": False,
+                    "bindAddress": "127.0.0.1",
+                    "port": 12345,
+                    "bufferSizeBytes": 8192,
+                    "connection_mode": "priority",
+                }
+            }
+        )
+    )
+
+    settings = config.get_tcp_config()
+
+    assert settings.enabled is False
+    assert settings.bind_address == "127.0.0.1"
+    assert settings.port == 12345
+    assert settings.buffer_size_bytes == 8192
+    assert settings.connection_mode == "priority"
+
+
+def test_update_tcp_config_merges_and_persists(temp_config_path):
+    """Updates should merge with existing tcpInput section and persist."""
+    temp_config_path.write_text(
+        json.dumps(
+            {
+                "tcpInput": {
+                    "enabled": False,
+                    "bindAddress": "0.0.0.0",
+                    "port": 46001,
+                    "bufferSizeBytes": 128000,
+                },
+                "keep": {"untouched": True},
+            }
+        )
+    )
+
+    result = config.update_tcp_config({"port": 47000, "bind_address": "10.0.0.1"})
+
+    assert result is True
+    saved = json.loads(temp_config_path.read_text())
+    tcp_section = saved.get("tcpInput", {})
+    assert tcp_section["port"] == 47000
+    assert tcp_section["bindAddress"] == "10.0.0.1"
+    # Existing values should be preserved when not overwritten
+    assert tcp_section["bufferSizeBytes"] == 128000
+    # Unrelated keys remain untouched
+    assert saved["keep"] == {"untouched": True}
+
+
+def test_update_tcp_config_rejects_empty_payload(temp_config_path):
+    """Empty updates should be rejected for safety."""
+    temp_config_path.write_text(json.dumps({}))
+
+    assert config.update_tcp_config({}) is False


### PR DESCRIPTION
## Summary
- config.jsonにtcpInputセクションを追加し、サービス層へTCP設定取得/更新APIを実装
- ダッシュボードにTCP入力ステータスカードを追加し、低遅延など既存カードのインジケーター表示を改善（ON/OFF表示と点灯）
- TCP設定ヘルパーと新UIをテストでカバー（configサービスユニットテスト、ダッシュボードカードの存在確認）

## Test plan
- uv run pytest web/tests/test_config_service.py web/tests/test_components.py