### PR TITLE
fix: update Raspberry Pi default settings for production environment

### DIFF
--- a/raspberry_pi/Dockerfile
+++ b/raspberry_pi/Dockerfile
@@ -18,16 +18,16 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/pcm-bridge
-COPY raspberry_pi/rtp_receiver /opt/pcm-bridge/raspberry_pi/rtp_receiver
-COPY raspberry_pi/rtp_sender.py /opt/pcm-bridge/raspberry_pi/rtp_sender.py
-COPY raspberry_pi/__init__.py /opt/pcm-bridge/raspberry_pi/__init__.py
-COPY raspberry_pi/docker/entrypoint.sh /usr/local/bin/pcm-bridge-entrypoint.sh
+COPY rtp_receiver /opt/pcm-bridge/raspberry_pi/rtp_receiver
+COPY rtp_sender.py /opt/pcm-bridge/raspberry_pi/rtp_sender.py
+COPY __init__.py /opt/pcm-bridge/raspberry_pi/__init__.py
+COPY docker/entrypoint.sh /usr/local/bin/pcm-bridge-entrypoint.sh
 RUN chmod +x /usr/local/bin/pcm-bridge-entrypoint.sh
-RUN pip3 install --no-cache-dir pyzmq
+RUN pip3 install --no-cache-dir --break-system-packages pyzmq
 
 ENV PYTHONPATH=/opt/pcm-bridge:${PYTHONPATH}
 
-ENV RTP_SENDER_DEVICE=hw:0,0 \
+ENV RTP_SENDER_DEVICE=hw:2,0 \
     RTP_SENDER_HOST=192.168.55.1 \
     RTP_SENDER_RTP_PORT=46000 \
     RTP_SENDER_RTCP_PORT=46001 \

--- a/raspberry_pi/docker-compose.yml
+++ b/raspberry_pi/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     group_add:
       - "audio"
     environment:
-      RTP_SENDER_DEVICE: ${RTP_SENDER_DEVICE:-hw:0,0}
+      RTP_SENDER_DEVICE: ${RTP_SENDER_DEVICE:-hw:2,0}
       RTP_SENDER_HOST: ${RTP_SENDER_HOST:-192.168.55.1}
       RTP_SENDER_RTP_PORT: ${RTP_SENDER_RTP_PORT:-46000}
       RTP_SENDER_RTCP_PORT: ${RTP_SENDER_RTCP_PORT:-46001}
@@ -37,7 +37,7 @@ services:
     ports:
       - "80:80"
     environment:
-      JETSON_HOST: ${JETSON_HOST:-jetson}
+      JETSON_HOST: ${JETSON_HOST:-192.168.55.1}
       JETSON_PORT: ${JETSON_PORT:-80}
     volumes:
       - ./docker/nginx/default.conf.template:/etc/nginx/templates/default.conf.template:ro

--- a/raspberry_pi/rtp_sender.py
+++ b/raspberry_pi/rtp_sender.py
@@ -13,7 +13,7 @@ import subprocess
 from dataclasses import dataclass
 from typing import Iterable, List, Tuple
 
-_DEFAULT_DEVICE = "hw:0,0"
+_DEFAULT_DEVICE = "hw:2,0"
 _DEFAULT_HOST = "192.168.55.1"
 _DEFAULT_RTP_PORT = 46000
 _DEFAULT_RTCP_PORT = 46001
@@ -98,7 +98,6 @@ def build_gst_command(cfg: RtpSenderConfig) -> List[str]:
         "rtpbin",
         "name=rtpbin",
         "ntp-sync=true",
-        "buffer-mode=sync",
     ]
     if cfg.latency_ms is not None:
         args.append(f"latency={cfg.latency_ms}")


### PR DESCRIPTION
- Change default ALSA device from hw:0,0 to hw:2,0 (UAC2 Gadget)
- Change default JETSON_HOST from 'jetson' to '192.168.55.1'
- Fix Dockerfile COPY paths for correct build context
- Add --break-system-packages flag for pip on Debian 12
- Remove unsupported buffer-mode=sync from rtpbin

🤖 Generated with [Claude Code](https://claude.com/claude-code)