### PR TITLE
#869 RuntimeState導入

### DIFF
--- a/include/daemon/app/runtime_state.h
+++ b/include/daemon/app/runtime_state.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#include "audio/filter_headroom.h"
+#include "audio/soft_mute.h"
+#include "convolution_engine.h"
+#include "core/config_loader.h"
+#include "core/daemon_constants.h"
+#include "crossfeed_engine.h"
+#include "daemon/api/dependencies.h"
+
+#include <alsa/asoundlib.h>
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace audio_pipeline {
+class AudioPipeline;
+class RateSwitcher;
+class FilterManager;
+class SoftMuteRunner;
+}  // namespace audio_pipeline
+
+namespace streaming_cache {
+class StreamingCacheManager;
+}  // namespace streaming_cache
+
+namespace daemon_output {
+class PlaybackBufferManager;
+class AlsaOutput;
+}  // namespace daemon_output
+
+namespace daemon_control::handlers {
+class HandlerRegistry;
+}  // namespace daemon_control::handlers
+
+namespace dac {
+class DacManager;
+}  // namespace dac
+
+namespace FallbackManager {
+class Manager;
+}  // namespace FallbackManager
+
+namespace daemon_app {
+
+using StreamFloatVector = ConvolutionEngine::StreamFloatVector;
+
+struct GainState {
+    std::atomic<float> output{1.0f};
+    std::atomic<float> headroom{1.0f};
+    std::atomic<float> limiter{1.0f};
+    std::atomic<float> effective{1.0f};
+};
+
+struct RateState {
+    std::atomic<int> currentInputRate{DaemonConstants::DEFAULT_INPUT_SAMPLE_RATE};
+    std::atomic<int> currentOutputRate{DaemonConstants::DEFAULT_OUTPUT_SAMPLE_RATE};
+    std::atomic<int> currentRateFamilyInt{
+        static_cast<int>(ConvolutionEngine::RateFamily::RATE_44K)};
+    std::atomic<int> pendingRateChange{0};
+    std::atomic<bool> alsaReconfigureNeeded{false};
+    std::atomic<int> alsaNewOutputRate{0};
+
+    ConvolutionEngine::RateFamily activeRateFamily = ConvolutionEngine::RateFamily::RATE_44K;
+    PhaseType activePhaseType = PhaseType::Minimum;
+    int inputSampleRate = DaemonConstants::DEFAULT_INPUT_SAMPLE_RATE;
+};
+
+struct ControlFlags {
+    std::atomic<bool> running{true};
+    std::atomic<bool> reloadRequested{false};
+    std::atomic<bool> zmqBindFailed{false};
+    std::atomic<bool> outputReady{false};
+};
+
+struct SoftMuteState {
+    SoftMute::Controller* controller = nullptr;
+    std::mutex opMutex;
+    std::atomic<bool> restorePending{false};
+    std::atomic<int> restoreFadeMs{0};
+    std::atomic<int> restoreSampleRate{0};
+};
+
+struct PlaybackState {
+    std::unique_ptr<daemon_output::PlaybackBufferManager> buffer;
+};
+
+struct StreamingState {
+    StreamFloatVector streamInputLeft;
+    StreamFloatVector streamInputRight;
+    size_t streamAccumulatedLeft = 0;
+    size_t streamAccumulatedRight = 0;
+    StreamFloatVector upsamplerOutputLeft;
+    StreamFloatVector upsamplerOutputRight;
+
+    std::mutex streamingMutex;
+};
+
+struct CrossfeedState {
+    CrossfeedEngine::HRTFProcessor* processor = nullptr;
+    std::atomic<bool> enabled{false};
+    std::vector<float> cfStreamInputLeft;
+    std::vector<float> cfStreamInputRight;
+    size_t cfStreamAccumulatedLeft = 0;
+    size_t cfStreamAccumulatedRight = 0;
+    std::vector<float> cfOutputLeft;
+    std::vector<float> cfOutputRight;
+    std::vector<float> cfOutputBufferLeft;
+    std::vector<float> cfOutputBufferRight;
+    std::mutex crossfeedMutex;
+};
+
+struct LoopbackState {
+    std::mutex handleMutex;
+    snd_pcm_t* handle = nullptr;
+    std::atomic<bool> captureRunning{false};
+    std::atomic<bool> captureReady{false};
+};
+
+struct ManagerState {
+    std::unique_ptr<streaming_cache::StreamingCacheManager> streamingCacheManager;
+    std::unique_ptr<daemon_core::api::EventDispatcher> eventDispatcher;
+    daemon_core::api::DaemonDependencies daemonDependencies{};
+
+    audio_pipeline::AudioPipeline* audioPipelineRaw = nullptr;
+    dac::DacManager* dacManagerRaw = nullptr;
+
+    std::unique_ptr<audio_pipeline::RateSwitcher> rateSwitcher;
+    std::unique_ptr<audio_pipeline::FilterManager> filterManager;
+    std::unique_ptr<audio_pipeline::SoftMuteRunner> softMuteRunner;
+    std::unique_ptr<daemon_output::AlsaOutput> alsaOutputInterface;
+    std::unique_ptr<daemon_control::handlers::HandlerRegistry> handlerRegistry;
+    std::unique_ptr<dac::DacManager> dacManager;
+};
+
+struct RuntimeState {
+    AppConfig config;
+    GainState gains;
+    FilterHeadroomCache headroomCache;
+
+    ControlFlags flags;
+    RateState rates;
+
+    ConvolutionEngine::GPUUpsampler* upsampler = nullptr;
+    std::mutex inputProcessMutex;
+    std::unique_ptr<audio_pipeline::AudioPipeline> audioPipeline;
+
+    SoftMuteState softMute;
+    PlaybackState playback;
+    StreamingState streaming;
+    CrossfeedState crossfeed;
+    ManagerState managers;
+    LoopbackState loopback;
+
+    FallbackManager::Manager* fallbackManager = nullptr;
+    std::atomic<bool> fallbackActive{false};
+    int pidLockFd = -1;
+};
+
+}  // namespace daemon_app

--- a/src/alsa_daemon.cpp
+++ b/src/alsa_daemon.cpp
@@ -11,6 +11,7 @@
 #include "crossfeed_engine.h"
 #include "daemon/api/dependencies.h"
 #include "daemon/api/events.h"
+#include "daemon/app/runtime_state.h"
 #include "daemon/audio_pipeline/audio_pipeline.h"
 #include "daemon/audio_pipeline/filter_manager.h"
 #include "daemon/audio_pipeline/rate_switcher.h"
@@ -153,32 +154,16 @@ static void ensure_output_config(AppConfig& config) {
 }
 
 // Runtime configuration (loaded from config.json)
-static AppConfig g_config;
-static std::atomic<float> g_output_gain{1.0f};
-static std::atomic<float> g_headroom_gain{1.0f};
-static FilterHeadroomCache g_headroom_cache;
-static ConvolutionEngine::RateFamily g_active_rate_family = ConvolutionEngine::RateFamily::RATE_44K;
-static PhaseType g_active_phase_type = PhaseType::Minimum;
-static std::atomic<float> g_limiter_gain{1.0f};
-static std::atomic<float> g_effective_gain{1.0f};
+static daemon_app::RuntimeState g_state;
 
-// Global state
-static std::atomic<bool> g_running{true};
-static std::atomic<bool> g_reload_requested{false};
-static std::atomic<bool> g_zmq_bind_failed{false};  // True if ZeroMQ bind failed
-static std::atomic<bool> g_output_ready{false};  // Indicates ALSA DAC is ready for input processing
-static ConvolutionEngine::GPUUpsampler* g_upsampler = nullptr;
-static std::mutex g_input_process_mutex;
+inline ConvolutionEngine::RateFamily g_get_rate_family() {
+    return static_cast<ConvolutionEngine::RateFamily>(
+        g_state.rates.currentRateFamilyInt.load(std::memory_order_acquire));
+}
 
-static std::unique_ptr<audio_pipeline::AudioPipeline> g_audio_pipeline;
-
-// Runtime state: Input sample rate (auto-negotiated, not from config)
-// Detected from the active input path (TCP/loopback) or defaulted to 44.1 kHz
-// Issue #219: Changed to atomic for thread-safe multi-rate switching
-static std::atomic<int> g_current_input_rate{DEFAULT_INPUT_SAMPLE_RATE};
-static std::atomic<int> g_current_output_rate{DEFAULT_OUTPUT_SAMPLE_RATE};
-static std::atomic<int> g_current_rate_family_int{
-    static_cast<int>(ConvolutionEngine::RateFamily::RATE_44K)};
+inline void g_set_rate_family(ConvolutionEngine::RateFamily family) {
+    g_state.rates.currentRateFamilyInt.store(static_cast<int>(family), std::memory_order_release);
+}
 
 static size_t get_max_output_buffer_frames() {
     using namespace DaemonConstants;
@@ -187,7 +172,7 @@ static size_t get_max_output_buffer_frames() {
         return DEFAULT_MAX_OUTPUT_BUFFER_FRAMES;
     }
 
-    int outputRate = g_current_output_rate.load(std::memory_order_acquire);
+    int outputRate = g_state.rates.currentOutputRate.load(std::memory_order_acquire);
     if (outputRate <= 0) {
         outputRate = DEFAULT_OUTPUT_SAMPLE_RATE;
     }
@@ -201,52 +186,28 @@ static size_t get_max_output_buffer_frames() {
 
 // Pending rate change (set by input event handlers, processed in main loop)
 // Value: 0 = no change pending, >0 = detected input sample rate
-static std::atomic<int> g_pending_rate_change{0};
-
-// ALSA reconfiguration flags (set when output rate changes)
-static std::atomic<bool> g_alsa_reconfigure_needed{false};
-static std::atomic<int> g_alsa_new_output_rate{0};
-
-// Helper to get/set rate family atomically
-inline ConvolutionEngine::RateFamily g_get_rate_family() {
-    return static_cast<ConvolutionEngine::RateFamily>(
-        g_current_rate_family_int.load(std::memory_order_acquire));
-}
-inline void g_set_rate_family(ConvolutionEngine::RateFamily family) {
-    g_current_rate_family_int.store(static_cast<int>(family), std::memory_order_release);
-}
-
-// Legacy alias (for backward compatibility with existing code)
-static int g_input_sample_rate = DEFAULT_INPUT_SAMPLE_RATE;
-
-// Soft Mute controller for glitch-free shutdown (50ms fade at output sample rate)
-static SoftMute::Controller* g_soft_mute = nullptr;
-static std::mutex g_soft_mute_op_mutex;
-static std::atomic<bool> g_soft_mute_restore_pending{false};
-static std::atomic<int> g_soft_mute_restore_fade_ms{0};
-static std::atomic<int> g_soft_mute_restore_sample_rate{0};
 
 static void maybe_restore_soft_mute_params() {
-    if (!g_soft_mute) {
+    if (!g_state.softMute.controller) {
         return;
     }
-    if (!g_soft_mute_restore_pending.load(std::memory_order_acquire)) {
+    if (!g_state.softMute.restorePending.load(std::memory_order_acquire)) {
         return;
     }
-    SoftMute::MuteState st = g_soft_mute->getState();
+    SoftMute::MuteState st = g_state.softMute.controller->getState();
     if (st != SoftMute::MuteState::PLAYING && st != SoftMute::MuteState::MUTED) {
         return;
     }
 
-    std::lock_guard<std::mutex> lock(g_soft_mute_op_mutex);
-    if (!g_soft_mute) {
+    std::lock_guard<std::mutex> lock(g_state.softMute.opMutex);
+    if (!g_state.softMute.controller) {
         return;
     }
-    int fadeMs = g_soft_mute_restore_fade_ms.load(std::memory_order_relaxed);
-    int sr = g_soft_mute_restore_sample_rate.load(std::memory_order_relaxed);
-    g_soft_mute->setFadeDuration(fadeMs);
-    g_soft_mute->setSampleRate(sr);
-    g_soft_mute_restore_pending.store(false, std::memory_order_release);
+    int fadeMs = g_state.softMute.restoreFadeMs.load(std::memory_order_relaxed);
+    int sr = g_state.softMute.restoreSampleRate.load(std::memory_order_relaxed);
+    g_state.softMute.controller->setFadeDuration(fadeMs);
+    g_state.softMute.controller->setSampleRate(sr);
+    g_state.softMute.restorePending.store(false, std::memory_order_release);
 }
 
 // Helper function for soft mute during filter switching (Issue #266)
@@ -260,37 +221,37 @@ static void maybe_restore_soft_mute_params() {
 static void applySoftMuteForFilterSwitch(std::function<bool()> filterSwitchFunc) {
     using namespace DaemonConstants;
 
-    if (!g_soft_mute) {
+    if (!g_state.softMute.controller) {
         // If soft mute not initialized, perform switch without mute
         filterSwitchFunc();
         return;
     }
 
-    std::lock_guard<std::mutex> lock(g_soft_mute_op_mutex);
+    std::lock_guard<std::mutex> lock(g_state.softMute.opMutex);
 
     // Cancel any stale pending restore (new switch supersedes)
-    g_soft_mute_restore_pending.store(false, std::memory_order_release);
+    g_state.softMute.restorePending.store(false, std::memory_order_release);
 
     // Save current fade duration for restoration
-    int originalFadeDuration = g_soft_mute->getFadeDuration();
-    int outputSampleRate = g_soft_mute->getSampleRate();
+    int originalFadeDuration = g_state.softMute.controller->getFadeDuration();
+    int outputSampleRate = g_state.softMute.controller->getSampleRate();
 
     // Update fade duration for filter switching
     // Note: This is called from command thread, but audio thread may be processing.
     // The fade calculation will use the new duration from the next audio frame.
-    g_soft_mute->setFadeDuration(FILTER_SWITCH_FADE_MS);
-    g_soft_mute->setSampleRate(outputSampleRate);
+    g_state.softMute.controller->setFadeDuration(FILTER_SWITCH_FADE_MS);
+    g_state.softMute.controller->setSampleRate(outputSampleRate);
 
     std::cout << "[Filter Switch] Starting fade-out (" << (FILTER_SWITCH_FADE_MS / 1000.0)
               << "s)..." << '\n';
-    g_soft_mute->startFadeOut();
+    g_state.softMute.controller->startFadeOut();
 
     // Wait briefly until mostly muted (or timeout) to avoid pops, but keep command responsive
     auto fade_start = std::chrono::steady_clock::now();
     const auto quick_timeout = std::chrono::milliseconds(250);
     while (true) {
-        SoftMute::MuteState st = g_soft_mute->getState();
-        float gain = g_soft_mute->getCurrentGain();
+        SoftMute::MuteState st = g_state.softMute.controller->getState();
+        float gain = g_state.softMute.controller->getCurrentGain();
         if (st == SoftMute::MuteState::MUTED || gain < 0.05f) {
             break;
         }
@@ -307,138 +268,86 @@ static void applySoftMuteForFilterSwitch(std::function<bool()> filterSwitchFunc)
         // Start fade-in after filter switch
         std::cout << "[Filter Switch] Starting fade-in (" << (FILTER_SWITCH_FADE_MS / 1000.0)
                   << "s)..." << '\n';
-        g_soft_mute->startFadeIn();
+        g_state.softMute.controller->startFadeIn();
 
         // Mark pending restoration to be applied once transition completes
-        g_soft_mute_restore_fade_ms.store(originalFadeDuration, std::memory_order_relaxed);
-        g_soft_mute_restore_sample_rate.store(outputSampleRate, std::memory_order_relaxed);
-        g_soft_mute_restore_pending.store(true, std::memory_order_release);
+        g_state.softMute.restoreFadeMs.store(originalFadeDuration, std::memory_order_relaxed);
+        g_state.softMute.restoreSampleRate.store(outputSampleRate, std::memory_order_relaxed);
+        g_state.softMute.restorePending.store(true, std::memory_order_release);
     } else {
         // If switch failed, restore original state immediately
         std::cerr << "[Filter Switch] Switch failed, restoring audio state" << '\n';
-        g_soft_mute->setPlaying();
-        g_soft_mute->setFadeDuration(originalFadeDuration);
-        g_soft_mute->setSampleRate(outputSampleRate);
+        g_state.softMute.controller->setPlaying();
+        g_state.softMute.controller->setFadeDuration(originalFadeDuration);
+        g_state.softMute.controller->setSampleRate(outputSampleRate);
     }
 }
 
 // Audio buffer for thread communication (managed component)
-static std::unique_ptr<daemon_output::PlaybackBufferManager> g_playback_buffer;
-
 static daemon_output::PlaybackBufferManager& playback_buffer() {
-    if (!g_playback_buffer) {
-        g_playback_buffer = std::make_unique<daemon_output::PlaybackBufferManager>(
+    if (!g_state.playback.buffer) {
+        g_state.playback.buffer = std::make_unique<daemon_output::PlaybackBufferManager>(
             []() { return get_max_output_buffer_frames(); });
     }
-    return *g_playback_buffer;
+    return *g_state.playback.buffer;
 }
 
-// Streaming input accumulation buffers
-static StreamFloatVector g_stream_input_left;
-static StreamFloatVector g_stream_input_right;
-static size_t g_stream_accumulated_left = 0;
-static size_t g_stream_accumulated_right = 0;
-static StreamFloatVector g_upsampler_output_left;
-static StreamFloatVector g_upsampler_output_right;
-
-// Crossfeed (HRTF) processor
-static CrossfeedEngine::HRTFProcessor* g_hrtf_processor = nullptr;
-static std::atomic<bool> g_crossfeed_enabled{false};  // Atomic for quick check
-static std::vector<float> g_cf_stream_input_left;
-static std::vector<float> g_cf_stream_input_right;
-static size_t g_cf_stream_accumulated_left = 0;
-static size_t g_cf_stream_accumulated_right = 0;
-static std::vector<float> g_cf_output_left;
-static std::vector<float> g_cf_output_right;
-static std::mutex g_crossfeed_mutex;  // Protects HRTFProcessor and CF buffers
-static std::mutex g_streaming_mutex;  // Protects streaming buffer state during rate switch
-static std::vector<float> g_cf_output_buffer_left;
-static std::vector<float> g_cf_output_buffer_right;
-
-static std::unique_ptr<streaming_cache::StreamingCacheManager> g_streaming_cache_manager;
-
-static std::unique_ptr<daemon_core::api::EventDispatcher> g_event_dispatcher;
-static daemon_core::api::DaemonDependencies g_daemon_dependencies{
-    .config = &g_config,
-    .running = &g_running,
-    .outputReady = &g_output_ready,
-    .crossfeedEnabled = &g_crossfeed_enabled,
-    .currentInputRate = &g_current_input_rate,
-    .currentOutputRate = &g_current_output_rate,
-    .softMute = &g_soft_mute,
-    .upsampler = &g_upsampler,
-    .audioPipeline = nullptr,
-    .dacManager = nullptr,
-    .streamingMutex = &g_streaming_mutex,
-    .refreshHeadroom = refresh_current_headroom,
-};
-
-static audio_pipeline::AudioPipeline* g_audio_pipeline_raw = nullptr;
-static dac::DacManager* g_dac_manager_raw = nullptr;
-
-static std::unique_ptr<audio_pipeline::RateSwitcher> g_rate_switcher;
-static std::unique_ptr<audio_pipeline::FilterManager> g_filter_manager;
-static std::unique_ptr<audio_pipeline::SoftMuteRunner> g_soft_mute_runner;
-static std::unique_ptr<daemon_output::AlsaOutput> g_alsa_output_interface;
-static std::unique_ptr<daemon_control::handlers::HandlerRegistry> g_handler_registry;
-static std::mutex g_loopback_handle_mutex;
-static snd_pcm_t* g_loopback_handle = nullptr;
-static std::atomic<bool> g_loopback_capture_running{false};
-static std::atomic<bool> g_loopback_capture_ready{false};
-
 static void update_daemon_dependencies() {
-    g_daemon_dependencies.config = &g_config;
-    g_daemon_dependencies.running = &g_running;
-    g_daemon_dependencies.outputReady = &g_output_ready;
-    g_daemon_dependencies.crossfeedEnabled = &g_crossfeed_enabled;
-    g_daemon_dependencies.currentInputRate = &g_current_input_rate;
-    g_daemon_dependencies.currentOutputRate = &g_current_output_rate;
-    g_daemon_dependencies.softMute = &g_soft_mute;
-    g_daemon_dependencies.upsampler = &g_upsampler;
-    g_daemon_dependencies.audioPipeline = &g_audio_pipeline_raw;
-    g_daemon_dependencies.dacManager = &g_dac_manager_raw;
-    g_daemon_dependencies.streamingMutex = &g_streaming_mutex;
-    g_daemon_dependencies.refreshHeadroom = [](const std::string& reason) {
+    g_state.managers.daemonDependencies.config = &g_state.config;
+    g_state.managers.daemonDependencies.running = &g_state.flags.running;
+    g_state.managers.daemonDependencies.outputReady = &g_state.flags.outputReady;
+    g_state.managers.daemonDependencies.crossfeedEnabled = &g_state.crossfeed.enabled;
+    g_state.managers.daemonDependencies.currentInputRate = &g_state.rates.currentInputRate;
+    g_state.managers.daemonDependencies.currentOutputRate = &g_state.rates.currentOutputRate;
+    g_state.managers.daemonDependencies.softMute = &g_state.softMute.controller;
+    g_state.managers.daemonDependencies.upsampler = &g_state.upsampler;
+    g_state.managers.daemonDependencies.audioPipeline = &g_state.managers.audioPipelineRaw;
+    g_state.managers.daemonDependencies.dacManager = &g_state.managers.dacManagerRaw;
+    g_state.managers.daemonDependencies.streamingMutex = &g_state.streaming.streamingMutex;
+    g_state.managers.daemonDependencies.refreshHeadroom = [](const std::string& reason) {
         refresh_current_headroom(reason);
     };
 }
 
 static void initialize_event_modules() {
-    g_event_dispatcher = std::make_unique<daemon_core::api::EventDispatcher>();
+    g_state.managers.eventDispatcher = std::make_unique<daemon_core::api::EventDispatcher>();
     update_daemon_dependencies();
 
-    g_rate_switcher = std::make_unique<audio_pipeline::RateSwitcher>(
-        audio_pipeline::RateSwitcherDependencies{.dispatcher = g_event_dispatcher.get(),
-                                                 .deps = g_daemon_dependencies,
-                                                 .pendingRate = &g_pending_rate_change});
-    g_filter_manager =
+    g_state.managers.rateSwitcher =
+        std::make_unique<audio_pipeline::RateSwitcher>(audio_pipeline::RateSwitcherDependencies{
+            .dispatcher = g_state.managers.eventDispatcher.get(),
+            .deps = g_state.managers.daemonDependencies,
+            .pendingRate = &g_state.rates.pendingRateChange});
+    g_state.managers.filterManager =
         std::make_unique<audio_pipeline::FilterManager>(audio_pipeline::FilterManagerDependencies{
-            .dispatcher = g_event_dispatcher.get(), .deps = g_daemon_dependencies});
-    g_soft_mute_runner =
+            .dispatcher = g_state.managers.eventDispatcher.get(),
+            .deps = g_state.managers.daemonDependencies});
+    g_state.managers.softMuteRunner =
         std::make_unique<audio_pipeline::SoftMuteRunner>(audio_pipeline::SoftMuteRunnerDependencies{
-            .dispatcher = g_event_dispatcher.get(), .deps = g_daemon_dependencies});
-    g_alsa_output_interface =
-        std::make_unique<daemon_output::AlsaOutput>(daemon_output::AlsaOutputDependencies{
-            .dispatcher = g_event_dispatcher.get(), .deps = g_daemon_dependencies});
-    g_handler_registry = std::make_unique<daemon_control::handlers::HandlerRegistry>(
-        daemon_control::handlers::HandlerRegistryDependencies{.dispatcher =
-                                                                  g_event_dispatcher.get()});
+            .dispatcher = g_state.managers.eventDispatcher.get(),
+            .deps = g_state.managers.daemonDependencies});
+    g_state.managers.alsaOutputInterface = std::make_unique<daemon_output::AlsaOutput>(
+        daemon_output::AlsaOutputDependencies{.dispatcher = g_state.managers.eventDispatcher.get(),
+                                              .deps = g_state.managers.daemonDependencies});
+    g_state.managers.handlerRegistry = std::make_unique<daemon_control::handlers::HandlerRegistry>(
+        daemon_control::handlers::HandlerRegistryDependencies{
+            .dispatcher = g_state.managers.eventDispatcher.get()});
 
-    g_rate_switcher->start();
-    g_filter_manager->start();
-    g_soft_mute_runner->start();
-    g_alsa_output_interface->start();
-    g_handler_registry->registerDefaults();
+    g_state.managers.rateSwitcher->start();
+    g_state.managers.filterManager->start();
+    g_state.managers.softMuteRunner->start();
+    g_state.managers.alsaOutputInterface->start();
+    g_state.managers.handlerRegistry->registerDefaults();
 }
 
 static void publish_rate_change_event(int detected_rate) {
-    if (!g_rate_switcher || !g_event_dispatcher) {
+    if (!g_state.managers.rateSwitcher || !g_state.managers.eventDispatcher) {
         return;
     }
     daemon_core::api::RateChangeRequested event;
     event.detectedInputRate = detected_rate;
     event.rateFamily = ConvolutionEngine::detectRateFamily(detected_rate);
-    g_event_dispatcher->publish(event);
+    g_state.managers.eventDispatcher->publish(event);
 }
 
 static void publish_filter_switch_event(const std::string& filterPath, PhaseType phaseType,
@@ -447,8 +356,8 @@ static void publish_filter_switch_event(const std::string& filterPath, PhaseType
     event.filterPath = filterPath;
     event.phaseType = phaseType;
     event.reloadHeadroom = reloadHeadroom;
-    if (g_event_dispatcher) {
-        g_event_dispatcher->publish(event);
+    if (g_state.managers.eventDispatcher) {
+        g_state.managers.eventDispatcher->publish(event);
     }
 }
 
@@ -476,20 +385,20 @@ static size_t get_playback_ready_threshold(size_t period_size) {
     size_t crossfeedBlockSize = 0;
     size_t producerBlockSize = 0;
 
-    if (g_crossfeed_enabled.load(std::memory_order_relaxed)) {
-        std::lock_guard<std::mutex> cf_lock(g_crossfeed_mutex);
-        if (g_hrtf_processor && g_hrtf_processor->isEnabled()) {
+    if (g_state.crossfeed.enabled.load(std::memory_order_relaxed)) {
+        std::lock_guard<std::mutex> cf_lock(g_state.crossfeed.crossfeedMutex);
+        if (g_state.crossfeed.processor && g_state.crossfeed.processor->isEnabled()) {
             crossfeedActive = true;
-            crossfeedBlockSize = g_hrtf_processor->getStreamValidInputPerBlock();
+            crossfeedBlockSize = g_state.crossfeed.processor->getStreamValidInputPerBlock();
         }
     }
 
-    if (g_upsampler) {
+    if (g_state.upsampler) {
         // StreamValidInputPerBlock() is in input frames. Multiply by upsample ratio to obtain the
         // number of samples the producer actually contributes to the playback ring per block so the
         // ALSA thread can wake up as soon as a full GPU block finishes.
-        size_t streamBlock = g_upsampler->getStreamValidInputPerBlock();
-        int upsampleRatio = g_upsampler->getUpsampleRatio();
+        size_t streamBlock = g_state.upsampler->getStreamValidInputPerBlock();
+        int upsampleRatio = g_state.upsampler->getUpsampleRatio();
         if (streamBlock > 0 && upsampleRatio > 0) {
             producerBlockSize = streamBlock * static_cast<size_t>(upsampleRatio);
         }
@@ -500,41 +409,40 @@ static size_t get_playback_ready_threshold(size_t period_size) {
 }
 
 // Fallback manager (Issue #139)
-static FallbackManager::Manager* g_fallback_manager = nullptr;
-static std::atomic<bool> g_fallback_active{false};  // Atomic for quick check in audio thread
 
 // Resets crossfeed streaming buffers and GPU overlap state.
-// Caller must hold g_crossfeed_mutex.
+// Caller must hold g_state.crossfeed.crossfeedMutex.
 static void reset_crossfeed_stream_state_locked() {
-    g_cf_stream_input_left.clear();
-    g_cf_stream_input_right.clear();
-    g_cf_stream_accumulated_left = 0;
-    g_cf_stream_accumulated_right = 0;
-    g_cf_output_left.clear();
-    g_cf_output_right.clear();
-    if (g_hrtf_processor) {
-        g_hrtf_processor->resetStreaming();
+    g_state.crossfeed.cfStreamInputLeft.clear();
+    g_state.crossfeed.cfStreamInputRight.clear();
+    g_state.crossfeed.cfStreamAccumulatedLeft = 0;
+    g_state.crossfeed.cfStreamAccumulatedRight = 0;
+    g_state.crossfeed.cfOutputLeft.clear();
+    g_state.crossfeed.cfOutputRight.clear();
+    if (g_state.crossfeed.processor) {
+        g_state.crossfeed.processor->resetStreaming();
     }
 }
 
 static void initialize_streaming_cache_manager() {
     streaming_cache::StreamingCacheDependencies deps;
-    deps.inputMutex = &g_input_process_mutex;
+    deps.inputMutex = &g_state.inputProcessMutex;
     deps.resetPlaybackBuffer = []() { playback_buffer().reset(); };
 
-    deps.streamInputLeft = &g_stream_input_left;
-    deps.streamInputRight = &g_stream_input_right;
-    deps.streamAccumulatedLeft = &g_stream_accumulated_left;
-    deps.streamAccumulatedRight = &g_stream_accumulated_right;
-    deps.streamingMutex = &g_streaming_mutex;
+    deps.streamInputLeft = &g_state.streaming.streamInputLeft;
+    deps.streamInputRight = &g_state.streaming.streamInputRight;
+    deps.streamAccumulatedLeft = &g_state.streaming.streamAccumulatedLeft;
+    deps.streamAccumulatedRight = &g_state.streaming.streamAccumulatedRight;
+    deps.streamingMutex = &g_state.streaming.streamingMutex;
 
-    deps.upsamplerPtr = &g_upsampler;
-    deps.softMute = &g_soft_mute;
+    deps.upsamplerPtr = &g_state.upsampler;
+    deps.softMute = &g_state.softMute.controller;
     deps.onCrossfeedReset = []() {
-        std::lock_guard<std::mutex> cf_lock(g_crossfeed_mutex);
+        std::lock_guard<std::mutex> cf_lock(g_state.crossfeed.crossfeedMutex);
         reset_crossfeed_stream_state_locked();
     };
-    g_streaming_cache_manager = std::make_unique<streaming_cache::StreamingCacheManager>(deps);
+    g_state.managers.streamingCacheManager =
+        std::make_unique<streaming_cache::StreamingCacheManager>(deps);
 }
 
 // ========== DAC Device Monitoring ==========
@@ -548,36 +456,33 @@ static inline int64_t get_timestamp_ms() {
 static dac::DacManager::Dependencies make_dac_dependencies(
     std::function<void(const nlohmann::json&)> eventPublisher = {}) {
     dac::DacManager::Dependencies deps;
-    deps.config = &g_config;
-    deps.runningFlag = &g_running;
+    deps.config = &g_state.config;
+    deps.runningFlag = &g_state.flags.running;
     deps.timestampProvider = get_timestamp_ms;
     deps.eventPublisher = std::move(eventPublisher);
     deps.defaultDevice = DEFAULT_ALSA_DEVICE;
     return deps;
 }
 
-static std::unique_ptr<dac::DacManager> g_dac_manager;
-
 static runtime_stats::Dependencies build_runtime_stats_dependencies() {
     runtime_stats::Dependencies deps;
-    deps.config = &g_config;
-    deps.upsampler = g_upsampler;
-    deps.headroomCache = &g_headroom_cache;
-    deps.dacManager = g_dac_manager.get();
-    deps.fallbackManager = g_fallback_manager;
-    deps.fallbackActive = &g_fallback_active;
-    deps.inputSampleRate = &g_input_sample_rate;
-    deps.headroomGain = &g_headroom_gain;
-    deps.outputGain = &g_output_gain;
-    deps.limiterGain = &g_limiter_gain;
-    deps.effectiveGain = &g_effective_gain;
+    deps.config = &g_state.config;
+    deps.upsampler = g_state.upsampler;
+    deps.headroomCache = &g_state.headroomCache;
+    deps.dacManager = g_state.managers.dacManager.get();
+    deps.fallbackManager = g_state.fallbackManager;
+    deps.fallbackActive = &g_state.fallbackActive;
+    deps.inputSampleRate = &g_state.rates.inputSampleRate;
+    deps.headroomGain = &g_state.gains.headroom;
+    deps.outputGain = &g_state.gains.output;
+    deps.limiterGain = &g_state.gains.limiter;
+    deps.effectiveGain = &g_state.gains.effective;
     return deps;
 }
 
 // ========== PID File Lock (flock-based) ==========
 
 // File descriptor for the PID lock file (kept open while running)
-static int g_pid_lock_fd = -1;
 
 // Read PID from lock file (for display purposes)
 static pid_t read_pid_from_lockfile() {
@@ -594,14 +499,14 @@ static pid_t read_pid_from_lockfile() {
 // Returns true if lock acquired, false if another instance is running
 static bool acquire_pid_lock() {
     // Open or create the lock file
-    g_pid_lock_fd = open(PID_FILE_PATH, O_RDWR | O_CREAT, 0644);
-    if (g_pid_lock_fd < 0) {
+    g_state.pidLockFd = open(PID_FILE_PATH, O_RDWR | O_CREAT, 0644);
+    if (g_state.pidLockFd < 0) {
         LOG_ERROR("Cannot open PID file: {} ({})", PID_FILE_PATH, strerror(errno));
         return false;
     }
 
     // Try to acquire exclusive lock (non-blocking)
-    if (flock(g_pid_lock_fd, LOCK_EX | LOCK_NB) < 0) {
+    if (flock(g_state.pidLockFd, LOCK_EX | LOCK_NB) < 0) {
         if (errno == EWOULDBLOCK) {
             // Another process holds the lock
             pid_t existing_pid = read_pid_from_lockfile();
@@ -614,17 +519,17 @@ static bool acquire_pid_lock() {
         } else {
             LOG_ERROR("Cannot lock PID file: {}", strerror(errno));
         }
-        close(g_pid_lock_fd);
-        g_pid_lock_fd = -1;
+        close(g_state.pidLockFd);
+        g_state.pidLockFd = -1;
         return false;
     }
 
     // Lock acquired - write our PID to the file
-    if (ftruncate(g_pid_lock_fd, 0) < 0) {
+    if (ftruncate(g_state.pidLockFd, 0) < 0) {
         LOG_WARN("Cannot truncate PID file");
     }
-    dprintf(g_pid_lock_fd, "%d\n", getpid());
-    fsync(g_pid_lock_fd);  // Ensure PID is written to disk
+    dprintf(g_state.pidLockFd, "%d\n", getpid());
+    fsync(g_state.pidLockFd);  // Ensure PID is written to disk
 
     return true;
 }
@@ -632,10 +537,10 @@ static bool acquire_pid_lock() {
 // Release PID lock and remove file
 // Note: Lock is automatically released when process exits (even on crash)
 static void release_pid_lock() {
-    if (g_pid_lock_fd >= 0) {
-        flock(g_pid_lock_fd, LOCK_UN);
-        close(g_pid_lock_fd);
-        g_pid_lock_fd = -1;
+    if (g_state.pidLockFd >= 0) {
+        flock(g_state.pidLockFd, LOCK_UN);
+        close(g_state.pidLockFd);
+        g_state.pidLockFd = -1;
     }
     // Remove the PID file on clean shutdown
     unlink(PID_FILE_PATH);
@@ -646,7 +551,7 @@ static void release_pid_lock() {
 // ========== Configuration ==========
 
 static void print_config_summary(const AppConfig& cfg) {
-    int outputRate = g_input_sample_rate * cfg.upsampleRatio;
+    int outputRate = g_state.rates.inputSampleRate * cfg.upsampleRatio;
     LOG_INFO("Config:");
     LOG_INFO("  ALSA device:    {}", cfg.alsaDevice);
     LOG_INFO("  Output mode:    {} (preferred USB device: {})", outputModeToString(cfg.output.mode),
@@ -655,7 +560,7 @@ static void print_config_summary(const AppConfig& cfg) {
              (cfg.loopback.enabled ? "enabled" : "disabled"), cfg.loopback.device,
              cfg.loopback.sampleRate, cfg.loopback.channels, cfg.loopback.format,
              cfg.loopback.periodFrames);
-    LOG_INFO("  Input rate:     {} Hz (auto-negotiated)", g_input_sample_rate);
+    LOG_INFO("  Input rate:     {} Hz (auto-negotiated)", g_state.rates.inputSampleRate);
     LOG_INFO("  Output rate:    {} Hz ({:.1f} kHz)", outputRate, outputRate / 1000.0);
     LOG_INFO("  Buffer size:    {}", cfg.bufferSize);
     LOG_INFO("  Period size:    {}", cfg.periodSize);
@@ -673,27 +578,29 @@ static void print_config_summary(const AppConfig& cfg) {
         LOG_INFO("  EQ profile:     {}", cfg.eqProfilePath);
     }
     // Update metrics with audio configuration
-    gpu_upsampler::metrics::setAudioConfig(g_input_sample_rate, outputRate, cfg.upsampleRatio);
+    gpu_upsampler::metrics::setAudioConfig(g_state.rates.inputSampleRate, outputRate,
+                                           cfg.upsampleRatio);
 }
 
 static std::string resolve_filter_path_for(ConvolutionEngine::RateFamily family, PhaseType phase) {
     if (phase == PhaseType::Linear) {
-        return (family == ConvolutionEngine::RateFamily::RATE_44K) ? g_config.filterPath44kLinear
-                                                                   : g_config.filterPath48kLinear;
+        return (family == ConvolutionEngine::RateFamily::RATE_44K)
+                   ? g_state.config.filterPath44kLinear
+                   : g_state.config.filterPath48kLinear;
     }
-    return (family == ConvolutionEngine::RateFamily::RATE_44K) ? g_config.filterPath44kMin
-                                                               : g_config.filterPath48kMin;
+    return (family == ConvolutionEngine::RateFamily::RATE_44K) ? g_state.config.filterPath44kMin
+                                                               : g_state.config.filterPath48kMin;
 }
 
 static std::string current_filter_path() {
-    return resolve_filter_path_for(g_active_rate_family, g_active_phase_type);
+    return resolve_filter_path_for(g_state.rates.activeRateFamily, g_state.rates.activePhaseType);
 }
 
 static void update_effective_gain(float headroomGain, const std::string& reason) {
-    g_headroom_gain.store(headroomGain, std::memory_order_relaxed);
-    float effective = g_config.gain * headroomGain;
-    g_output_gain.store(effective, std::memory_order_relaxed);
-    LOG_INFO("Gain [{}]: user {:.4f} * headroom {:.4f} = {:.4f}", reason, g_config.gain,
+    g_state.gains.headroom.store(headroomGain, std::memory_order_relaxed);
+    float effective = g_state.config.gain * headroomGain;
+    g_state.gains.output.store(effective, std::memory_order_relaxed);
+    LOG_INFO("Gain [{}]: user {:.4f} * headroom {:.4f} = {:.4f}", reason, g_state.config.gain,
              headroomGain, effective);
 }
 
@@ -704,7 +611,7 @@ static void apply_headroom_for_path(const std::string& path, const std::string& 
         return;
     }
 
-    FilterHeadroomInfo info = g_headroom_cache.get(path);
+    FilterHeadroomInfo info = g_state.headroomCache.get(path);
     update_effective_gain(info.safeGain, reason);
 
     if (!info.metadataFound) {
@@ -721,74 +628,74 @@ static void refresh_current_headroom(const std::string& reason) {
 }
 
 static void reset_runtime_state() {
-    g_streaming_cache_manager.reset();
+    g_state.managers.streamingCacheManager.reset();
 
     playback_buffer().reset();
-    g_stream_input_left.clear();
-    g_stream_input_right.clear();
-    g_stream_accumulated_left = 0;
-    g_stream_accumulated_right = 0;
-    g_upsampler_output_left.clear();
-    g_upsampler_output_right.clear();
+    g_state.streaming.streamInputLeft.clear();
+    g_state.streaming.streamInputRight.clear();
+    g_state.streaming.streamAccumulatedLeft = 0;
+    g_state.streaming.streamAccumulatedRight = 0;
+    g_state.streaming.upsamplerOutputLeft.clear();
+    g_state.streaming.upsamplerOutputRight.clear();
 
     // Reset crossfeed streaming buffers
-    g_cf_stream_input_left.clear();
-    g_cf_stream_input_right.clear();
-    g_cf_stream_accumulated_left = 0;
-    g_cf_stream_accumulated_right = 0;
-    g_cf_output_buffer_left.clear();
-    g_cf_output_buffer_right.clear();
+    g_state.crossfeed.cfStreamInputLeft.clear();
+    g_state.crossfeed.cfStreamInputRight.clear();
+    g_state.crossfeed.cfStreamAccumulatedLeft = 0;
+    g_state.crossfeed.cfStreamAccumulatedRight = 0;
+    g_state.crossfeed.cfOutputBufferLeft.clear();
+    g_state.crossfeed.cfOutputBufferRight.clear();
 }
 
 static bool reinitialize_streaming_for_legacy_mode() {
-    if (!g_upsampler) {
+    if (!g_state.upsampler) {
         return false;
     }
 
-    std::lock_guard<std::mutex> streamLock(g_streaming_mutex);
-    g_upsampler->resetStreaming();
+    std::lock_guard<std::mutex> streamLock(g_state.streaming.streamingMutex);
+    g_state.upsampler->resetStreaming();
     playback_buffer().reset();
 
-    g_stream_input_left.clear();
-    g_stream_input_right.clear();
-    g_stream_accumulated_left = 0;
-    g_stream_accumulated_right = 0;
-    g_upsampler_output_left.clear();
-    g_upsampler_output_right.clear();
+    g_state.streaming.streamInputLeft.clear();
+    g_state.streaming.streamInputRight.clear();
+    g_state.streaming.streamAccumulatedLeft = 0;
+    g_state.streaming.streamAccumulatedRight = 0;
+    g_state.streaming.upsamplerOutputLeft.clear();
+    g_state.streaming.upsamplerOutputRight.clear();
 
     // Rebuild legacy streams so the buffers match the full FFT (avoids invalid cudaMemset after
     // disabling partitions).
-    if (!g_upsampler->initializeStreaming()) {
+    if (!g_state.upsampler->initializeStreaming()) {
         std::cerr << "[Partition] Failed to initialize legacy streaming buffers" << '\n';
         return false;
     }
 
-    size_t buffer_capacity = g_upsampler->getStreamValidInputPerBlock() * 2;
+    size_t buffer_capacity = g_state.upsampler->getStreamValidInputPerBlock() * 2;
     if (buffer_capacity > 0) {
-        g_stream_input_left.resize(buffer_capacity, 0.0f);
-        g_stream_input_right.resize(buffer_capacity, 0.0f);
+        g_state.streaming.streamInputLeft.resize(buffer_capacity, 0.0f);
+        g_state.streaming.streamInputRight.resize(buffer_capacity, 0.0f);
     } else {
-        g_stream_input_left.clear();
-        g_stream_input_right.clear();
+        g_state.streaming.streamInputLeft.clear();
+        g_state.streaming.streamInputRight.clear();
     }
-    g_stream_accumulated_left = 0;
-    g_stream_accumulated_right = 0;
+    g_state.streaming.streamAccumulatedLeft = 0;
+    g_state.streaming.streamAccumulatedRight = 0;
 
-    size_t upsampler_output_capacity =
-        g_upsampler->getStreamValidInputPerBlock() * g_upsampler->getUpsampleRatio() * 2;
-    g_upsampler_output_left.reserve(upsampler_output_capacity);
-    g_upsampler_output_right.reserve(upsampler_output_capacity);
+    size_t upsampler_output_capacity = g_state.upsampler->getStreamValidInputPerBlock() *
+                                       g_state.upsampler->getUpsampleRatio() * 2;
+    g_state.streaming.upsamplerOutputLeft.reserve(upsampler_output_capacity);
+    g_state.streaming.upsamplerOutputRight.reserve(upsampler_output_capacity);
 
     return true;
 }
 
 static bool handle_rate_switch(int newInputRate) {
-    if (!g_upsampler || !g_upsampler->isMultiRateEnabled()) {
+    if (!g_state.upsampler || !g_state.upsampler->isMultiRateEnabled()) {
         std::cerr << "[Rate] Multi-rate mode not enabled" << '\n';
         return false;
     }
 
-    int currentRate = g_upsampler->getCurrentInputRate();
+    int currentRate = g_state.upsampler->getCurrentInputRate();
     if (currentRate == newInputRate) {
         std::cout << "[Rate] Already at target rate: " << newInputRate << " Hz" << '\n';
         return true;
@@ -798,10 +705,10 @@ static bool handle_rate_switch(int newInputRate) {
 
     int savedRate = currentRate;
 
-    if (g_soft_mute) {
-        g_soft_mute->startFadeOut();
+    if (g_state.softMute.controller) {
+        g_state.softMute.controller->startFadeOut();
         auto startTime = std::chrono::steady_clock::now();
-        while (g_soft_mute->isTransitioning()) {
+        while (g_state.softMute.controller->isTransitioning()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
             auto elapsed = std::chrono::steady_clock::now() - startTime;
             if (elapsed > std::chrono::milliseconds(200)) {
@@ -811,67 +718,67 @@ static bool handle_rate_switch(int newInputRate) {
         }
     }
 
-    int newOutputRate = g_upsampler->getOutputSampleRate();
-    int newUpsampleRatio = g_upsampler->getUpsampleRatio();
+    int newOutputRate = g_state.upsampler->getOutputSampleRate();
+    int newUpsampleRatio = g_state.upsampler->getUpsampleRatio();
     size_t buffer_capacity = 0;
 
     {
-        std::lock_guard<std::mutex> streamLock(g_streaming_mutex);
+        std::lock_guard<std::mutex> streamLock(g_state.streaming.streamingMutex);
 
-        g_upsampler->resetStreaming();
+        g_state.upsampler->resetStreaming();
 
         playback_buffer().reset();
-        g_stream_input_left.clear();
-        g_stream_input_right.clear();
-        g_stream_accumulated_left = 0;
-        g_stream_accumulated_right = 0;
+        g_state.streaming.streamInputLeft.clear();
+        g_state.streaming.streamInputRight.clear();
+        g_state.streaming.streamAccumulatedLeft = 0;
+        g_state.streaming.streamAccumulatedRight = 0;
 
-        if (!g_upsampler->switchToInputRate(newInputRate)) {
+        if (!g_state.upsampler->switchToInputRate(newInputRate)) {
             std::cerr << "[Rate] Failed to switch rate, rolling back" << '\n';
-            if (g_upsampler->switchToInputRate(savedRate)) {
+            if (g_state.upsampler->switchToInputRate(savedRate)) {
                 std::cout << "[Rate] Rollback successful: restored to " << savedRate << " Hz"
                           << '\n';
             } else {
                 std::cerr << "[Rate] ERROR: Rollback failed!" << '\n';
             }
-            if (g_soft_mute) {
-                g_soft_mute->startFadeIn();
+            if (g_state.softMute.controller) {
+                g_state.softMute.controller->startFadeIn();
             }
             return false;
         }
 
-        if (!g_upsampler->initializeStreaming()) {
+        if (!g_state.upsampler->initializeStreaming()) {
             std::cerr << "[Rate] Failed to re-initialize streaming mode, rolling back" << '\n';
-            if (g_upsampler->switchToInputRate(savedRate)) {
-                if (g_upsampler->initializeStreaming()) {
+            if (g_state.upsampler->switchToInputRate(savedRate)) {
+                if (g_state.upsampler->initializeStreaming()) {
                     std::cout << "[Rate] Rollback successful: restored to " << savedRate << " Hz"
                               << '\n';
                 }
             }
-            if (g_soft_mute) {
-                g_soft_mute->startFadeIn();
+            if (g_state.softMute.controller) {
+                g_state.softMute.controller->startFadeIn();
             }
             return false;
         }
 
-        g_input_sample_rate = newInputRate;
-        newOutputRate = g_upsampler->getOutputSampleRate();
-        newUpsampleRatio = g_upsampler->getUpsampleRatio();
+        g_state.rates.inputSampleRate = newInputRate;
+        newOutputRate = g_state.upsampler->getOutputSampleRate();
+        newUpsampleRatio = g_state.upsampler->getUpsampleRatio();
 
-        buffer_capacity = g_upsampler->getStreamValidInputPerBlock() * 2;
-        g_stream_input_left.resize(buffer_capacity, 0.0f);
-        g_stream_input_right.resize(buffer_capacity, 0.0f);
-        g_stream_accumulated_left = 0;
-        g_stream_accumulated_right = 0;
+        buffer_capacity = g_state.upsampler->getStreamValidInputPerBlock() * 2;
+        g_state.streaming.streamInputLeft.resize(buffer_capacity, 0.0f);
+        g_state.streaming.streamInputRight.resize(buffer_capacity, 0.0f);
+        g_state.streaming.streamAccumulatedLeft = 0;
+        g_state.streaming.streamAccumulatedRight = 0;
 
-        if (g_soft_mute) {
-            delete g_soft_mute;
+        if (g_state.softMute.controller) {
+            delete g_state.softMute.controller;
         }
-        g_soft_mute = new SoftMute::Controller(50, newOutputRate);
+        g_state.softMute.controller = new SoftMute::Controller(50, newOutputRate);
     }
 
-    if (g_soft_mute) {
-        g_soft_mute->startFadeIn();
+    if (g_state.softMute.controller) {
+        g_state.softMute.controller->startFadeIn();
     }
 
     std::cout << "[Rate] Switch complete: " << newInputRate << " Hz (" << newUpsampleRatio
@@ -885,61 +792,61 @@ static bool handle_rate_switch(int newInputRate) {
 static void load_runtime_config() {
     AppConfig loaded;
     bool found = loadAppConfig(CONFIG_FILE_PATH, loaded);
-    g_config = loaded;
-    ensure_output_config(g_config);
+    g_state.config = loaded;
+    ensure_output_config(g_state.config);
 
-    if (g_config.alsaDevice.empty()) {
-        set_preferred_output_device(g_config, DEFAULT_ALSA_DEVICE);
+    if (g_state.config.alsaDevice.empty()) {
+        set_preferred_output_device(g_state.config, DEFAULT_ALSA_DEVICE);
     }
-    if (g_config.filterPath.empty()) {
-        g_config.filterPath = DEFAULT_FILTER_PATH;
+    if (g_state.config.filterPath.empty()) {
+        g_state.config.filterPath = DEFAULT_FILTER_PATH;
     }
-    if (g_config.upsampleRatio <= 0) {
-        g_config.upsampleRatio = DEFAULT_UPSAMPLE_RATIO;
+    if (g_state.config.upsampleRatio <= 0) {
+        g_state.config.upsampleRatio = DEFAULT_UPSAMPLE_RATIO;
     }
-    if (g_config.blockSize <= 0) {
-        g_config.blockSize = DEFAULT_BLOCK_SIZE;
+    if (g_state.config.blockSize <= 0) {
+        g_state.config.blockSize = DEFAULT_BLOCK_SIZE;
     }
-    if (g_config.bufferSize <= 0) {
-        g_config.bufferSize = 262144;
+    if (g_state.config.bufferSize <= 0) {
+        g_state.config.bufferSize = 262144;
     }
-    if (g_config.periodSize <= 0) {
-        g_config.periodSize = 32768;
+    if (g_state.config.periodSize <= 0) {
+        g_state.config.periodSize = 32768;
     }
-    if (g_config.loopback.device.empty()) {
-        g_config.loopback.device = DEFAULT_LOOPBACK_DEVICE;
+    if (g_state.config.loopback.device.empty()) {
+        g_state.config.loopback.device = DEFAULT_LOOPBACK_DEVICE;
     }
-    if (g_config.loopback.sampleRate == 0) {
-        g_config.loopback.sampleRate = DEFAULT_INPUT_SAMPLE_RATE;
+    if (g_state.config.loopback.sampleRate == 0) {
+        g_state.config.loopback.sampleRate = DEFAULT_INPUT_SAMPLE_RATE;
     }
-    if (g_config.loopback.channels == 0) {
-        g_config.loopback.channels = CHANNELS;
+    if (g_state.config.loopback.channels == 0) {
+        g_state.config.loopback.channels = CHANNELS;
     }
-    if (g_config.loopback.periodFrames == 0) {
-        g_config.loopback.periodFrames = DEFAULT_LOOPBACK_PERIOD_FRAMES;
+    if (g_state.config.loopback.periodFrames == 0) {
+        g_state.config.loopback.periodFrames = DEFAULT_LOOPBACK_PERIOD_FRAMES;
     }
-    if (g_config.loopback.format.empty()) {
-        g_config.loopback.format = "S16_LE";
+    if (g_state.config.loopback.format.empty()) {
+        g_state.config.loopback.format = "S16_LE";
     }
-    if (g_config.loopback.enabled) {
-        g_input_sample_rate = static_cast<int>(g_config.loopback.sampleRate);
+    if (g_state.config.loopback.enabled) {
+        g_state.rates.inputSampleRate = static_cast<int>(g_state.config.loopback.sampleRate);
     }
-    if (g_input_sample_rate != 44100 && g_input_sample_rate != 48000) {
-        g_input_sample_rate = DEFAULT_INPUT_SAMPLE_RATE;
+    if (g_state.rates.inputSampleRate != 44100 && g_state.rates.inputSampleRate != 48000) {
+        g_state.rates.inputSampleRate = DEFAULT_INPUT_SAMPLE_RATE;
     }
 
     if (!found) {
         std::cout << "Config: Using defaults (no config.json found)" << '\n';
     }
 
-    enforce_phase_partition_constraints(g_config);
+    enforce_phase_partition_constraints(g_state.config);
 
-    print_config_summary(g_config);
-    g_headroom_cache.setTargetPeak(g_config.headroomTarget);
+    print_config_summary(g_state.config);
+    g_state.headroomCache.setTargetPeak(g_state.config.headroomTarget);
     update_effective_gain(1.0f, "config load (pending filter headroom)");
-    float initialOutput = g_output_gain.load(std::memory_order_relaxed);
-    g_limiter_gain.store(1.0f, std::memory_order_relaxed);
-    g_effective_gain.store(initialOutput, std::memory_order_relaxed);
+    float initialOutput = g_state.gains.output.load(std::memory_order_relaxed);
+    g_state.gains.limiter.store(1.0f, std::memory_order_relaxed);
+    g_state.gains.effective.store(initialOutput, std::memory_order_relaxed);
 }
 
 static snd_pcm_format_t parse_loopback_format(const std::string& formatStr) {
@@ -1092,16 +999,16 @@ static void loopback_capture_thread(const std::string& device, snd_pcm_format_t 
 
     snd_pcm_t* handle = open_loopback_capture(device, format, rate, channels, period_frames);
     {
-        std::lock_guard<std::mutex> lock(g_loopback_handle_mutex);
-        g_loopback_handle = handle;
+        std::lock_guard<std::mutex> lock(g_state.loopback.handleMutex);
+        g_state.loopback.handle = handle;
     }
 
     if (!handle) {
         return;
     }
 
-    g_loopback_capture_running.store(true, std::memory_order_release);
-    g_loopback_capture_ready.store(true, std::memory_order_release);
+    g_state.loopback.captureRunning.store(true, std::memory_order_release);
+    g_state.loopback.captureReady.store(true, std::memory_order_release);
 
     std::vector<int16_t> buffer16;
     std::vector<int32_t> buffer32;
@@ -1115,11 +1022,12 @@ static void loopback_capture_thread(const std::string& device, snd_pcm_format_t 
     }
     std::vector<float> floatBuffer;
 
-    while (g_running.load(std::memory_order_acquire)) {
+    while (g_state.flags.running.load(std::memory_order_acquire)) {
         // Apply backpressure before pulling more input.
         // This prevents software loopback / bursty upstream from running ahead of ALSA playback.
-        playback_buffer().throttleProducerIfFull(
-            g_running, []() { return g_current_output_rate.load(std::memory_order_acquire); });
+        playback_buffer().throttleProducerIfFull(g_state.flags.running, []() {
+            return g_state.rates.currentOutputRate.load(std::memory_order_acquire);
+        });
 
         void* rawBuffer = nullptr;
         if (format == SND_PCM_FORMAT_S16_LE) {
@@ -1160,19 +1068,19 @@ static void loopback_capture_thread(const std::string& device, snd_pcm_format_t 
             break;
         }
 
-        if (g_audio_pipeline) {
-            g_audio_pipeline->process(floatBuffer.data(), static_cast<uint32_t>(frames));
+        if (g_state.audioPipeline) {
+            g_state.audioPipeline->process(floatBuffer.data(), static_cast<uint32_t>(frames));
         }
     }
 
     snd_pcm_drop(handle);
     snd_pcm_close(handle);
     {
-        std::lock_guard<std::mutex> lock(g_loopback_handle_mutex);
-        g_loopback_handle = nullptr;
+        std::lock_guard<std::mutex> lock(g_state.loopback.handleMutex);
+        g_state.loopback.handle = nullptr;
     }
-    g_loopback_capture_running.store(false, std::memory_order_release);
-    g_loopback_capture_ready.store(false, std::memory_order_release);
+    g_state.loopback.captureRunning.store(false, std::memory_order_release);
+    g_state.loopback.captureReady.store(false, std::memory_order_release);
     LOG_INFO("[Loopback] Capture thread terminated");
 }
 
@@ -1181,13 +1089,14 @@ void alsa_output_thread() {
     elevate_realtime_priority("ALSA output");
 
     daemon_output::AlsaPcmController pcmController(daemon_output::AlsaPcmControllerDependencies{
-        .config = &g_config,
-        .dacManager = g_dac_manager.get(),
-        .streamingCacheManager = g_streaming_cache_manager.get(),
-        .fallbackManager = g_fallback_manager,
-        .running = &g_running,
-        .outputReady = &g_output_ready,
-        .currentOutputRate = []() { return g_current_output_rate.load(std::memory_order_acquire); },
+        .config = &g_state.config,
+        .dacManager = g_state.managers.dacManager.get(),
+        .streamingCacheManager = g_state.managers.streamingCacheManager.get(),
+        .fallbackManager = g_state.fallbackManager,
+        .running = &g_state.flags.running,
+        .outputReady = &g_state.flags.outputReady,
+        .currentOutputRate =
+            []() { return g_state.rates.currentOutputRate.load(std::memory_order_acquire); },
     });
 
     if (!pcmController.openSelected()) {
@@ -1196,15 +1105,15 @@ void alsa_output_thread() {
 
     auto period_size = static_cast<snd_pcm_uframes_t>(pcmController.periodFrames());
     if (period_size == 0) {
-        period_size =
-            static_cast<snd_pcm_uframes_t>((g_config.periodSize > 0) ? g_config.periodSize : 32768);
+        period_size = static_cast<snd_pcm_uframes_t>(
+            (g_state.config.periodSize > 0) ? g_state.config.periodSize : 32768);
     }
     std::vector<int32_t> interleaved_buffer(period_size * CHANNELS);
     std::vector<float> float_buffer(period_size * CHANNELS);  // for soft mute processing
     auto& bufferManager = playback_buffer();
 
     // Main playback loop
-    while (g_running) {
+    while (g_state.flags.running) {
         // Heartbeat check every few hundred loops
         static int alive_counter = 0;
         if (++alive_counter > 200) {  // ~200 iterations ~ a few seconds depending on buffer wait
@@ -1212,13 +1121,13 @@ void alsa_output_thread() {
             if (!pcmController.alive()) {
                 std::cerr << "ALSA: PCM disconnected/suspended, attempting reopen..." << '\n';
                 pcmController.close();
-                while (g_running && !pcmController.openSelected()) {
+                while (g_state.flags.running && !pcmController.openSelected()) {
                     std::this_thread::sleep_for(std::chrono::seconds(5));
                 }
                 period_size = static_cast<snd_pcm_uframes_t>(pcmController.periodFrames());
                 if (period_size == 0) {
                     period_size = static_cast<snd_pcm_uframes_t>(
-                        (g_config.periodSize > 0) ? g_config.periodSize : 32768);
+                        (g_state.config.periodSize > 0) ? g_state.config.periodSize : 32768);
                 }
                 interleaved_buffer.resize(period_size * CHANNELS);
                 float_buffer.resize(period_size * CHANNELS);
@@ -1227,8 +1136,8 @@ void alsa_output_thread() {
         }
 
         // Issue #219: Check for pending ALSA reconfiguration (output rate changed)
-        if (g_alsa_reconfigure_needed.exchange(false, std::memory_order_acquire)) {
-            int new_output_rate = g_alsa_new_output_rate.load(std::memory_order_acquire);
+        if (g_state.rates.alsaReconfigureNeeded.exchange(false, std::memory_order_acquire)) {
+            int new_output_rate = g_state.rates.alsaNewOutputRate.load(std::memory_order_acquire);
             if (new_output_rate > 0) {
                 LOG_INFO("[Main] Reconfiguring ALSA for new output rate {} Hz", new_output_rate);
 
@@ -1237,21 +1146,21 @@ void alsa_output_thread() {
                     period_size = static_cast<snd_pcm_uframes_t>(pcmController.periodFrames());
                     if (period_size == 0) {
                         period_size = static_cast<snd_pcm_uframes_t>(
-                            (g_config.periodSize > 0) ? g_config.periodSize : 32768);
+                            (g_state.config.periodSize > 0) ? g_state.config.periodSize : 32768);
                     }
                     interleaved_buffer.resize(period_size * CHANNELS);
                     float_buffer.resize(period_size * CHANNELS);
 
                     // Update soft mute sample rate
-                    if (g_soft_mute) {
-                        g_soft_mute->setSampleRate(new_output_rate);
+                    if (g_state.softMute.controller) {
+                        g_state.softMute.controller->setSampleRate(new_output_rate);
                     }
 
                     LOG_INFO("[Main] ALSA reconfiguration successful");
                 } else {
                     // Failed to reconfigure - try to reopen with old rate
                     LOG_ERROR("[Main] ALSA reconfiguration failed, attempting recovery...");
-                    int old_rate = g_current_output_rate.load(std::memory_order_acquire);
+                    int old_rate = g_state.rates.currentOutputRate.load(std::memory_order_acquire);
                     if (!pcmController.reconfigure(old_rate)) {
                         LOG_ERROR("[Main] ALSA recovery failed, waiting for reconnect...");
                     }
@@ -1259,7 +1168,7 @@ void alsa_output_thread() {
             }
         }
 
-        if (auto pendingDevice = g_dac_manager->consumePendingChange()) {
+        if (auto pendingDevice = g_state.managers.dacManager->consumePendingChange()) {
             std::string nextDevice = *pendingDevice;
             if (!nextDevice.empty() && nextDevice != pcmController.device()) {
                 std::cout << "ALSA: Switching output to " << nextDevice << '\n';
@@ -1269,7 +1178,7 @@ void alsa_output_thread() {
                 period_size = static_cast<snd_pcm_uframes_t>(pcmController.periodFrames());
                 if (period_size == 0) {
                     period_size = static_cast<snd_pcm_uframes_t>(
-                        (g_config.periodSize > 0) ? g_config.periodSize : 32768);
+                        (g_state.config.periodSize > 0) ? g_state.config.periodSize : 32768);
                 }
                 interleaved_buffer.resize(period_size * CHANNELS);
                 float_buffer.resize(period_size * CHANNELS);
@@ -1281,19 +1190,21 @@ void alsa_output_thread() {
         size_t ready_threshold = get_playback_ready_threshold(static_cast<size_t>(period_size));
         bufferManager.cv().wait_for(
             lock, std::chrono::milliseconds(200), [&bufferManager, ready_threshold] {
-                return bufferManager.queuedFramesLocked() >= ready_threshold || !g_running;
+                return bufferManager.queuedFramesLocked() >= ready_threshold ||
+                       !g_state.flags.running;
             });
 
-        if (!g_running) {
+        if (!g_state.flags.running) {
             break;
         }
 
         lock.unlock();
 
         audio_pipeline::RenderResult renderResult;
-        if (g_audio_pipeline) {
-            renderResult = g_audio_pipeline->renderOutput(
-                static_cast<size_t>(period_size), interleaved_buffer, float_buffer, g_soft_mute);
+        if (g_state.audioPipeline) {
+            renderResult = g_state.audioPipeline->renderOutput(static_cast<size_t>(period_size),
+                                                               interleaved_buffer, float_buffer,
+                                                               g_state.softMute.controller);
         } else {
             renderResult.framesRequested = period_size;
             renderResult.framesRendered = period_size;
@@ -1333,7 +1244,7 @@ void alsa_output_thread() {
             std::cerr << "ALSA: Write error: " << snd_strerror(frames_written)
                       << ", retrying reopen..." << '\n';
             pcmController.close();
-            while (g_running && !pcmController.openSelected()) {
+            while (g_state.flags.running && !pcmController.openSelected()) {
                 std::this_thread::sleep_for(std::chrono::seconds(5));
             }
             if (!pcmController.isOpen()) {
@@ -1342,7 +1253,7 @@ void alsa_output_thread() {
             period_size = static_cast<snd_pcm_uframes_t>(pcmController.periodFrames());
             if (period_size == 0) {
                 period_size = static_cast<snd_pcm_uframes_t>(
-                    (g_config.periodSize > 0) ? g_config.periodSize : 32768);
+                    (g_state.config.periodSize > 0) ? g_state.config.periodSize : 32768);
             }
             interleaved_buffer.resize(period_size * CHANNELS);
             float_buffer.resize(period_size * CHANNELS);
@@ -1374,8 +1285,9 @@ int main(int argc, char* argv[]) {
     LOG_INFO("========================================");
     LOG_INFO("PID: {} (file: {})", getpid(), PID_FILE_PATH);
 
-    shutdown_manager::ShutdownManager::Dependencies shutdownDeps{&g_soft_mute, &g_running,
-                                                                 &g_reload_requested, nullptr};
+    shutdown_manager::ShutdownManager::Dependencies shutdownDeps{
+        &g_state.softMute.controller, &g_state.flags.running, &g_state.flags.reloadRequested,
+        nullptr};
     shutdown_manager::ShutdownManager shutdownManager(shutdownDeps);
     shutdownManager.installSignalHandlers();
 
@@ -1383,9 +1295,9 @@ int main(int argc, char* argv[]) {
 
     do {
         shutdownManager.reset();
-        g_running = true;
-        g_reload_requested = false;
-        g_zmq_bind_failed.store(false);
+        g_state.flags.running = true;
+        g_state.flags.reloadRequested = false;
+        g_state.flags.zmqBindFailed.store(false);
         reset_runtime_state();
 
         // Load configuration from config.json (if exists)
@@ -1393,186 +1305,194 @@ int main(int argc, char* argv[]) {
 
         // Environment variable overrides config.json
         if (const char* env_dev = std::getenv("ALSA_DEVICE")) {
-            set_preferred_output_device(g_config, env_dev);
+            set_preferred_output_device(g_state.config, env_dev);
             std::cout << "Config: ALSA_DEVICE env override: " << env_dev << '\n';
         }
 
         // Command line argument overrides filter path
         if (argc > 1) {
-            g_config.filterPath = argv[1];
+            g_state.config.filterPath = argv[1];
             std::cout << "Config: CLI filter path override: " << argv[1] << '\n';
         }
 
         initialize_event_modules();
 
-        PartitionRuntime::RuntimeRequest partitionRequest{g_config.partitionedConvolution.enabled,
-                                                          g_config.eqEnabled,
-                                                          g_config.crossfeed.enabled};
+        PartitionRuntime::RuntimeRequest partitionRequest{
+            g_state.config.partitionedConvolution.enabled, g_state.config.eqEnabled,
+            g_state.config.crossfeed.enabled};
 
         // Auto-select filter based on sample rate if configured filter doesn't exist
         // but a sample-rate-specific version does
-        if (!std::filesystem::exists(g_config.filterPath)) {
+        if (!std::filesystem::exists(g_state.config.filterPath)) {
             // Try to find sample-rate-specific filter
-            std::string basePath = g_config.filterPath;
+            std::string basePath = g_state.config.filterPath;
             size_t dotPos = basePath.rfind('.');
             if (dotPos != std::string::npos) {
                 std::string rateSpecificPath = basePath.substr(0, dotPos) + "_" +
-                                               std::to_string(g_input_sample_rate) +
+                                               std::to_string(g_state.rates.inputSampleRate) +
                                                basePath.substr(dotPos);
                 if (std::filesystem::exists(rateSpecificPath)) {
                     std::cout << "Config: Using sample-rate-specific filter: " << rateSpecificPath
                               << '\n';
-                    g_config.filterPath = rateSpecificPath;
+                    g_state.config.filterPath = rateSpecificPath;
                 }
             }
         }
 
         // Warn if using 44.1kHz filter with 48kHz input
-        if (g_input_sample_rate == 48000 &&
-            g_config.filterPath.find("44100") == std::string::npos &&
-            g_config.filterPath.find("48000") == std::string::npos) {
+        if (g_state.rates.inputSampleRate == 48000 &&
+            g_state.config.filterPath.find("44100") == std::string::npos &&
+            g_state.config.filterPath.find("48000") == std::string::npos) {
             std::cout << "Warning: Using generic filter with 48kHz input. "
                       << "For optimal quality, generate a 48kHz-optimized filter." << '\n';
         }
 
         // Initialize GPU upsampler with configured values
         std::cout << "Initializing GPU upsampler..." << '\n';
-        g_upsampler = new ConvolutionEngine::GPUUpsampler();
-        g_upsampler->setPartitionedConvolutionConfig(g_config.partitionedConvolution);
+        g_state.upsampler = new ConvolutionEngine::GPUUpsampler();
+        g_state.upsampler->setPartitionedConvolutionConfig(g_state.config.partitionedConvolution);
 
         bool initSuccess = false;
         ConvolutionEngine::RateFamily initialFamily = ConvolutionEngine::RateFamily::RATE_44K;
-        if (g_config.multiRateEnabled) {
+        if (g_state.config.multiRateEnabled) {
             std::cout << "Multi-rate mode enabled" << '\n';
-            std::cout << "  Coefficient directory: " << g_config.coefficientDir << '\n';
+            std::cout << "  Coefficient directory: " << g_state.config.coefficientDir << '\n';
 
-            if (!std::filesystem::exists(g_config.coefficientDir)) {
+            if (!std::filesystem::exists(g_state.config.coefficientDir)) {
                 std::cerr << "Config error: Coefficient directory not found: "
-                          << g_config.coefficientDir << '\n';
-                delete g_upsampler;
+                          << g_state.config.coefficientDir << '\n';
+                delete g_state.upsampler;
                 exitCode = 1;
                 break;
             }
 
-            initSuccess = g_upsampler->initializeMultiRate(g_config.coefficientDir,
-                                                           g_config.blockSize, g_input_sample_rate);
+            initSuccess = g_state.upsampler->initializeMultiRate(g_state.config.coefficientDir,
+                                                                 g_state.config.blockSize,
+                                                                 g_state.rates.inputSampleRate);
 
             if (initSuccess) {
-                g_current_input_rate.store(g_upsampler->getInputSampleRate(),
-                                           std::memory_order_release);
-                g_current_output_rate.store(g_upsampler->getOutputSampleRate(),
-                                            std::memory_order_release);
-                g_set_rate_family(ConvolutionEngine::detectRateFamily(g_input_sample_rate));
+                g_state.rates.currentInputRate.store(g_state.upsampler->getInputSampleRate(),
+                                                     std::memory_order_release);
+                g_state.rates.currentOutputRate.store(g_state.upsampler->getOutputSampleRate(),
+                                                      std::memory_order_release);
+                g_set_rate_family(
+                    ConvolutionEngine::detectRateFamily(g_state.rates.inputSampleRate));
             }
         } else {
             std::cout << "Quad-phase mode enabled" << '\n';
 
             bool allFilesExist = true;
-            for (const auto& path : {g_config.filterPath44kMin, g_config.filterPath48kMin,
-                                     g_config.filterPath44kLinear, g_config.filterPath48kLinear}) {
+            for (const auto& path :
+                 {g_state.config.filterPath44kMin, g_state.config.filterPath48kMin,
+                  g_state.config.filterPath44kLinear, g_state.config.filterPath48kLinear}) {
                 if (!std::filesystem::exists(path)) {
                     std::cerr << "Config error: Filter file not found: " << path << '\n';
                     allFilesExist = false;
                 }
             }
             if (!allFilesExist) {
-                delete g_upsampler;
+                delete g_state.upsampler;
                 exitCode = 1;
                 break;
             }
 
-            initialFamily = ConvolutionEngine::detectRateFamily(g_input_sample_rate);
+            initialFamily = ConvolutionEngine::detectRateFamily(g_state.rates.inputSampleRate);
             if (initialFamily == ConvolutionEngine::RateFamily::RATE_UNKNOWN) {
                 initialFamily = ConvolutionEngine::RateFamily::RATE_44K;
             }
 
-            initSuccess = g_upsampler->initializeQuadPhase(
-                g_config.filterPath44kMin, g_config.filterPath48kMin, g_config.filterPath44kLinear,
-                g_config.filterPath48kLinear, g_config.upsampleRatio, g_config.blockSize,
-                initialFamily, g_config.phaseType);
+            initSuccess = g_state.upsampler->initializeQuadPhase(
+                g_state.config.filterPath44kMin, g_state.config.filterPath48kMin,
+                g_state.config.filterPath44kLinear, g_state.config.filterPath48kLinear,
+                g_state.config.upsampleRatio, g_state.config.blockSize, initialFamily,
+                g_state.config.phaseType);
         }
 
         if (!initSuccess) {
             std::cerr << "Failed to initialize GPU upsampler" << '\n';
-            delete g_upsampler;
+            delete g_state.upsampler;
             exitCode = 1;
             break;
         }
 
         // Check for early abort (signal received during GPU initialization)
-        if (!g_running) {
+        if (!g_state.flags.running) {
             std::cout << "Startup interrupted by signal" << '\n';
-            delete g_upsampler;
-            g_upsampler = nullptr;
+            delete g_state.upsampler;
+            g_state.upsampler = nullptr;
             break;
         }
 
-        if (g_config.multiRateEnabled) {
-            std::cout << "GPU upsampler ready (multi-rate mode, " << g_config.blockSize
+        if (g_state.config.multiRateEnabled) {
+            std::cout << "GPU upsampler ready (multi-rate mode, " << g_state.config.blockSize
                       << " samples/block)" << '\n';
-            std::cout << "  Current input rate: " << g_upsampler->getCurrentInputRate() << " Hz"
+            std::cout << "  Current input rate: " << g_state.upsampler->getCurrentInputRate()
+                      << " Hz" << '\n';
+            std::cout << "  Upsample ratio: " << g_state.upsampler->getUpsampleRatio() << "x"
                       << '\n';
-            std::cout << "  Upsample ratio: " << g_upsampler->getUpsampleRatio() << "x" << '\n';
-            std::cout << "  Output rate: " << g_upsampler->getOutputSampleRate() << " Hz" << '\n';
+            std::cout << "  Output rate: " << g_state.upsampler->getOutputSampleRate() << " Hz"
+                      << '\n';
         } else {
-            std::cout << "GPU upsampler ready (" << g_config.upsampleRatio << "x upsampling, "
-                      << g_config.blockSize << " samples/block)" << '\n';
+            std::cout << "GPU upsampler ready (" << g_state.config.upsampleRatio << "x upsampling, "
+                      << g_state.config.blockSize << " samples/block)" << '\n';
         }
 
-        // Set g_active_rate_family and g_active_phase_type for headroom tracking
-        if (g_config.multiRateEnabled) {
+        // Set g_state.rates.activeRateFamily and g_state.rates.activePhaseType for headroom
+        // tracking
+        if (g_state.config.multiRateEnabled) {
             // Rate family already set during initializeMultiRate()
-            // g_active_rate_family is set via g_set_rate_family() above
+            // g_state.rates.activeRateFamily is set via g_set_rate_family() above
         } else {
-            g_active_rate_family = initialFamily;
+            g_state.rates.activeRateFamily = initialFamily;
         }
 
-        g_active_phase_type = g_config.phaseType;
-        publish_filter_switch_event(current_filter_path(), g_active_phase_type, true);
+        g_state.rates.activePhaseType = g_state.config.phaseType;
+        publish_filter_switch_event(current_filter_path(), g_state.rates.activePhaseType, true);
 
-        std::cout << "Input sample rate: " << g_upsampler->getInputSampleRate() << " Hz -> "
-                  << g_upsampler->getOutputSampleRate() << " Hz output" << '\n';
-        if (!g_config.multiRateEnabled) {
-            std::cout << "Phase type: " << phaseTypeToString(g_config.phaseType) << '\n';
+        std::cout << "Input sample rate: " << g_state.upsampler->getInputSampleRate() << " Hz -> "
+                  << g_state.upsampler->getOutputSampleRate() << " Hz output" << '\n';
+        if (!g_state.config.multiRateEnabled) {
+            std::cout << "Phase type: " << phaseTypeToString(g_state.config.phaseType) << '\n';
         }
 
         // Log latency warning for linear phase
-        if (g_config.phaseType == PhaseType::Linear) {
-            double latencySec = g_upsampler->getLatencySeconds();
+        if (g_state.config.phaseType == PhaseType::Linear) {
+            double latencySec = g_state.upsampler->getLatencySeconds();
             std::cout << "  WARNING: Linear phase latency: " << latencySec << " seconds ("
-                      << g_upsampler->getLatencySamples() << " samples)" << '\n';
+                      << g_state.upsampler->getLatencySamples() << " samples)" << '\n';
         }
 
         // Initialize streaming mode to preserve overlap buffers across input callbacks
-        if (!g_upsampler->initializeStreaming()) {
+        if (!g_state.upsampler->initializeStreaming()) {
             std::cerr << "Failed to initialize streaming mode" << '\n';
-            delete g_upsampler;
+            delete g_state.upsampler;
             exitCode = 1;
             break;
         }
-        PartitionRuntime::applyPartitionPolicy(partitionRequest, *g_upsampler, g_config, "ALSA");
+        PartitionRuntime::applyPartitionPolicy(partitionRequest, *g_state.upsampler, g_state.config,
+                                               "ALSA");
 
         // Check for early abort
-        if (!g_running) {
+        if (!g_state.flags.running) {
             std::cout << "Startup interrupted by signal" << '\n';
-            delete g_upsampler;
-            g_upsampler = nullptr;
+            delete g_state.upsampler;
+            g_state.upsampler = nullptr;
             break;
         }
 
         // Apply EQ profile if enabled
-        if (g_config.eqEnabled && !g_config.eqProfilePath.empty()) {
-            std::cout << "Loading EQ profile: " << g_config.eqProfilePath << '\n';
+        if (g_state.config.eqEnabled && !g_state.config.eqProfilePath.empty()) {
+            std::cout << "Loading EQ profile: " << g_state.config.eqProfilePath << '\n';
             EQ::EqProfile eqProfile;
-            if (EQ::parseEqFile(g_config.eqProfilePath, eqProfile)) {
+            if (EQ::parseEqFile(g_state.config.eqProfilePath, eqProfile)) {
                 std::cout << "  EQ: " << eqProfile.name << " (" << eqProfile.bands.size()
                           << " bands, preamp " << eqProfile.preampDb << " dB)" << '\n';
 
                 // Compute EQ magnitude response and apply with minimum phase reconstruction
-                size_t filterFftSize = g_upsampler->getFilterFftSize();  // N/2+1 (R2C output)
-                size_t fullFftSize = g_upsampler->getFullFftSize();      // N (full FFT)
-                double outputSampleRate =
-                    static_cast<double>(g_input_sample_rate) * g_config.upsampleRatio;
+                size_t filterFftSize = g_state.upsampler->getFilterFftSize();  // N/2+1 (R2C output)
+                size_t fullFftSize = g_state.upsampler->getFullFftSize();      // N (full FFT)
+                double outputSampleRate = static_cast<double>(g_state.rates.inputSampleRate) *
+                                          g_state.config.upsampleRatio;
                 auto eqMagnitude = EQ::computeEqMagnitudeForFft(filterFftSize, fullFftSize,
                                                                 outputSampleRate, eqProfile);
                 double eqMax = 0.0;
@@ -1585,47 +1505,50 @@ int main(int argc, char* argv[]) {
                           << 20.0 * std::log10(std::max(eqMax, 1e-30)) << " dB), min=" << eqMin
                           << '\n';
 
-                if (g_upsampler->applyEqMagnitude(eqMagnitude)) {
+                if (g_state.upsampler->applyEqMagnitude(eqMagnitude)) {
                     // Log message depends on phase type (already logged by applyEqMagnitude)
                 } else {
                     std::cerr << "  EQ: Failed to apply frequency response" << '\n';
                 }
             } else {
-                std::cerr << "  EQ: Failed to parse profile: " << g_config.eqProfilePath << '\n';
+                std::cerr << "  EQ: Failed to parse profile: " << g_state.config.eqProfilePath
+                          << '\n';
             }
         }
 
         // Pre-allocate streaming input buffers (based on streamValidInputPerBlock_)
         // Use 2x safety margin to handle timing variations
-        size_t buffer_capacity = g_upsampler->getStreamValidInputPerBlock() * 2;
-        g_stream_input_left.resize(buffer_capacity, 0.0f);
-        g_stream_input_right.resize(buffer_capacity, 0.0f);
+        size_t buffer_capacity = g_state.upsampler->getStreamValidInputPerBlock() * 2;
+        g_state.streaming.streamInputLeft.resize(buffer_capacity, 0.0f);
+        g_state.streaming.streamInputRight.resize(buffer_capacity, 0.0f);
         std::cout << "Streaming buffer capacity: " << buffer_capacity
                   << " samples (2x streamValidInputPerBlock)" << '\n';
-        g_stream_accumulated_left = 0;
-        g_stream_accumulated_right = 0;
+        g_state.streaming.streamAccumulatedLeft = 0;
+        g_state.streaming.streamAccumulatedRight = 0;
         size_t upsampler_output_capacity =
-            g_upsampler->getStreamValidInputPerBlock() * g_config.upsampleRatio * 2;
-        g_upsampler_output_left.reserve(upsampler_output_capacity);
-        g_upsampler_output_right.reserve(upsampler_output_capacity);
+            g_state.upsampler->getStreamValidInputPerBlock() * g_state.config.upsampleRatio * 2;
+        g_state.streaming.upsamplerOutputLeft.reserve(upsampler_output_capacity);
+        g_state.streaming.upsamplerOutputRight.reserve(upsampler_output_capacity);
         initialize_streaming_cache_manager();
 
-        if (!g_config.partitionedConvolution.enabled) {
+        if (!g_state.config.partitionedConvolution.enabled) {
             // Initialize HRTF processor for crossfeed (optional feature)
             // Crossfeed is disabled by default until enabled via ZeroMQ command
             std::string hrtfDir = "data/crossfeed/hrtf";
             if (std::filesystem::exists(hrtfDir)) {
                 std::cout << "Initializing HRTF processor for crossfeed..." << '\n';
-                g_hrtf_processor = new CrossfeedEngine::HRTFProcessor();
+                g_state.crossfeed.processor = new CrossfeedEngine::HRTFProcessor();
 
                 // Determine rate family based on input sample rate
                 CrossfeedEngine::RateFamily rateFamily =
-                    (g_input_sample_rate == 48000) ? CrossfeedEngine::RateFamily::RATE_48K
-                                                   : CrossfeedEngine::RateFamily::RATE_44K;
+                    (g_state.rates.inputSampleRate == 48000)
+                        ? CrossfeedEngine::RateFamily::RATE_48K
+                        : CrossfeedEngine::RateFamily::RATE_44K;
 
-                if (g_hrtf_processor->initialize(hrtfDir, g_config.blockSize,
-                                                 CrossfeedEngine::HeadSize::M, rateFamily)) {
-                    if (g_hrtf_processor->initializeStreaming()) {
+                if (g_state.crossfeed.processor->initialize(hrtfDir, g_state.config.blockSize,
+                                                            CrossfeedEngine::HeadSize::M,
+                                                            rateFamily)) {
+                    if (g_state.crossfeed.processor->initializeStreaming()) {
                         std::cout << "  HRTF processor ready (head size: M, rate family: "
                                   << (rateFamily == CrossfeedEngine::RateFamily::RATE_44K ? "44k"
                                                                                           : "48k")
@@ -1633,24 +1556,24 @@ int main(int argc, char* argv[]) {
 
                         // Pre-allocate crossfeed streaming buffers
                         size_t cf_buffer_capacity =
-                            g_hrtf_processor->getStreamValidInputPerBlock() * 2;
-                        g_cf_stream_input_left.resize(cf_buffer_capacity, 0.0f);
-                        g_cf_stream_input_right.resize(cf_buffer_capacity, 0.0f);
-                        g_cf_stream_accumulated_left = 0;
-                        g_cf_stream_accumulated_right = 0;
-                        g_cf_output_buffer_left.reserve(cf_buffer_capacity);
-                        g_cf_output_buffer_right.reserve(cf_buffer_capacity);
+                            g_state.crossfeed.processor->getStreamValidInputPerBlock() * 2;
+                        g_state.crossfeed.cfStreamInputLeft.resize(cf_buffer_capacity, 0.0f);
+                        g_state.crossfeed.cfStreamInputRight.resize(cf_buffer_capacity, 0.0f);
+                        g_state.crossfeed.cfStreamAccumulatedLeft = 0;
+                        g_state.crossfeed.cfStreamAccumulatedRight = 0;
+                        g_state.crossfeed.cfOutputBufferLeft.reserve(cf_buffer_capacity);
+                        g_state.crossfeed.cfOutputBufferRight.reserve(cf_buffer_capacity);
                         std::cout << "  Crossfeed buffer capacity: " << cf_buffer_capacity
                                   << " samples" << '\n';
 
                         // Crossfeed is initialized but disabled by default
-                        g_crossfeed_enabled.store(false);
-                        g_hrtf_processor->setEnabled(false);
+                        g_state.crossfeed.enabled.store(false);
+                        g_state.crossfeed.processor->setEnabled(false);
                         std::cout << "  Crossfeed: initialized (disabled by default)" << '\n';
                     } else {
                         std::cerr << "  HRTF: Failed to initialize streaming mode" << '\n';
-                        delete g_hrtf_processor;
-                        g_hrtf_processor = nullptr;
+                        delete g_state.crossfeed.processor;
+                        g_state.crossfeed.processor = nullptr;
                     }
                 } else {
                     std::cerr << "  HRTF: Failed to initialize processor" << '\n';
@@ -1658,8 +1581,8 @@ int main(int argc, char* argv[]) {
                                  "generate HRTF "
                                  "filters"
                               << '\n';
-                    delete g_hrtf_processor;
-                    g_hrtf_processor = nullptr;
+                    delete g_state.crossfeed.processor;
+                    g_state.crossfeed.processor = nullptr;
                 }
             } else {
                 std::cout << "HRTF directory not found (" << hrtfDir
@@ -1675,129 +1598,131 @@ int main(int argc, char* argv[]) {
 
         std::cout << '\n';
 
-        if (!g_audio_pipeline && g_upsampler) {
+        if (!g_state.audioPipeline && g_state.upsampler) {
             audio_pipeline::Dependencies pipelineDeps{};
-            pipelineDeps.config = &g_config;
+            pipelineDeps.config = &g_state.config;
             pipelineDeps.upsampler.available = true;
-            pipelineDeps.upsampler.streamLeft = g_upsampler->streamLeft_;
-            pipelineDeps.upsampler.streamRight = g_upsampler->streamRight_;
-            pipelineDeps.output.outputGain = &g_output_gain;
-            pipelineDeps.output.limiterGain = &g_limiter_gain;
-            pipelineDeps.output.effectiveGain = &g_effective_gain;
+            pipelineDeps.upsampler.streamLeft = g_state.upsampler->streamLeft_;
+            pipelineDeps.upsampler.streamRight = g_state.upsampler->streamRight_;
+            pipelineDeps.output.outputGain = &g_state.gains.output;
+            pipelineDeps.output.limiterGain = &g_state.gains.limiter;
+            pipelineDeps.output.effectiveGain = &g_state.gains.effective;
             pipelineDeps.upsampler.process =
                 [](const float* data, size_t frames, ConvolutionEngine::StreamFloatVector& output,
                    cudaStream_t stream, ConvolutionEngine::StreamFloatVector& streamInput,
                    size_t& streamAccumulated) {
-                    if (!g_upsampler) {
+                    if (!g_state.upsampler) {
                         return false;
                     }
-                    return g_upsampler->processStreamBlock(data, frames, output, stream,
-                                                           streamInput, streamAccumulated);
+                    return g_state.upsampler->processStreamBlock(data, frames, output, stream,
+                                                                 streamInput, streamAccumulated);
                 };
-            pipelineDeps.fallbackActive = &g_fallback_active;
-            pipelineDeps.outputReady = &g_output_ready;
-            pipelineDeps.inputMutex = &g_input_process_mutex;
-            pipelineDeps.streamingCacheManager = g_streaming_cache_manager.get();
-            pipelineDeps.streamInputLeft = &g_stream_input_left;
-            pipelineDeps.streamInputRight = &g_stream_input_right;
-            pipelineDeps.streamAccumulatedLeft = &g_stream_accumulated_left;
-            pipelineDeps.streamAccumulatedRight = &g_stream_accumulated_right;
-            pipelineDeps.upsamplerOutputLeft = &g_upsampler_output_left;
-            pipelineDeps.upsamplerOutputRight = &g_upsampler_output_right;
-            pipelineDeps.cfStreamInputLeft = &g_cf_stream_input_left;
-            pipelineDeps.cfStreamInputRight = &g_cf_stream_input_right;
-            pipelineDeps.cfStreamAccumulatedLeft = &g_cf_stream_accumulated_left;
-            pipelineDeps.cfStreamAccumulatedRight = &g_cf_stream_accumulated_right;
-            pipelineDeps.cfOutputLeft = &g_cf_output_left;
-            pipelineDeps.cfOutputRight = &g_cf_output_right;
-            pipelineDeps.crossfeedEnabled = &g_crossfeed_enabled;
-            pipelineDeps.crossfeedProcessor = g_hrtf_processor;
-            pipelineDeps.crossfeedMutex = &g_crossfeed_mutex;
+            pipelineDeps.fallbackActive = &g_state.fallbackActive;
+            pipelineDeps.outputReady = &g_state.flags.outputReady;
+            pipelineDeps.inputMutex = &g_state.inputProcessMutex;
+            pipelineDeps.streamingCacheManager = g_state.managers.streamingCacheManager.get();
+            pipelineDeps.streamInputLeft = &g_state.streaming.streamInputLeft;
+            pipelineDeps.streamInputRight = &g_state.streaming.streamInputRight;
+            pipelineDeps.streamAccumulatedLeft = &g_state.streaming.streamAccumulatedLeft;
+            pipelineDeps.streamAccumulatedRight = &g_state.streaming.streamAccumulatedRight;
+            pipelineDeps.upsamplerOutputLeft = &g_state.streaming.upsamplerOutputLeft;
+            pipelineDeps.upsamplerOutputRight = &g_state.streaming.upsamplerOutputRight;
+            pipelineDeps.cfStreamInputLeft = &g_state.crossfeed.cfStreamInputLeft;
+            pipelineDeps.cfStreamInputRight = &g_state.crossfeed.cfStreamInputRight;
+            pipelineDeps.cfStreamAccumulatedLeft = &g_state.crossfeed.cfStreamAccumulatedLeft;
+            pipelineDeps.cfStreamAccumulatedRight = &g_state.crossfeed.cfStreamAccumulatedRight;
+            pipelineDeps.cfOutputLeft = &g_state.crossfeed.cfOutputLeft;
+            pipelineDeps.cfOutputRight = &g_state.crossfeed.cfOutputRight;
+            pipelineDeps.crossfeedEnabled = &g_state.crossfeed.enabled;
+            pipelineDeps.crossfeedProcessor = g_state.crossfeed.processor;
+            pipelineDeps.crossfeedMutex = &g_state.crossfeed.crossfeedMutex;
             pipelineDeps.buffer.playbackBuffer = &playback_buffer();
             pipelineDeps.maxOutputBufferFrames = []() { return get_max_output_buffer_frames(); };
             pipelineDeps.currentOutputRate = []() {
-                return g_current_output_rate.load(std::memory_order_acquire);
+                return g_state.rates.currentOutputRate.load(std::memory_order_acquire);
             };
-            g_audio_pipeline =
+            g_state.audioPipeline =
                 std::make_unique<audio_pipeline::AudioPipeline>(std::move(pipelineDeps));
-            g_audio_pipeline_raw = g_audio_pipeline.get();
+            g_state.managers.audioPipelineRaw = g_state.audioPipeline.get();
         }
 
         // Check for early abort before starting threads
-        if (!g_running) {
+        if (!g_state.flags.running) {
             std::cout << "Startup interrupted by signal" << '\n';
-            delete g_upsampler;
-            g_upsampler = nullptr;
+            delete g_state.upsampler;
+            g_state.upsampler = nullptr;
             break;
         }
 
         // Initialize soft mute controller with output sample rate
         using namespace DaemonConstants;
-        int outputSampleRate = g_input_sample_rate * g_config.upsampleRatio;
-        g_soft_mute = new SoftMute::Controller(DEFAULT_SOFT_MUTE_FADE_MS, outputSampleRate);
+        int outputSampleRate = g_state.rates.inputSampleRate * g_state.config.upsampleRatio;
+        g_state.softMute.controller =
+            new SoftMute::Controller(DEFAULT_SOFT_MUTE_FADE_MS, outputSampleRate);
         std::cout << "Soft mute initialized (" << DEFAULT_SOFT_MUTE_FADE_MS << "ms fade at "
                   << outputSampleRate << "Hz)" << '\n';
 
         // Initialize fallback manager (Issue #139)
-        if (g_config.fallback.enabled) {
-            g_fallback_manager = new FallbackManager::Manager();
+        if (g_state.config.fallback.enabled) {
+            g_state.fallbackManager = new FallbackManager::Manager();
             FallbackManager::FallbackConfig fbConfig;
-            fbConfig.gpuThreshold = g_config.fallback.gpuThreshold;
-            fbConfig.gpuThresholdCount = g_config.fallback.gpuThresholdCount;
-            fbConfig.gpuRecoveryThreshold = g_config.fallback.gpuRecoveryThreshold;
-            fbConfig.gpuRecoveryCount = g_config.fallback.gpuRecoveryCount;
-            fbConfig.xrunTriggersFallback = g_config.fallback.xrunTriggersFallback;
-            fbConfig.monitorIntervalMs = g_config.fallback.monitorIntervalMs;
+            fbConfig.gpuThreshold = g_state.config.fallback.gpuThreshold;
+            fbConfig.gpuThresholdCount = g_state.config.fallback.gpuThresholdCount;
+            fbConfig.gpuRecoveryThreshold = g_state.config.fallback.gpuRecoveryThreshold;
+            fbConfig.gpuRecoveryCount = g_state.config.fallback.gpuRecoveryCount;
+            fbConfig.xrunTriggersFallback = g_state.config.fallback.xrunTriggersFallback;
+            fbConfig.monitorIntervalMs = g_state.config.fallback.monitorIntervalMs;
 
             // State change callback: update atomic flag and notify via ZeroMQ
             auto stateCallback = [](FallbackManager::FallbackState state) {
                 bool isFallback = (state == FallbackManager::FallbackState::Fallback);
-                g_fallback_active.store(isFallback, std::memory_order_relaxed);
+                g_state.fallbackActive.store(isFallback, std::memory_order_relaxed);
 
                 // ZeroMQ notification is handled by STATS command response
                 LOG_INFO("Fallback state changed: {}", isFallback ? "FALLBACK" : "NORMAL");
             };
 
-            if (g_fallback_manager->initialize(fbConfig, stateCallback)) {
+            if (g_state.fallbackManager->initialize(fbConfig, stateCallback)) {
                 std::cout << "Fallback manager initialized (GPU threshold: "
                           << fbConfig.gpuThreshold << "%, XRUN fallback: "
                           << (fbConfig.xrunTriggersFallback ? "enabled" : "disabled") << ")"
                           << '\n';
             } else {
                 std::cerr << "Warning: Failed to initialize fallback manager" << '\n';
-                delete g_fallback_manager;
-                g_fallback_manager = nullptr;
-                g_fallback_active.store(false, std::memory_order_relaxed);
+                delete g_state.fallbackManager;
+                g_state.fallbackManager = nullptr;
+                g_state.fallbackActive.store(false, std::memory_order_relaxed);
             }
         } else {
             std::cout << "Fallback manager disabled" << '\n';
-            g_fallback_active.store(false, std::memory_order_relaxed);
+            g_state.fallbackActive.store(false, std::memory_order_relaxed);
         }
 
         std::unique_ptr<daemon_control::ControlPlane> controlPlane;
         // Legacy RTP path was removed: ALSA/TCP-only configuration
 
-        if (!g_dac_manager) {
-            g_dac_manager = std::make_unique<dac::DacManager>(make_dac_dependencies());
+        if (!g_state.managers.dacManager) {
+            g_state.managers.dacManager =
+                std::make_unique<dac::DacManager>(make_dac_dependencies());
         }
-        if (!g_dac_manager) {
+        if (!g_state.managers.dacManager) {
             std::cerr << "Failed to initialize DAC manager" << '\n';
             exitCode = 1;
             break;
         }
-        g_dac_manager_raw = g_dac_manager.get();
+        g_state.managers.dacManagerRaw = g_state.managers.dacManager.get();
 
         daemon_control::ControlPlaneDependencies controlDeps{};
-        controlDeps.config = &g_config;
-        controlDeps.runningFlag = &g_running;
-        controlDeps.reloadRequested = &g_reload_requested;
-        controlDeps.zmqBindFailed = &g_zmq_bind_failed;
-        controlDeps.currentOutputRate = &g_current_output_rate;
-        controlDeps.softMute = &g_soft_mute;
-        controlDeps.activePhaseType = &g_active_phase_type;
-        controlDeps.inputSampleRate = &g_input_sample_rate;
+        controlDeps.config = &g_state.config;
+        controlDeps.runningFlag = &g_state.flags.running;
+        controlDeps.reloadRequested = &g_state.flags.reloadRequested;
+        controlDeps.zmqBindFailed = &g_state.flags.zmqBindFailed;
+        controlDeps.currentOutputRate = &g_state.rates.currentOutputRate;
+        controlDeps.softMute = &g_state.softMute.controller;
+        controlDeps.activePhaseType = &g_state.rates.activePhaseType;
+        controlDeps.inputSampleRate = &g_state.rates.inputSampleRate;
         controlDeps.defaultAlsaDevice = DEFAULT_ALSA_DEVICE;
-        controlDeps.dispatcher = g_event_dispatcher.get();
+        controlDeps.dispatcher = g_state.managers.eventDispatcher.get();
         controlDeps.quitMainLoop = []() {};
         controlDeps.buildRuntimeStats = []() { return build_runtime_stats_dependencies(); };
         controlDeps.bufferCapacityFrames = []() { return get_max_output_buffer_frames(); };
@@ -1813,52 +1738,52 @@ int main(int argc, char* argv[]) {
         controlDeps.setPreferredOutputDevice = [](AppConfig& cfg, const std::string& device) {
             set_preferred_output_device(cfg, device);
         };
-        controlDeps.dacManager = g_dac_manager.get();
-        controlDeps.upsampler = &g_upsampler;
-        controlDeps.crossfeed.processor = &g_hrtf_processor;
-        controlDeps.crossfeed.enabledFlag = &g_crossfeed_enabled;
-        controlDeps.crossfeed.mutex = &g_crossfeed_mutex;
+        controlDeps.dacManager = g_state.managers.dacManager.get();
+        controlDeps.upsampler = &g_state.upsampler;
+        controlDeps.crossfeed.processor = &g_state.crossfeed.processor;
+        controlDeps.crossfeed.enabledFlag = &g_state.crossfeed.enabled;
+        controlDeps.crossfeed.mutex = &g_state.crossfeed.crossfeedMutex;
         controlDeps.crossfeed.resetStreamingState = []() { reset_crossfeed_stream_state_locked(); };
         controlDeps.statsFilePath = STATS_FILE_PATH;
 
         controlPlane = std::make_unique<daemon_control::ControlPlane>(std::move(controlDeps));
-        if (controlPlane && controlPlane->start() && g_dac_manager) {
-            g_dac_manager->setEventPublisher(controlPlane->eventPublisher());
+        if (controlPlane && controlPlane->start() && g_state.managers.dacManager) {
+            g_state.managers.dacManager->setEventPublisher(controlPlane->eventPublisher());
         }
 
-        if (g_dac_manager) {
-            g_dac_manager->initialize();
+        if (g_state.managers.dacManager) {
+            g_state.managers.dacManager->initialize();
         }
 
         // Start ALSA output thread
-        if (g_dac_manager) {
-            g_dac_manager->start();
+        if (g_state.managers.dacManager) {
+            g_state.managers.dacManager->start();
         }
         std::cout << "Starting ALSA output thread..." << '\n';
         std::thread alsa_thread(alsa_output_thread);
 
         std::thread loopback_thread;
-        if (g_config.loopback.enabled) {
-            if (!validate_loopback_config(g_config)) {
+        if (g_state.config.loopback.enabled) {
+            if (!validate_loopback_config(g_state.config)) {
                 exitCode = 1;
-                g_running = false;
+                g_state.flags.running = false;
                 alsa_thread.join();
                 break;
             }
-            snd_pcm_format_t lb_format = parse_loopback_format(g_config.loopback.format);
-            std::cout << "Starting loopback capture thread (" << g_config.loopback.device
-                      << ", fmt=" << g_config.loopback.format
-                      << ", rate=" << g_config.loopback.sampleRate
-                      << ", period=" << g_config.loopback.periodFrames << ")" << '\n';
+            snd_pcm_format_t lb_format = parse_loopback_format(g_state.config.loopback.format);
+            std::cout << "Starting loopback capture thread (" << g_state.config.loopback.device
+                      << ", fmt=" << g_state.config.loopback.format
+                      << ", rate=" << g_state.config.loopback.sampleRate
+                      << ", period=" << g_state.config.loopback.periodFrames << ")" << '\n';
             loopback_thread =
-                std::thread(loopback_capture_thread, g_config.loopback.device, lb_format,
-                            g_config.loopback.sampleRate, g_config.loopback.channels,
-                            static_cast<snd_pcm_uframes_t>(g_config.loopback.periodFrames));
+                std::thread(loopback_capture_thread, g_state.config.loopback.device, lb_format,
+                            g_state.config.loopback.sampleRate, g_state.config.loopback.channels,
+                            static_cast<snd_pcm_uframes_t>(g_state.config.loopback.periodFrames));
 
             // Wait briefly for loopback thread to become ready
             bool loopback_ready = false;
             for (int i = 0; i < 40; ++i) {  // up to ~2s
-                if (g_loopback_capture_ready.load(std::memory_order_acquire)) {
+                if (g_state.loopback.captureReady.load(std::memory_order_acquire)) {
                     loopback_ready = true;
                     break;
                 }
@@ -1866,7 +1791,7 @@ int main(int argc, char* argv[]) {
             }
             if (!loopback_ready) {
                 LOG_ERROR("[Loopback] Failed to start capture thread (not ready)");
-                g_running = false;
+                g_state.flags.running = false;
                 playback_buffer().cv().notify_all();
                 if (loopback_thread.joinable()) {
                     loopback_thread.join();
@@ -1877,18 +1802,19 @@ int main(int argc, char* argv[]) {
             }
         }
 
-        double outputRateKHz = g_input_sample_rate * g_config.upsampleRatio / 1000.0;
+        double outputRateKHz =
+            g_state.rates.inputSampleRate * g_state.config.upsampleRatio / 1000.0;
         std::cout << '\n';
-        if (g_config.loopback.enabled) {
+        if (g_state.config.loopback.enabled) {
             std::cout << "System ready (Loopback capture mode). Audio routing configured:" << '\n';
-            std::cout << "  1. Loopback capture → GPU Upsampler (" << g_config.upsampleRatio
+            std::cout << "  1. Loopback capture → GPU Upsampler (" << g_state.config.upsampleRatio
                       << "x upsampling)" << '\n';
             std::cout << "  2. GPU Upsampler → ALSA → SMSL DAC (" << outputRateKHz << "kHz direct)"
                       << '\n';
         } else {
             std::cout << "System ready (TCP/loopback input). Audio routing configured:" << '\n';
             std::cout << "  1. Network or loopback source → GPU Upsampler ("
-                      << g_config.upsampleRatio << "x upsampling)" << '\n';
+                      << g_state.config.upsampleRatio << "x upsampling)" << '\n';
             std::cout << "  2. GPU Upsampler → ALSA → SMSL DAC (" << outputRateKHz << "kHz direct)"
                       << '\n';
         }
@@ -1898,13 +1824,14 @@ int main(int argc, char* argv[]) {
         shutdownManager.notifyReady();
 
         auto runMainLoop = [&]() {
-            while (g_running.load() && !g_reload_requested.load() && !g_zmq_bind_failed.load()) {
+            while (g_state.flags.running.load() && !g_state.flags.reloadRequested.load() &&
+                   !g_state.flags.zmqBindFailed.load()) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
                 shutdownManager.tick();
             }
         };
 
-        if (g_zmq_bind_failed.load()) {
+        if (g_state.flags.zmqBindFailed.load()) {
             std::cerr << "Startup aborted due to ZeroMQ bind failure." << '\n';
         } else {
             runMainLoop();
@@ -1914,7 +1841,7 @@ int main(int argc, char* argv[]) {
 
         // Step 5: Signal worker threads to stop and wait for them
         std::cout << "  Step 5: Stopping worker threads..." << '\n';
-        g_running = false;
+        g_state.flags.running = false;
         playback_buffer().cv().notify_all();
         if (controlPlane) {
             controlPlane->stop();
@@ -1926,38 +1853,38 @@ int main(int argc, char* argv[]) {
 
         // Step 6: Release audio processing resources
         std::cout << "  Step 6: Releasing resources..." << '\n';
-        if (g_fallback_manager) {
-            g_fallback_manager->shutdown();
-            delete g_fallback_manager;
-            g_fallback_manager = nullptr;
-            g_fallback_active.store(false, std::memory_order_relaxed);
+        if (g_state.fallbackManager) {
+            g_state.fallbackManager->shutdown();
+            delete g_state.fallbackManager;
+            g_state.fallbackManager = nullptr;
+            g_state.fallbackActive.store(false, std::memory_order_relaxed);
         }
-        delete g_soft_mute;
-        g_soft_mute = nullptr;
-        delete g_hrtf_processor;
-        g_hrtf_processor = nullptr;
-        g_crossfeed_enabled.store(false);
-        if (g_audio_pipeline) {
-            g_audio_pipeline.reset();  // Tear down pipeline before deleting GPU upsampler
-            g_audio_pipeline_raw = nullptr;
+        delete g_state.softMute.controller;
+        g_state.softMute.controller = nullptr;
+        delete g_state.crossfeed.processor;
+        g_state.crossfeed.processor = nullptr;
+        g_state.crossfeed.enabled.store(false);
+        if (g_state.audioPipeline) {
+            g_state.audioPipeline.reset();  // Tear down pipeline before deleting GPU upsampler
+            g_state.managers.audioPipelineRaw = nullptr;
         }
-        delete g_upsampler;
-        g_upsampler = nullptr;
-        if (g_dac_manager) {
-            g_dac_manager->stop();
+        delete g_state.upsampler;
+        g_state.upsampler = nullptr;
+        if (g_state.managers.dacManager) {
+            g_state.managers.dacManager->stop();
         }
 
         // Don't reload if ZMQ bind failed - exit completely
-        if (g_zmq_bind_failed.load()) {
+        if (g_state.flags.zmqBindFailed.load()) {
             std::cerr << "Exiting due to ZeroMQ initialization failure." << '\n';
             exitCode = 1;
             break;
         }
 
-        if (g_reload_requested) {
+        if (g_state.flags.reloadRequested) {
             std::cout << "Reload requested. Restarting daemon with updated config..." << '\n';
         }
-    } while (g_reload_requested);
+    } while (g_state.flags.reloadRequested);
 
     // Release PID lock and remove file on clean exit
     release_pid_lock();


### PR DESCRIPTION
## Summary
- RuntimeStateを追加してals⼦ daemonのg_*状態を集約
- DaemonDependencies経由の依存注入に合わせてStateポインタを更新
- ループバック/クロスフィード/ストリーミングバッファをState管理に整理

## Testing
- /usr/bin/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
- /usr/bin/cmake --build build -j8
