### PR TITLE
Fix: rtpbin buffer-mode=sync → buffer-mode=synced

### DIFF
--- a/raspberry_pi/README.md
+++ b/raspberry_pi/README.md
@@ -97,7 +97,7 @@ Magic Box Web UI からのレイテンシ変更を Pi に伝える場合に使�
 Python ラッパーの出力と同等の gst-launch 例です。
 
 ```bash
-gst-launch-1.0 -e rtpbin name=rtpbin ntp-sync=true buffer-mode=sync latency=100 \
+gst-launch-1.0 -e rtpbin name=rtpbin ntp-sync=true buffer-mode=synced latency=100 \
   alsasrc device=hw:0,0 ! audioresample quality=10 ! audioconvert ! \
   audio/x-raw,rate=44100,channels=2,format=S24BE ! rtpL24pay pt=96 ! \
   application/x-rtp,media=audio,clock-rate=44100,encoding-name=L24,payload=96,channels=2 ! \

--- a/raspberry_pi/rtp_sender.py
+++ b/raspberry_pi/rtp_sender.py
@@ -254,7 +254,8 @@ def build_gst_command(cfg: RtpSenderConfig) -> List[str]:
         "name=rtpbin",
         "ntp-sync=true",
         # Align with README recommended pipeline (stabilize clock sync)
-        "buffer-mode=sync",
+        # Valid values: none(0), slave(1), buffer(2), synced(4)
+        "buffer-mode=synced",
     ]
     if cfg.latency_ms is not None:
         args.append(f"latency={cfg.latency_ms}")

--- a/raspberry_pi/tests/test_rtp_sender.py
+++ b/raspberry_pi/tests/test_rtp_sender.py
@@ -146,7 +146,7 @@ def test_build_gst_command_includes_stability_buffers_by_default() -> None:
 
     # rtpbin: clock sync stabilization
     assert "rtpbin" in cmd
-    assert "buffer-mode=sync" in cmd
+    assert "buffer-mode=synced" in cmd
 
     # alsasrc: explicit buffering to avoid period/avail brinkmanship
     assert any(part.startswith("buffer-time=") for part in cmd)


### PR DESCRIPTION
GStreamer rtpbin の buffer-mode で無効な値 "sync" を使用していたため パイプラインが起動時にクラッシュしていた。

有効な値: none(0), slave(1), buffer(2), synced(4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)