### PR TITLE
Fix #823: USB検知強化（I2S/USB一時切断から自動復帰）

### DIFF
--- a/tests/python/test_usb_i2s_bridge.py
+++ b/tests/python/test_usb_i2s_bridge.py
@@ -62,3 +62,11 @@ def test_build_gst_launch_command_includes_convert_when_enabled() -> None:
     )
     assert "audioresample" in cmd
     assert "audioconvert" in cmd
+
+
+def test_pcm_device_node_mapping_capture() -> None:
+    assert str(bridge._pcm_device_node("hw:2,0", "c")) == "/dev/snd/pcmC2D0c"
+
+
+def test_pcm_device_node_mapping_playback() -> None:
+    assert str(bridge._pcm_device_node("plughw:0,0", "p")) == "/dev/snd/pcmC0D0p"


### PR DESCRIPTION
## Summary
- 既存のUSB→I2Sブリッジで、電源断復帰/USB抜き差し等のエッジケース時に **復帰検知が弱い**問題を補強。
- `hw_params` が `closed` のままでも **/dev/snd のデバイスノード出現**を根拠に「USB入力が戻った」ことを判定し、サイレンス状態から capture へ自動遷移。
- rate/format が未確定の復帰直後は **変換モードで安全に立ち上げ**、確定後に passthrough を試す（失敗時は自動で変換に戻る）。

## Why
- I2S経路で一部切れる（USB再enumerate/起動順/瞬断）ケースで、サイレンス維持のまま復帰できない可能性があったため。

## Test plan
- [ ] Piで USB抜き差し/PC再起動後に自動で capture に戻ること
- [ ] 44.1k系⇄48k系切替でも追従すること

Refs: #823