### PR TITLE
#859 ステータス表示の翻訳埋め込みバグ修正

### DIFF
--- a/web/templates/pages/dashboard.html
+++ b/web/templates/pages/dashboard.html
@@ -16,28 +16,28 @@
         {% set status_icon = "⚙️" %}
         {% set status_title = t.get('dashboard.daemon') %}
         {% set status_class = "status.daemon_running ? 'status-ok' : 'status-error'" %}
-        {% set status_text = "status.daemon_running ? '{{ t.get('dashboard.status.running') }}' : '{{ t.get('dashboard.status.stopped') }}'" %}
+        {% set status_text = "status.daemon_running ? '" ~ t.get('dashboard.status.running') ~ "' : '" ~ t.get('dashboard.status.stopped') ~ "'" %}
         {% include 'components/status_card.html' %}
 
         <!-- EQ Status Card -->
         {% set status_icon = "🎚️" %}
         {% set status_title = t.get('dashboard.eq') %}
         {% set status_class = "status.eq_active ? 'status-ok' : 'status-off'" %}
-        {% set status_text = "status.eq_active ? '{{ t.get('dashboard.status.on') }}' : '{{ t.get('dashboard.status.off') }}'" %}
+        {% set status_text = "status.eq_active ? '" ~ t.get('dashboard.status.on') ~ "' : '" ~ t.get('dashboard.status.off') ~ "'" %}
         {% include 'components/status_card.html' %}
 
         <!-- Crossfeed Status Card -->
         {% set status_icon = "🎧" %}
         {% set status_title = t.get('dashboard.crossfeed') %}
         {% set status_class = "status.crossfeed_enabled ? 'status-ok' : 'status-off'" %}
-        {% set status_text = "status.crossfeed_enabled ? '{{ t.get('dashboard.status.on') }}' : '{{ t.get('dashboard.status.off') }}'" %}
+        {% set status_text = "status.crossfeed_enabled ? '" ~ t.get('dashboard.status.on') ~ "' : '" ~ t.get('dashboard.status.off') ~ "'" %}
         {% include 'components/status_card.html' %}
 
         <!-- Low Latency Mode Card -->
         {% set status_icon = "⚡" %}
         {% set status_title = t.get('dashboard.low_latency') %}
         {% set status_class = "status.low_latency_enabled ? 'status-ok' : 'status-off'" %}
-        {% set status_text = "status.low_latency_enabled ? '{{ t.get('dashboard.status.on') }}' : '{{ t.get('dashboard.status.off') }}'" %}
+        {% set status_text = "status.low_latency_enabled ? '" ~ t.get('dashboard.status.on') ~ "' : '" ~ t.get('dashboard.status.off') ~ "'" %}
         {% include 'components/status_card.html' %}
 
     </div>

--- a/web/templates/pages/system_settings.html
+++ b/web/templates/pages/system_settings.html
@@ -28,19 +28,19 @@
             {% set status_icon = "⚙️" %}
             {% set status_title = t.get('system.health.daemon') %}
             {% set status_class = "health.daemon_running ? 'status-ok' : 'status-error'" %}
-            {% set status_text = "health.daemon_running ? '{{ t.get('system.daemon.running') }}' : '{{ t.get('system.daemon.stopped') }}'" %}
+            {% set status_text = "health.daemon_running ? '" ~ t.get('system.daemon.running') ~ "' : '" ~ t.get('system.daemon.stopped') ~ "'" %}
             {% include 'components/status_card.html' %}
 
             {% set status_icon = "🎚️" %}
             {% set status_title = t.get('system.health.input_rate') %}
             {% set status_class = "health.input_rate > 0 ? 'status-ok' : 'status-off'" %}
-            {% set status_text = "health.input_rate ? `${health.input_rate} Hz` : '{{ t.get('system.health.na') }}'" %}
+            {% set status_text = "health.input_rate ? `${health.input_rate} Hz` : '" ~ t.get('system.health.na') ~ "'" %}
             {% include 'components/status_card.html' %}
 
             {% set status_icon = "🎛️" %}
             {% set status_title = t.get('system.health.output_rate') %}
             {% set status_class = "health.output_rate > 0 ? 'status-ok' : 'status-off'" %}
-            {% set status_text = "health.output_rate ? `${health.output_rate} Hz` : '{{ t.get('system.health.na') }}'" %}
+            {% set status_text = "health.output_rate ? `${health.output_rate} Hz` : '" ~ t.get('system.health.na') ~ "'" %}
             {% include 'components/status_card.html' %}
         </div>
     </div>


### PR DESCRIPTION
## Summary
- ダッシュボードのステータスカードで翻訳値を正しく文字列連結して埋め込み、Alpine.js の `x-text` に生の `{{ ... }}` 表示が入らないようにしました
- システム画面のステータスカードでも翻訳値を安全に結合するように揃え、i18n が読めていないときの未翻訳表示を防ぎました

## Testing
- pytest web/tests *(fails: `web/tests/test_rtp_input_service.py::test_build_gst_command_supports_encodings` expects `rtpbin.recv_rtp_src_0 !` while the generated pipeline still uses `rtpbin.recv_rtp_sink_0`; unrelated to this change)*