### PR TITLE
#733 jetson-pcm-receiverのperiod/buffer拡大

### DIFF
--- a/jetson_pcm_receiver/src/alsa_playback.cpp
+++ b/jetson_pcm_receiver/src/alsa_playback.cpp
@@ -13,8 +13,8 @@
 
 namespace {
 
-constexpr snd_pcm_uframes_t DEFAULT_PERIOD_FRAMES = 512;
-constexpr snd_pcm_uframes_t DEFAULT_BUFFER_FRAMES = DEFAULT_PERIOD_FRAMES * 4;
+constexpr snd_pcm_uframes_t DEFAULT_PERIOD_FRAMES = 1024;
+constexpr snd_pcm_uframes_t DEFAULT_BUFFER_FRAMES = 8192;
 
 snd_pcm_format_t toPcmFormat(uint16_t format) {
     switch (format) {


### PR DESCRIPTION
## Summary
- ALSA playback のデフォルト period を 1024 frames に拡大し magicbox 側と揃えた
- buffer を 8192 frames に引き上げ、Loopback 書き込み側のアンダーラン余裕を確保
- XRUN storm 回避のためのデフォルト設定差分のみ（挙動変更なし）

## Test plan
- 未実施（Loopback: writer hw:Loopback,0,0 / reader hw:Loopback,1,0 で 44.1kHz 再生し XRUN が止まることを確認予定）