### PR TITLE
Fix: 存在しないgpu_upsampler_daemonへの参照を削除

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,7 +15,6 @@ cmake-build-*/
 # Exclude most of build/ but keep binaries for Docker
 build/*
 !build/gpu_upsampler_alsa
-!build/gpu_upsampler_daemon
 
 # IDE
 .idea/

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,12 +31,12 @@ docker compose -f jetson/docker-compose.jetson.yml down
 - `restart: always` を指定済み。systemd で単体起動する場合も `Restart=always` を付け、片側クラッシュ時に自動復帰させてください。
 
 ## Magic Box コンテナの事前ビルド（Jetson 本体で実行）
-`docker/jetson/Dockerfile.jetson` はホストでビルド済みのバイナリをコピーする前提です。コンテナを立ち上げる前に Jetson 上で以下を実行し、`build/gpu_upsampler_alsa` と `build/gpu_upsampler_daemon` を用意してください。
+`docker/jetson/Dockerfile.jetson` はホストでビルド済みのバイナリをコピーする前提です。コンテナを立ち上げる前に Jetson 上で以下を実行し、`build/gpu_upsampler_alsa` を用意してください。
 
 ```bash
 cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=87
 cmake --build build -j$(nproc)
-ls -l build/gpu_upsampler_alsa build/gpu_upsampler_daemon
+ls -l build/gpu_upsampler_alsa
 ```
 
 ビルド手順の詳細は `../docs/setup/build.md` を参照してください。

--- a/docker/jetson/Dockerfile.jetson
+++ b/docker/jetson/Dockerfile.jetson
@@ -63,10 +63,8 @@ RUN mkdir -p bin build && mkdir -p /var/log/gpu_upsampler
 
 # Copy pre-built binaries from host (same architecture)
 COPY build/gpu_upsampler_alsa build/gpu_upsampler_alsa
-COPY build/gpu_upsampler_daemon build/gpu_upsampler_daemon
-RUN chmod +x build/gpu_upsampler_alsa build/gpu_upsampler_daemon \
-    && ln -sf ../build/gpu_upsampler_alsa bin/gpu_upsampler_alsa \
-    && ln -sf ../build/gpu_upsampler_daemon bin/gpu_upsampler_daemon
+RUN chmod +x build/gpu_upsampler_alsa \
+    && ln -sf ../build/gpu_upsampler_alsa bin/gpu_upsampler_alsa
 
 # Copy data files (filter coefficients + EQ)
 COPY data/coefficients/ data/coefficients/


### PR DESCRIPTION
問題:
- Dockerfile.jetsonが存在しないgpu_upsampler_daemonをコピーしようとしていた
- これによりDocker buildが失敗していた

原因:
- gpu_upsampler_daemonは古い名残
- 実際にはgpu_upsampler_alsaがデーモン本体として使用されている
- entrypoint.shでもgpu_upsampler_alsaのみが参照されている

変更内容:
- docker/jetson/Dockerfile.jetson: gpu_upsampler_daemonのCOPY/chmod/lnを削除
- docker/README.md: ビルド手順からgpu_upsampler_daemonの記述を削除
- .dockerignore: gpu_upsampler_daemonの除外ルールを削除

期待される結果:
- Docker buildが正常に完了する

🤖 Generated with [Claude Code](https://claude.com/claude-code)