### PR TITLE
#689 FastAPI最終クリーンアップとTCPドキュメント整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,10 @@ cmake --build build -j$(nproc)
 | `/api/eq/apply` | POST | EQ適用 |
 | `/api/opra/search` | GET | OPRAヘッドホン検索 |
 | `/api/dac/capability/{id}` | GET | DAC性能取得 |
+| `/api/tcp-input/status` | GET | TCP入力ステータス・テレメトリ取得 |
+| `/api/tcp-input/start` | POST | TCP入力開始 |
+| `/api/tcp-input/stop` | POST | TCP入力停止 |
+| `/api/tcp-input/config` | PUT | TCP入力設定更新 |
 
 ### ZeroMQコマンド
 
@@ -380,7 +384,10 @@ cmake --build build -j$(nproc)
 | `SWITCH_RATE` | レートファミリー切り替え |
 | `APPLY_EQ` | EQ適用 |
 | `RESTORE_EQ` | EQ解除 |
-| `RTP_DISCOVER_STREAMS` | RTP送信元スキャン |
+| `TCP_INPUT_STATUS` | TCP入力ステータス取得 |
+| `TCP_INPUT_START` | TCP入力開始 |
+| `TCP_INPUT_STOP` | TCP入力停止 |
+| `TCP_INPUT_CONFIG_UPDATE` | TCP入力設定更新 |
 
 ---
 

--- a/docker/jetson/docker-compose.jetson.yml
+++ b/docker/jetson/docker-compose.jetson.yml
@@ -33,9 +33,9 @@ services:
     devices:
       - /dev/snd:/dev/snd
 
-    # RTP input port + Web UI
+    # TCP input port + Web UI
     ports:
-      - "46000:46000/udp"
+      - "46001:46001/tcp"
       - "80:80"
 
     # Shared memory for audio buffers

--- a/docs/api/CHANGELOG.md
+++ b/docs/api/CHANGELOG.md
@@ -7,6 +7,11 @@ APIへの重要な変更はこのファイルに記録されます。
 ## [Unreleased]
 
 ### Added
+- **TCP Input API** (#684-#687)
+  - `GET /api/tcp-input/status` - TCP入力ステータス・テレメトリ取得
+  - `POST /api/tcp-input/start` - TCP入力開始
+  - `POST /api/tcp-input/stop` - TCP入力停止
+  - `PUT /api/tcp-input/config` - TCP入力設定更新（bindAddress/port/buffer/connectionMode/priorityClients）
 - **Phase Type Control**: 位相タイプのランタイム切り替え（フィルタは常時プリロード）
   - `GET /daemon/phase-type` - 現在の位相タイプ取得
   - `PUT /daemon/phase-type` - 位相タイプ変更（即時反映）
@@ -20,20 +25,11 @@ APIへの重要な変更はこのファイルに記録されます。
   - `scripts/inspect_impulse.py` に partition summary / latency 推定を追加
   - `scripts/verify_frequency_response.py` に fast/tail スペクトル比較と自動スキップ機能を追加
   - `docs/investigations/low_latency_partition_validation.md` にループバック手順とQA基準を掲載
-- **RTP Session Metadata Enhancement** (#381)
-  - `GET /api/rtp/sessions` レスポンスに自動起動フラグと全トランスポート情報を追加
-  - `RtpSessionMetrics` に以下のフィールドを追加：
-    - `auto_start`: セッションが自動起動設定されているか
-    - `bind_address`, `port`, `source_host`: トランスポート情報
-    - `payload_type`, `channels`, `bits_per_sample`: フォーマット情報
-    - `multicast`, `multicast_group`, `interface`: ネットワーク設定
-    - `enable_rtcp`, `rtcp_port`, `enable_ptp`: 詳細設定
-    - `target_latency_ms`, `watchdog_timeout_ms`, `telemetry_interval_ms`: タイミング設定
-  - Web UIで自動起動セッションを初回ロード時から可視化
 
 ### Changed
 - **FastAPI Lifespan Migration**: `@router.on_event("startup"/"shutdown")` から `lifespan` コンテキストマネージャへ移行
-  - RTPテレメトリポーラーのライフサイクル管理を `web/main.py` の `lifespan` 関数に統合
+  - TCPテレメトリポーラーのライフサイクル管理を `web/main.py` の `lifespan` 関数に統合
+- **Protocol Cleanup**: RTP/PipeWireエンドポイントとモデルを削除し、TCP入力のみをサポート
 
 ### Security
 - ALSAデバイス名のバリデーション追加（パストラバーサル防止）

--- a/docs/architecture/error-codes.md
+++ b/docs/architecture/error-codes.md
@@ -72,8 +72,6 @@ Q: どのカテゴリを使うべきか？
 | 0x1004 | `AUDIO_FILTER_NOT_FOUND` | 404 | 指定されたフィルタ係数ファイルが見つからない |
 | 0x1005 | `AUDIO_BUFFER_OVERFLOW` | 500 | 内部バッファがオーバーフロー（処理が追いつかない） |
 | 0x1006 | `AUDIO_XRUN_DETECTED` | 500 | ALSA XRUNが発生（アンダーラン/オーバーラン） |
-| 0x1007 | `AUDIO_RTP_SOCKET_ERROR` | 500 | RTPソケット初期化またはマルチキャスト参加に失敗 |
-| 0x1008 | `AUDIO_RTP_SESSION_NOT_FOUND` | 404 | 指定されたRTPセッションが存在しない |
 
 ### 3.2 DAC/ALSA (0x2000)
 

--- a/docs/dev/daemon_refactor_guide.md
+++ b/docs/dev/daemon_refactor_guide.md
@@ -12,7 +12,7 @@
 | `src/daemon/audio_pipeline/` | 入力→GPUアップサンプル→CF→出力バッファ管理、ソフトミュート補助 | `audio_pipeline.cpp`, `rate_switcher.cpp`, `filter_manager.cpp`, `soft_mute_runner.cpp` |
 | `src/daemon/output/` | ALSA 出力のライフサイクル管理、デバイス切替対応 | `alsa_output.{h,cpp}` |
 | `src/daemon/pcm/` | DAC能力の判定/選択 | `dac_manager.cpp` |
-| `src/daemon/rtp/` | RTP セッション制御 | `rtp_engine_coordinator.cpp` |
+| `jetson_pcm_receiver/` | TCP PCM受信・テレメトリ配信 | `tcp_server.cpp`, `pcm_stream_handler.cpp` |
 | `src/daemon/metrics/` | ランタイム統計の集約/永続化 | `runtime_stats.cpp` |
 
 ## イベント契約（共通ヘッダ）

--- a/docs/jetson/dev-autostart.md
+++ b/docs/jetson/dev-autostart.md
@@ -74,7 +74,7 @@ sudo ./scripts/jetson/setup-dev-autostart.sh status
 
 | サービス名 | 役割 | 主な設定 |
 |------------|------|----------|
-| `gpu-upsampler-dev.service` | `build/gpu_upsampler_alsa` をリポジトリ root で実行 | `LimitRTPRIO=99`, `LimitMEMLOCK=infinity`, `Restart=always` |
+| `gpu-upsampler-dev.service` | `build/gpu_upsampler_alsa` をリポジトリ root で実行 | `LimitRTPRIO=99`(Real-Time優先度), `LimitMEMLOCK=infinity`, `Restart=always` |
 | `magicbox-web-dev.service` | `uv run uvicorn web.main:app` を起動し Web UI を提供 | `After=gpu-upsampler-dev`, `Restart=always`, ポート <1024 の場合は Capability 付与 |
 
 - どちらも `WantedBy=multi-user.target` のため、Jetson 再起動後に自動で起動します。
@@ -99,5 +99,3 @@ sudo ./scripts/jetson/setup-dev-autostart.sh status
 - `magicbox-gadget.service` など USB Gadget まわりとの連携
 - `/opt/magicbox` パッケージとの差分を自動検出し警告
 - `--oneshot` でインストールのみ／有効化のみを切り替えるオプション
-
-

--- a/docs/jetson/systemd/service-design.md
+++ b/docs/jetson/systemd/service-design.md
@@ -146,6 +146,7 @@ IOWeight=200
 
 # リアルタイム優先度
 Nice=-10
+# LimitRTPRIO は Real-Time Priority の設定（プロトコル名ではない）
 LimitRTPRIO=99
 LimitMEMLOCK=infinity
 

--- a/docs/jetson/usb-gadget/known-issues.md
+++ b/docs/jetson/usb-gadget/known-issues.md
@@ -155,17 +155,10 @@ PC  ──USB──>  DAC  ─┤ I2S (BCLK, LRCK, DATA) ├──>  Magic Box (
 - ネットワーク依存（パケットロス）
 - リアルタイム性が低い
 
-#### 設定例
+#### 設定例（廃止）
 
-**PC側 (送信)**:
-```bash
-pw-link audio_source rtp-sink
-```
-
-**Jetson側 (受信)**:
-```bash
-pactl load-module module-rtp-recv
-```
+> ⚠️ RTP/PipeWire経路は #690 で廃止し、TCP PCM入力に一本化しました。
+> 本節の設定は現在サポートされていません（歴史的記録のみ）。
 
 ---
 

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -11,7 +11,7 @@ Magic Box Projectの開発環境構築とセットアップに関するドキュ
 | [テスト実行](test.md) | テストの実行方法 | 開発者 |
 | [PC開発環境](pc_development.md) | ALSA/TCP入力の詳細設定 | 開発者（実機動作） |
 | [Web UI](web_ui.md) | Web UIサーバーの起動・設定 | 開発者 |
-| [Raspberry Pi ブリッジ](pi_bridge.md) | PiをUAC2+RTPブリッジとして初期化 | Jetson + Pi構成 |
+| [Raspberry Pi ブリッジ](pi_bridge.md) | PiをUAC2+TCPブリッジとして初期化 | Jetson + Pi構成 |
 
 ## 環境別ガイド
 

--- a/tests/cpp/test_config_loader.cpp
+++ b/tests/cpp/test_config_loader.cpp
@@ -592,7 +592,3 @@ TEST_F(ConfigLoaderTest, Issue219_LoadConfigWithMultiRateAndFilterPaths) {
     EXPECT_EQ(config.filterPath48kLinear, "a/path48kLinear.bin");
     EXPECT_EQ(config.coefficientDir, "multi/coefficients");
 }
-
-// ============================================================
-// RTP settings (Issue #697)
-// ============================================================


### PR DESCRIPTION
## Summary
- RTP/PipeWire参照を整理し、CLAUDE/README/roadmap等をTCP入力前提に更新
- API ChangelogとJetson docker/systemdドキュメントをTCP入力ポート/優先度注記に合わせて修正
- configローダーテストの不要なRTPコメントを削除し、OpenAPIチェックとTCP関連Webテストを通過確認

## Test plan
- uv run python scripts/export_openapi.py --check
- PYTHONPATH=\"scripts:.\" uv run python -m pytest web/tests/test_tcp_input_router.py web/tests/test_tcp_input_service.py web/tests/test_tcp_input_page.py web/tests/test_daemon_client_tcp_commands.py web/tests/test_models.py web/tests/test_config_service.py