### PR TITLE
Fix #898: ALSA出力RTスレッドから stats I/O と stdio を排除

### DIFF
--- a/src/daemon/control/control_plane.cpp
+++ b/src/daemon/control/control_plane.cpp
@@ -216,8 +216,8 @@ void ControlPlane::startStatsThread() {
             size_t total = runtime_stats::totalSamples();
             size_t clips = runtime_stats::clipCount();
             if (clips > lastLoggedClips && total > 0) {
-                std::cout << "WARNING: Clipping detected - " << clips << " samples clipped out of "
-                          << total << " (" << (100.0 * clips / total) << "%)" << '\n';
+                LOG_WARN("Clipping detected: {} samples out of {} ({}%)", clips, total,
+                         (100.0 * static_cast<double>(clips) / static_cast<double>(total)));
                 lastLoggedClips = clips;
             }
 


### PR DESCRIPTION
## Summary
- `alsa_output_thread()`（RT優先度）から `runtime_stats::writeStatsFile(...)` を撤去し、stats JSON の書き出しを ControlPlane の stats thread に一本化
- RTパスの `std::cout/std::cerr` 直書きを排除し、`LOG_*`（必要箇所は `LOG_EVERY_N`）へ置換
- clipping 警告の出力も `std::cout` から `LOG_WARN` へ統一

## Test plan
- [x] `cmake -B build -DCMAKE_BUILD_TYPE=Release`
- [x] `cmake --build build -j$(nproc)`
- [x] `ctest --test-dir build --output-on-failure` (482 tests passed)

Fixes #898