### PR TITLE
#416 レスポンシブ最終調整とテスト

### DIFF
--- a/web/static/css/main.css
+++ b/web/static/css/main.css
@@ -6,6 +6,16 @@
     padding: 0;
 }
 
+[x-cloak] {
+    display: none !important;
+}
+
+:root {
+    --sidebar-width: 240px;
+    --content-max-width: 1100px;
+    --content-padding: 40px;
+}
+
 body {
     font-family: 'Courier New', 'SF Mono', 'Consolas', monospace;
     background: #0a0e12;
@@ -33,7 +43,7 @@ body::before {
 
 /* Sidebar */
 .sidebar {
-    width: 240px;
+    width: var(--sidebar-width);
     background: rgba(10, 14, 18, 0.95);
     border-right: 1px solid rgba(0, 255, 255, 0.2);
     box-shadow:
@@ -97,11 +107,21 @@ body::before {
         inset 2px 0 5px rgba(0, 255, 255, 0.3);
 }
 
+.nav-item:focus-visible,
+.mobile-menu-toggle:focus-visible,
+.action-button:focus-visible,
+.btn-icon:focus-visible,
+.toggle-switch:focus-visible {
+    outline: 2px solid #00ffff;
+    outline-offset: 3px;
+    box-shadow: 0 0 12px rgba(0, 255, 255, 0.35);
+}
+
 /* Main content */
 .main-content {
     flex: 1;
-    padding: 40px;
-    max-width: 900px;
+    padding: var(--content-padding);
+    max-width: var(--content-max-width);
     margin: 0 auto;
     overflow-y: auto;
     position: relative;
@@ -905,6 +925,40 @@ body::before {
    Responsive Design - Mobile/Tablet Support
    ============================================ */
 
+@media (min-width: 1200px) {
+    :root {
+        --content-max-width: 1250px;
+        --content-padding: 48px;
+    }
+
+    .card-grid {
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+}
+
+@media (max-width: 1100px) {
+    :root {
+        --content-max-width: 1000px;
+        --content-padding: 32px;
+        --sidebar-width: 220px;
+    }
+}
+
+@media (max-width: 1024px) {
+    :root {
+        --content-max-width: 900px;
+        --content-padding: 28px;
+    }
+
+    .mode-switcher {
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    }
+
+    .card-grid {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+}
+
 /* Mobile hamburger menu button */
 .mobile-menu-toggle {
     display: none;
@@ -916,8 +970,11 @@ body::before {
     border: 1px solid rgba(0, 255, 255, 0.3);
     border-radius: 4px;
     padding: 10px;
+    min-width: 44px;
+    min-height: 44px;
     cursor: pointer;
     transition: all 0.3s;
+    touch-action: manipulation;
 }
 
 .mobile-menu-toggle:hover {
@@ -934,6 +991,16 @@ body::before {
     transition: all 0.3s;
 }
 
+.menu-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.65);
+    z-index: 40;
+}
+
 /* Mobile/Tablet Breakpoint: 768px */
 @media (max-width: 768px) {
     /* Show hamburger menu button */
@@ -945,8 +1012,9 @@ body::before {
     .sidebar {
         position: fixed;
         top: 0;
-        left: -240px;
+        left: calc(var(--sidebar-width) * -1);
         height: 100vh;
+        width: var(--sidebar-width);
         transition: left 0.3s ease;
         z-index: 50;
     }
@@ -1081,7 +1149,7 @@ body::before {
 /* Card Grid for Status Cards */
 .card-grid {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     gap: 12px;
     margin-bottom: 32px;
 }
@@ -1311,6 +1379,7 @@ body::before {
     transition: all 0.3s;
     font-family: 'Courier New', monospace;
     min-height: 44px;
+    touch-action: manipulation;
 }
 
 .action-button:hover:not(:disabled) {
@@ -1361,7 +1430,7 @@ body::before {
 .ws-indicator {
     position: fixed;
     bottom: 20px;
-    left: 260px;
+    left: calc(var(--sidebar-width) + 20px);
     padding: 8px 12px;
     border-radius: 4px;
     font-size: 11px;

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -16,12 +16,33 @@
 
     {% block extra_head %}{% endblock %}
 </head>
-<body x-data="{ mobileMenuOpen: false }" :class="{ 'menu-open': mobileMenuOpen }">
+<body
+    x-data="{
+        mobileMenuOpen: false,
+        toggleMenu() {
+            this.mobileMenuOpen = !this.mobileMenuOpen;
+            if (this.mobileMenuOpen) {
+                this.$nextTick(() => this.$refs.firstNavLink?.focus());
+            }
+        },
+        closeMenu() {
+            if (this.mobileMenuOpen) {
+                this.mobileMenuOpen = false;
+                this.$nextTick(() => this.$refs.mainContent?.focus());
+            }
+        },
+    }"
+    :class="{ 'menu-open': mobileMenuOpen }"
+    @keydown.window.escape.prevent="closeMenu()"
+>
     <!-- Mobile Menu Toggle Button -->
     <button
         class="mobile-menu-toggle"
-        @click="mobileMenuOpen = !mobileMenuOpen"
-        aria-label="Toggle menu"
+        @click="toggleMenu()"
+        :aria-expanded="mobileMenuOpen"
+        aria-controls="primary-sidebar"
+        aria-label="Toggle navigation menu"
+        data-testid="mobile-menu-toggle"
     >
         <span></span>
         <span></span>
@@ -29,20 +50,28 @@
     </button>
 
     <!-- Sidebar Navigation -->
-    <aside class="sidebar" :class="{ 'open': mobileMenuOpen }">
+    <aside
+        id="primary-sidebar"
+        class="sidebar"
+        :class="{ 'open': mobileMenuOpen }"
+        role="navigation"
+        aria-label="Primary navigation"
+    >
         {% include 'components/sidebar.html' %}
     </aside>
 
     <!-- Overlay for mobile menu (clicking closes menu) -->
     <div
-        @click="mobileMenuOpen = false"
+        class="menu-overlay"
+        data-testid="menu-overlay"
+        @click="closeMenu()"
         x-show="mobileMenuOpen"
         x-transition.opacity
-        style="display: none;"
+        x-cloak
     ></div>
 
     <!-- Main Content -->
-    <main class="main-content">
+    <main class="main-content" x-ref="mainContent" tabindex="-1">
         {% block content %}
         <!-- Page content goes here -->
         {% endblock %}

--- a/web/templates/components/sidebar.html
+++ b/web/templates/components/sidebar.html
@@ -5,16 +5,37 @@
 </div>
 
 <nav>
-    <a href="/" class="nav-item {% if current_page == 'dashboard' %}active{% endif %}">
+    <a
+        href="/"
+        class="nav-item {% if current_page == 'dashboard' %}active{% endif %}"
+        aria-current="{% if current_page == 'dashboard' %}page{% else %}false{% endif %}"
+        @click="closeMenu()"
+        x-ref="firstNavLink"
+    >
         <span style="margin-right: 8px;">📊</span> {{ t.get('nav.dashboard') }}
     </a>
-    <a href="/tcp-input" class="nav-item {% if current_page == 'tcp-input' %}active{% endif %}">
+    <a
+        href="/tcp-input"
+        class="nav-item {% if current_page == 'tcp-input' %}active{% endif %}"
+        aria-current="{% if current_page == 'tcp-input' %}page{% else %}false{% endif %}"
+        @click="closeMenu()"
+    >
         <span style="margin-right: 8px;">🌐</span> {{ t.get('nav.tcp_input') }}
     </a>
-    <a href="/eq" class="nav-item {% if current_page == 'eq' %}active{% endif %}">
+    <a
+        href="/eq"
+        class="nav-item {% if current_page == 'eq' %}active{% endif %}"
+        aria-current="{% if current_page == 'eq' %}page{% else %}false{% endif %}"
+        @click="closeMenu()"
+    >
         <span style="margin-right: 8px;">🎚️</span> {{ t.get('nav.eq') }}
     </a>
-    <a href="/system" class="nav-item {% if current_page == 'system' %}active{% endif %}">
+    <a
+        href="/system"
+        class="nav-item {% if current_page == 'system' %}active{% endif %}"
+        aria-current="{% if current_page == 'system' %}page{% else %}false{% endif %}"
+        @click="closeMenu()"
+    >
         <span style="margin-right: 8px;">⚙️</span> {{ t.get('nav.system') }}
     </a>
 </nav>

--- a/web/tests/test_responsive_layout.py
+++ b/web/tests/test_responsive_layout.py
@@ -1,0 +1,54 @@
+"""レスポンシブ最終調整の回帰テスト."""
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from web.main import app
+
+
+@pytest.fixture
+def client():
+    """FastAPIテストクライアントを提供."""
+    return TestClient(app)
+
+
+def test_mobile_toggle_has_accessibility_attrs(client):
+    """モバイルメニューのアクセシビリティ属性を検証."""
+    html = client.get("/").text
+
+    assert 'class="mobile-menu-toggle"' in html
+    assert 'data-testid="mobile-menu-toggle"' in html
+    assert 'aria-controls="primary-sidebar"' in html
+    assert ':aria-expanded="mobileMenuOpen"' in html
+
+
+def test_menu_overlay_present(client):
+    """メニューオーバーレイが描画されることを確認."""
+    html = client.get("/").text
+
+    assert 'class="menu-overlay"' in html
+    assert 'data-testid="menu-overlay"' in html
+
+
+def test_sidebar_navigation_landmark(client):
+    """サイドバーのナビゲーションランドマークを確認."""
+    html = client.get("/").text
+
+    assert 'id="primary-sidebar"' in html
+    assert 'role="navigation"' in html
+    assert 'x-ref="firstNavLink"' in html
+    assert 'aria-current="page"' in html
+
+
+def test_responsive_breakpoints_present():
+    """ブレークポイントとフォーカススタイルが保持されていることを確認."""
+    css_path = Path(__file__).parent.parent / "static" / "css" / "main.css"
+    content = css_path.read_text()
+
+    assert "@media (max-width: 1024px)" in content
+    assert "@media (max-width: 1100px)" in content
+    assert "@media (min-width: 1200px)" in content
+    assert "--sidebar-width" in content
+    assert ".nav-item:focus-visible" in content


### PR DESCRIPTION
## Summary
- モバイルメニューのフォーカス移動とオーバーレイ追加でタッチ/キーボード操作を改善
- サイドバー幅とカードグリッドをCSS変数+ブレークポイントで最適化し全デバイスのレイアウトを調整
- レスポンシブ回帰テストを追加しアクセシビリティ属性とブレークポイントの継続性を検証

## Test plan
- uv run pytest web/tests/test_responsive_layout.py web/tests/test_components.py