### PR TITLE
Fix #909: ユーザー明示依頼なしのマージ禁止ルール追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,10 @@ cmake --build build -j$(nproc)
 2. **Issue Number Required:** ブランチ名・PR名には必ずIssue番号を含める
    - ブランチ名: `feature/#123-feature-name` または `fix/#456-bug-description`
    - PR名: `#123 機能の説明` または `Fix #456: バグの説明`
+3. **No Auto Merge Without Explicit User Request (必須)**:
+   - **ユーザーが明示的に「マージして」と依頼した場合のみ** `gh pr merge` / merge API 等の **マージ操作を実行**すること。
+   - ユーザーが「マージ判断をせよ」「レビューして問題なければ判断」と言った場合は、**マージ可否の結論と根拠を提示するだけ**で、マージ操作は行わない。
+   - マージが必要そうでも、**明示依頼が無い限りは “マージ可能です。マージしますか？” 相当の確認を文章で返す**（マージ操作はしない）。
 
 ### Workflow
 


### PR DESCRIPTION
## Summary
- AGENTS.md に「ユーザーが明示的に『マージして』と依頼した場合のみマージ操作を実行する」ことを必須ルールとして追加。
- 「マージ判断をせよ」「レビューして問題なければ判断」等の指示では、判断結果を提示するだけでマージ操作は行わない。

## Background
- Issue #909: AIがユーザーの明示依頼なしにPRをマージしてしまう事故が発生したため、再発防止のためルールを明文化。

## Changes
- `AGENTS.md` の Git Workflow セクションに必須ルール #3 を追加。

Refs: Fix #909