### PR TITLE
Fix #839: 64bit/float64ビルドでアップサンプラー出力が極小になる

### DIFF
--- a/include/convolution_engine.h
+++ b/include/convolution_engine.h
@@ -405,6 +405,11 @@ class GPUUpsampler {
                                   cudaStream_t stream);
     cudaError_t downconvertToHostSync(float* hostDst, const DeviceSample* deviceSrc, size_t count);
 
+    // Host(float32) -> Device(active precision) transfer helper.
+    // In float64 builds, avoids passing short-lived host buffers to cudaMemcpyAsync.
+    cudaError_t copyHostToDeviceSamplesConvertedAsync(DeviceSample* dst, const float* src,
+                                                      size_t count, cudaStream_t stream);
+
     // Release CPU-side filter coefficient memory after GPU transfer
     // This saves ~100MB of RAM, especially important for Jetson Unified Memory
     // Call this after all GPU transfers are complete (FFT pre-computation done)

--- a/include/gpu/convolution_kernels.h
+++ b/include/gpu/convolution_kernels.h
@@ -19,6 +19,9 @@ __global__ void complexMultiplyKernel(DeviceFftComplex* data, const DeviceFftCom
 // CUDA kernel for scaling after IFFT
 __global__ void scaleKernel(DeviceSample* data, int size, DeviceScale scale);
 
+// CUDA kernel to upconvert float samples to active precision samples (float->double when enabled)
+__global__ void upconvertFromFloatKernel(const float* input, DeviceSample* output, int size);
+
 // CUDA kernel for cepstrum causality window with normalization
 // Applies: 1/N normalization (cuFFT doesn't normalize IFFT)
 // Plus causality: c[0] unchanged, c[1..N/2-1] *= 2, c[N/2] unchanged, c[N/2+1..N-1] = 0

--- a/src/gpu/convolution_kernels.cu
+++ b/src/gpu/convolution_kernels.cu
@@ -39,6 +39,13 @@ __global__ void scaleKernel(DeviceSample* data, int size, DeviceScale scale) {
     }
 }
 
+// CUDA kernel to upconvert float samples to active precision samples
+__global__ void upconvertFromFloatKernel(const float* input, DeviceSample* output, int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= size) return;
+    output[idx] = static_cast<DeviceSample>(input[idx]);
+}
+
 // CUDA kernel for cepstrum causality window with normalization
 // Applies: 1/N normalization (cuFFT doesn't normalize IFFT)
 // Plus causality: c[0] unchanged, c[1..N/2-1] *= 2, c[N/2] unchanged, c[N/2+1..N-1] = 0


### PR DESCRIPTION
## Summary
- float64(=GPU_UPSAMPLER_USE_FLOAT64)のストリーミング経路で、host(float)->device(double)変換に短命バッファを `cudaMemcpyAsync` へ渡していたため入力が破壊され、出力レベルが極小になる問題を修正しました。
- float->active precision のGPU変換カーネルを追加し、コピー経路を共通ヘルパに統一しました。
- 回帰テスト `ConvolutionEngineTest.Issue839_StreamBlock_NotAttenuated` を追加しました。

## Links
- Fix #839

## Test plan
- [x] `GPU_UPSAMPLER_USE_FLOAT64=ON` でビルド
- [x] `ctest -R ConvolutionEngineTest\\.Issue839_StreamBlock_NotAttenuated` が通る