### PR TITLE
Tweak: RTP受信を低遅延デフォルトへ（動画向け）

### DIFF
--- a/web/tests/test_rtp_input_service.py
+++ b/web/tests/test_rtp_input_service.py
@@ -23,9 +23,9 @@ def test_build_gst_command_supports_encodings():
     assert any(part.startswith("audio/x-raw,format=S16BE,") for part in l16)
     assert any(part.startswith("audio/x-raw,format=S24BE,") for part in l24)
     assert any(part.startswith("audio/x-raw,format=S32BE,") for part in l32)
-    assert any("latency=200" in part for part in l24)
+    assert any(f"latency={base.latency_ms}" in part for part in l24)
     assert any("quality=8" in part for part in l24)
-    assert "max-size-time=300000000" in l24
+    assert "max-size-time=60000000" in l24
     assert "rtpbin" in l24
     assert any("rtcp" in part for part in l24)
     l24_str = " ".join(l24)


### PR DESCRIPTION
rtpbin latency の倍率を環境変数で調整可能にし、デフォルトを latency_ms に合わせる。queue の max-size-time も 300ms→60ms に下げ、必要なら env で増やせるようにする。