### PR TITLE
#730 Jetson compose統合 (magicbox + pcm receiver)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -20,7 +20,7 @@ docker compose -f jetson/docker-compose.jetson.yml down
 - JetPack 6.1 以降 + NVIDIA Container Runtime 必須
 - `--device /dev/snd` を必ず付与（Loopback/実デバイスをコンテナへ渡す）
 - 環境変数 `JPR_*` で CLI 相当の設定を上書き可能（ポート、デバイス、接続モード、ZeroMQ など）
-- `jetson-pcm-receiver` はホスト 46001/TCP、`magicbox` の TCP 入力は競合回避のためホスト 46002→コンテナ 46001 を割り当て
+- TCP入力は `jetson-pcm-receiver` が受け、Magic Box には ALSA Loopback で渡す（Magic Box 側のTCP穴あけ不要）
 - サービスを個別に起動したい場合: `docker compose -f jetson/docker-compose.jetson.yml up -d --build jetson-pcm-receiver` のようにサービス名を指定
 
 ### 入力レート/フォーマットの扱い（TCPのみ）

--- a/docker/jetson/docker-compose.jetson.yml
+++ b/docker/jetson/docker-compose.jetson.yml
@@ -33,9 +33,8 @@ services:
     devices:
       - /dev/snd:/dev/snd
 
-    # TCP input port (host 46002 to avoid clash) + Web UI
+    # Web UI (TCP入力はjetson-pcm-receiver側で受ける)
     ports:
-      - "46002:46001/tcp"
       - "80:80"
 
     # Shared memory for audio buffers


### PR DESCRIPTION
## Summary
- jetson docker composeにjetson-pcm-receiverを追加して1ファイルで起動
- TCP入力はjetson-pcm-receiverのみ公開し、magicboxはWeb UIの80番のみ公開
- docker/README.mdを統合手順とポート説明に合わせて更新

## Test plan
- docker compose -f docker/jetson/docker-compose.jetson.yml config