### PR TITLE
Fix #894: AudioPipeline::process のRTパスでvector確保を避ける

### DIFF
--- a/include/daemon/audio_pipeline/audio_pipeline.h
+++ b/include/daemon/audio_pipeline/audio_pipeline.h
@@ -106,6 +106,10 @@ class AudioPipeline {
     Dependencies deps_;
     std::chrono::steady_clock::time_point lastDropWarn_{std::chrono::steady_clock::now() -
                                                         std::chrono::seconds(6)};
+
+    // RT パスで毎回 std::vector を生成しないためのワークバッファ (Issue #894)
+    std::vector<float> workLeft_;
+    std::vector<float> workRight_;
 };
 
 template <typename Container>


### PR DESCRIPTION
## Summary
- `AudioPipeline::process()` のRTパスで毎回 `std::vector<float>` を生成していたため、メンバのワークバッファ (`workLeft_`/`workRight_`) を導入して再利用するように変更しました。
- 初期化時に `blockSize/periodSize/loopback.periodFrames` 等から推定したサイズで `reserve/resize` し、通常経路での毎回のヒープ確保を避けます。

## Why
I2S移行後は周期が固定で、RTパスの malloc/new 由来の遅延が XRUN/音飛びとして顕在化しやすいため。

## Test plan
- `cmake -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j$(nproc)`
- `/usr/bin/ctest --test-dir build --output-on-failure`（482 tests, PASS）

Fixes #894