### PR TITLE
#793 RTPパイプライン構文修正（再）

### DIFF
--- a/web/services/rtp_input.py
+++ b/web/services/rtp_input.py
@@ -150,6 +150,7 @@ def build_gst_command(settings: RtpInputSettings) -> list[str]:
         f"caps={caps}",
         "!",
         "rtpbin.recv_rtp_sink_0",
+        "!",
         "rtpbin.recv_rtp_src_0",
         "!",
         depay,

--- a/web/tests/test_rtp_input_service.py
+++ b/web/tests/test_rtp_input_service.py
@@ -23,8 +23,8 @@ def test_build_gst_command_supports_encodings():
     assert "rtpbin" in l24
     assert any("rtcp" in part for part in l24)
     l24_str = " ".join(l24)
-    # sink -> depay までのチェーンに二重の '!' が入っていないことを確認
-    assert "! rtpbin.recv_rtp_src_0" not in l24_str
+    # sink -> src を '!' で連結している
+    assert "! rtpbin.recv_rtp_src_0 !" in l24_str
 
 
 def test_config_update_merges_and_validates():


### PR DESCRIPTION
## Summary
- rtpbin の recv sink/src を `!` で正しく連結し、syntax error / not-linked を解消
- 既存のログスロットリングとTCP_INPUT_STATUS抑制は維持

## Test plan
- uv run pytest web/tests/test_rtp_input_service.py web/tests/test_rtp_autostart.py web/tests/test_rtp_input_router.py