### PR TITLE
Fix #829: 出力バッファoverflow回避（入力バックプレッシャ）

### DIFF
--- a/src/alsa_daemon.cpp
+++ b/src/alsa_daemon.cpp
@@ -327,7 +327,7 @@ static std::vector<float> g_output_buffer_left;
 static std::vector<float> g_output_buffer_right;
 static size_t g_output_read_pos = 0;
 
-// Producer backpressure (loopback/TCP input) to prevent output buffer overflows.
+// Producer backpressure (loopback capture input) to prevent output buffer overflows.
 // Rationale:
 // - If upstream input is not paced in real-time (e.g., software loopback or bursty network),
 //   the GPU pipeline can enqueue output faster than ALSA can consume it.


### PR DESCRIPTION
## Summary
- 出力バッファが満杯になった際の frame drop（= 不連続）を回避するため、出力キュー高水位時に入力側（loopback capture）を短時間スロットルするバックプレッシャを追加
- これにより『Output buffer overflow: dropping ... frames』の連続発生を抑制し、周期的な『ジッ/プチ』ノイズの原因（drop）を潰す

## Notes
- 本PRのスロットルは `loopback_capture_thread()` に入っています（= loopback入力経路に適用）。もし別入力経路がある場合は同様のバックプレッシャが必要です。
- スロットルは「出力キューがほぼ満杯のときだけ」発動します。結果として入力側（loopback）でXRUNが発生する可能性はありますが、出力側のdrop（不連続）を優先的に避ける狙いです。

## Test plan
- [x] `cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j$(nproc)`
- [x] `./build/cpu_tests`
- [ ] 実機で再生し、`Output buffer overflow` が消える（または大幅に減る）ことを確認
- [ ] 実機で再生し、『ジッ』が解消することを確認
- [ ] 実機で `Throttling input:` の警告が出る場合、同時刻に `Output buffer overflow` が出ていないことを確認