### PR TITLE
Fix #831: DAC切替/復帰の残留音ループ対策 + ALSA short write対応

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,6 +447,7 @@ add_executable(cpu_tests
     tests/cpp/test_partition_plan.cpp
     tests/cpp/test_phase_alignment.cpp
     tests/cpp/test_playback_buffer_threshold.cpp
+    tests/cpp/test_alsa_write_loop.cpp
     tests/cpp/test_runtime_stats.cpp
     tests/cpp/test_audio_pipeline.cpp
     src/daemon/audio_pipeline/audio_pipeline.cpp

--- a/include/daemon/output/alsa_write_loop.h
+++ b/include/daemon/output/alsa_write_loop.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <type_traits>
+
+namespace daemon_output {
+namespace alsa_write_loop {
+
+// A small, testable helper for writing interleaved int32 frames in a loop.
+//
+// - Handles short writes (0 < written < frames)
+// - Treats 0 / -EAGAIN as "try again later" via yieldFn()
+// - Calls onXrun() on -EPIPE before attempting recoverFn()
+// - Uses recoverFn(err) to recover; if recoverFn returns < 0, the original error is returned.
+//
+// This is intentionally ALSA-agnostic to allow unit testing without snd_pcm_t.
+inline long writeAllInterleaved(const int32_t* interleaved, size_t frames, unsigned int channels,
+                                const std::function<long(const int32_t*, size_t)>& writeFn,
+                                const std::function<long(long)>& recoverFn,
+                                const std::function<void()>& yieldFn,
+                                const std::function<bool()>& runningFn,
+                                const std::function<void()>& onXrun, long eagainErrno,
+                                long epipeErrno) {
+    if (!interleaved || frames == 0 || channels == 0) {
+        return 0;
+    }
+
+    size_t totalWritten = 0;
+    while (totalWritten < frames && (!runningFn || runningFn())) {
+        const int32_t* ptr = interleaved + totalWritten * static_cast<size_t>(channels);
+        const size_t remaining = frames - totalWritten;
+        const long written = writeFn ? writeFn(ptr, remaining) : 0;
+
+        if (written > 0) {
+            totalWritten += static_cast<size_t>(written);
+            continue;
+        }
+
+        if (written == 0 || written == -eagainErrno) {
+            if (yieldFn) {
+                yieldFn();
+            }
+            continue;
+        }
+
+        if (written == -epipeErrno) {
+            if (onXrun) {
+                onXrun();
+            }
+        }
+
+        const long rec = recoverFn ? recoverFn(written) : -1;
+        if (rec < 0) {
+            return written;
+        }
+    }
+
+    return static_cast<long>(totalWritten);
+}
+
+}  // namespace alsa_write_loop
+}  // namespace daemon_output

--- a/tests/cpp/test_alsa_write_loop.cpp
+++ b/tests/cpp/test_alsa_write_loop.cpp
@@ -1,0 +1,116 @@
+#include "daemon/output/alsa_write_loop.h"
+
+#include <cerrno>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace {
+
+TEST(AlsaWriteLoopTest, HandlesShortWritesAndEagainWithCorrectPointerOffset) {
+    // 2ch interleaved: [L0 R0 L1 R1 ...]
+    constexpr unsigned int kChannels = 2;
+    constexpr size_t kFrames = 8;
+    std::vector<int32_t> interleaved(kFrames * kChannels, 0);
+
+    std::vector<const int32_t*> ptrs;
+    std::vector<size_t> reqFrames;
+    int yieldCount = 0;
+    int call = 0;
+
+    auto writeFn = [&](const int32_t* ptr, size_t frames) -> long {
+        ptrs.push_back(ptr);
+        reqFrames.push_back(frames);
+        // Write pattern:
+        // 1) short write 3 frames
+        // 2) EAGAIN
+        // 3) 0 (also treated as retry)
+        // 4) remaining frames
+        ++call;
+        if (call == 1) {
+            return 3;
+        }
+        if (call == 2) {
+            return -EAGAIN;
+        }
+        if (call == 3) {
+            return 0;
+        }
+        return static_cast<long>(frames);
+    };
+
+    auto recoverFn = [&](long) -> long {
+        // Should not be called in this test.
+        return -1;
+    };
+
+    auto yieldFn = [&]() { ++yieldCount; };
+    auto runningFn = [&]() { return true; };
+    auto onXrun = [&]() { FAIL() << "onXrun should not be called"; };
+
+    long written = daemon_output::alsa_write_loop::writeAllInterleaved(
+        interleaved.data(), kFrames, kChannels, writeFn, recoverFn, yieldFn, runningFn, onXrun,
+        EAGAIN, EPIPE);
+    EXPECT_EQ(written, static_cast<long>(kFrames));
+    EXPECT_EQ(yieldCount, 2);
+    ASSERT_GE(ptrs.size(), 2u);
+
+    // First call starts at frame 0
+    EXPECT_EQ(ptrs[0], interleaved.data());
+    // Second call is retry at frame 3 (because 3 frames were written)
+    EXPECT_EQ(ptrs[1], interleaved.data() + (3 * kChannels));
+}
+
+TEST(AlsaWriteLoopTest, CallsOnXrunAndUsesRecoverThenContinues) {
+    constexpr unsigned int kChannels = 2;
+    constexpr size_t kFrames = 4;
+    std::vector<int32_t> interleaved(kFrames * kChannels, 0);
+
+    int xrunCount = 0;
+    int recoverCount = 0;
+    int call = 0;
+
+    auto writeFn = [&](const int32_t*, size_t frames) -> long {
+        ++call;
+        if (call == 1) {
+            return -EPIPE;
+        }
+        return static_cast<long>(frames);
+    };
+
+    auto recoverFn = [&](long err) -> long {
+        ++recoverCount;
+        EXPECT_EQ(err, -EPIPE);
+        return 0;  // recovered
+    };
+
+    auto yieldFn = [&]() {};
+    auto runningFn = [&]() { return true; };
+    auto onXrun = [&]() { ++xrunCount; };
+
+    long written = daemon_output::alsa_write_loop::writeAllInterleaved(
+        interleaved.data(), kFrames, kChannels, writeFn, recoverFn, yieldFn, runningFn, onXrun,
+        EAGAIN, EPIPE);
+    EXPECT_EQ(written, static_cast<long>(kFrames));
+    EXPECT_EQ(xrunCount, 1);
+    EXPECT_EQ(recoverCount, 1);
+}
+
+TEST(AlsaWriteLoopTest, ReturnsOriginalErrorIfRecoverFails) {
+    constexpr unsigned int kChannels = 2;
+    constexpr size_t kFrames = 4;
+    std::vector<int32_t> interleaved(kFrames * kChannels, 0);
+
+    auto writeFn = [&](const int32_t*, size_t) -> long { return -123; };
+    auto recoverFn = [&](long) -> long { return -1; };
+    auto yieldFn = [&]() {};
+    auto runningFn = [&]() { return true; };
+    auto onXrun = [&]() {};
+
+    long written = daemon_output::alsa_write_loop::writeAllInterleaved(
+        interleaved.data(), kFrames, kChannels, writeFn, recoverFn, yieldFn, runningFn, onXrun,
+        EAGAIN, EPIPE);
+    EXPECT_EQ(written, -123);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary
- DAC切替/切断復帰時にストリーミング状態（出力キュー/入力ストリーミングバッファ/upsampler overlap/crossfeed）をフラッシュして、短い区間がループ再生される症状を抑制
- `snd_pcm_writei()` の short write / `-EAGAIN` を考慮し、period を書き切るまでループするようにして出力の安定性を向上

## Notes
- `mark_dac_disconnected()` で `g_output_ready=false` にしたタイミングでキャッシュをフラッシュします（入力が継続していても出力復帰後に古い状態を引きずらない）
- デバイス切替/再open前に `snd_pcm_drop()` を入れて、ハード側に残留している可能性があるバッファを止めます

## Test plan
- [x] `cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j$(nproc)`
- [x] `./build/cpu_tests`
- [ ] USBスイッチャーでDAC切替を複数回行い、残留音のループが出ないことを確認
- [ ] DAC抜き差し/電源断→復帰で、復帰後に短い区間ループが出ないことを確認