### PR TITLE
#824 I2S制御プレーン（レート/ビット深度/CH相互監視・断線復帰同期）

### DIFF
--- a/raspberry_pi/README.md
+++ b/raspberry_pi/README.md
@@ -87,6 +87,17 @@ Magic Box Web UI からのレイテンシ変更を Pi に伝える場合に使�
 
 > 再起動ポリシー: `docker-compose.yml` では `restart: always` を指定しています。裸運用する場合も systemd で `Restart=always` を付け、片側クラッシュ時も自動復帰させてください。
 
+### I2S 制御プレーン (Issue #824)
+
+I2S のレート/フォーマット/チャンネルを Pi-Jetson 間で同期させ、どちらかが切断中でも復帰後に共通パラメータになるまで capture を待機します。
+
+- REP (Pi): `USB_I2S_CONTROL_ENDPOINT` (既定 `tcp://0.0.0.0:60100`)
+- REQ (Jetson 側など): `USB_I2S_CONTROL_PEER` (既定 `tcp://jetson:60101`)
+- 待機ポリシー: `USB_I2S_CONTROL_REQUIRE_PEER=true` で peer 同期完了まで capture を禁止
+- タイムアウト/ポーリング: `USB_I2S_CONTROL_TIMEOUT_MS` / `USB_I2S_CONTROL_POLL_INTERVAL_SEC`
+
+Jetson 側も `raspberry_pi/usb_i2s_bridge/control_agent.py` を `python3 -m raspberry_pi.usb_i2s_bridge.control_agent` で起動すると、同じ仕組みでステータスを提供できます。
+
 ## 参考: 生の GStreamer コマンド
 
 Python ラッパーの出力と同等の gst-launch 例です。

--- a/raspberry_pi/docker-compose.yml
+++ b/raspberry_pi/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     ulimits:
       rtprio: 95
       memlock: -1
+    ports:
+      - "60100:60100"
     devices:
       - "/dev/snd:/dev/snd"
     group_add:
@@ -30,6 +32,11 @@ services:
       USB_I2S_ALSA_BUFFER_TIME_US: ${USB_I2S_ALSA_BUFFER_TIME_US:-200000}
       USB_I2S_ALSA_LATENCY_TIME_US: ${USB_I2S_ALSA_LATENCY_TIME_US:-20000}
       USB_I2S_QUEUE_TIME_NS: ${USB_I2S_QUEUE_TIME_NS:-100000000}
+      USB_I2S_CONTROL_ENDPOINT: ${USB_I2S_CONTROL_ENDPOINT:-tcp://0.0.0.0:60100}
+      USB_I2S_CONTROL_PEER: ${USB_I2S_CONTROL_PEER:-tcp://jetson:60101}
+      USB_I2S_CONTROL_REQUIRE_PEER: ${USB_I2S_CONTROL_REQUIRE_PEER:-true}
+      USB_I2S_CONTROL_POLL_INTERVAL_SEC: ${USB_I2S_CONTROL_POLL_INTERVAL_SEC:-1.0}
+      USB_I2S_CONTROL_TIMEOUT_MS: ${USB_I2S_CONTROL_TIMEOUT_MS:-2000}
     restart: always
     logging:
       driver: "json-file"

--- a/raspberry_pi/usb_i2s_bridge/Dockerfile
+++ b/raspberry_pi/usb_i2s_bridge/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
         gstreamer1.0-plugins-bad \
         gstreamer1.0-plugins-ugly \
         python3 \
+        python3-zmq \
         python3-gi \
         gir1.2-gstreamer-1.0 \
         gir1.2-gst-plugins-base-1.0 \

--- a/raspberry_pi/usb_i2s_bridge/control_agent.py
+++ b/raspberry_pi/usb_i2s_bridge/control_agent.py
@@ -1,0 +1,202 @@
+"""Jetson/Pi 双方で使える I2S 制御プレーンエージェント."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import signal
+import sys
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+from .control_plane import ControlPlaneSync, _is_supported_rate
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ENDPOINT = os.getenv("I2S_CONTROL_ENDPOINT", "tcp://0.0.0.0:60101")
+DEFAULT_PEER = os.getenv("I2S_CONTROL_PEER", "tcp://192.168.55.100:60100")
+DEFAULT_DEVICE = os.getenv("I2S_CONTROL_DEVICE", "hw:Loopback,0,0")
+DEFAULT_STREAM = os.getenv("I2S_CONTROL_STREAM", "c")  # c: capture, p: playback
+DEFAULT_CHANNELS = int(os.getenv("I2S_CONTROL_CHANNELS", "2"))
+DEFAULT_FORMAT = os.getenv("I2S_CONTROL_DEFAULT_FORMAT", "S32_LE")
+DEFAULT_RATE = int(os.getenv("I2S_CONTROL_DEFAULT_RATE", "48000"))
+DEFAULT_POLL_SEC = float(os.getenv("I2S_CONTROL_POLL_INTERVAL_SEC", "1.0"))
+DEFAULT_TIMEOUT_MS = int(os.getenv("I2S_CONTROL_TIMEOUT_MS", "2000"))
+DEFAULT_REQUIRE_PEER = os.getenv("I2S_CONTROL_REQUIRE_PEER", "1").lower() not in {
+    "0",
+    "false",
+    "no",
+}
+
+
+def _hw_params_path(device: str, stream: str) -> Optional[Path]:
+    match = re.match(r"^(?:plughw:|hw:)(?P<card>\\d+),(?P<pcm>\\d+)", device)
+    if not match:
+        return None
+    card = match.group("card")
+    pcm = match.group("pcm")
+    suffix = "c" if stream == "c" else "p"
+    return Path(f"/proc/asound/card{card}/pcm{pcm}{suffix}/sub0/hw_params")
+
+
+def _parse_hw_params(path: Path) -> Tuple[Optional[int], Optional[str]]:
+    if not path.exists():
+        return None, None
+    try:
+        text = path.read_text()
+    except OSError:
+        return None, None
+    if "closed" in text:
+        return None, None
+    rate = None
+    fmt = None
+    for line in text.splitlines():
+        if line.startswith("rate:"):
+            for token in line.split():
+                if token.isdigit():
+                    rate = int(token)
+                    break
+        elif line.startswith("format:"):
+            parts = line.split()
+            if len(parts) >= 2:
+                fmt = parts[1].strip()
+    return rate, fmt
+
+
+def _device_present(device: str, stream: str) -> bool:
+    match = re.match(r"^(?:plughw:|hw:)(?P<card>\\d+),(?P<pcm>\\d+)", device)
+    if not match:
+        return False
+    card = match.group("card")
+    pcm = match.group("pcm")
+    suffix = "c" if stream == "c" else "p"
+    node = Path(f"/dev/snd/pcmC{card}D{pcm}{suffix}")
+    return node.exists()
+
+
+def _env_or_default_rate(rate: int) -> int:
+    return rate if _is_supported_rate(rate) else DEFAULT_RATE
+
+
+def _setup_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="I2S control-plane agent")
+    parser.add_argument("--endpoint", default=DEFAULT_ENDPOINT)
+    parser.add_argument("--peer", default=DEFAULT_PEER)
+    parser.add_argument("--device", default=DEFAULT_DEVICE)
+    parser.add_argument("--stream", default=DEFAULT_STREAM, choices=["c", "p"])
+    parser.add_argument("--channels", type=int, default=DEFAULT_CHANNELS)
+    parser.add_argument("--default-rate", type=int, default=DEFAULT_RATE)
+    parser.add_argument("--default-format", default=DEFAULT_FORMAT)
+    parser.add_argument("--poll-interval", type=float, default=DEFAULT_POLL_SEC)
+    parser.add_argument("--timeout-ms", type=int, default=DEFAULT_TIMEOUT_MS)
+    parser.add_argument(
+        "--allow-without-peer",
+        action="store_true",
+        default=not DEFAULT_REQUIRE_PEER,
+        help="peer 不達でも capture を許可する（デバッグ用）",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="verbose logging")
+    return parser.parse_args(argv)
+
+
+def _build_status(
+    *,
+    device: str,
+    stream: str,
+    channels: int,
+    default_rate: int,
+    default_format: str,
+) -> tuple[bool, str, int, str, int]:
+    present = _device_present(device, stream)
+    rate, fmt = (None, None)
+    if present:
+        path = _hw_params_path(device, stream)
+        if path:
+            rate, fmt = _parse_hw_params(path)
+    sample_rate = _env_or_default_rate(rate or default_rate)
+    fmt = fmt or default_format
+    mode = "capture" if present else "none"
+    return present, mode, sample_rate, fmt, channels
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _setup_logging(args.verbose)
+
+    sync = ControlPlaneSync(
+        endpoint=args.endpoint,
+        peer_endpoint=args.peer or None,
+        require_peer=not args.allow_without_peer,
+        poll_interval_sec=args.poll_interval,
+        timeout_ms=args.timeout_ms,
+    )
+    sync.start()
+
+    stop = False
+
+    def _handle_signal(signum, frame):  # noqa: ANN001
+        nonlocal stop
+        _ = signum, frame
+        stop = True
+
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+    logger.info(
+        "I2S control agent start endpoint=%s peer=%s device=%s stream=%s require_peer=%s",
+        args.endpoint,
+        args.peer,
+        args.device,
+        args.stream,
+        not args.allow_without_peer,
+    )
+
+    try:
+        while not stop:
+            running, mode, sample_rate, fmt, channels = _build_status(
+                device=args.device,
+                stream=args.stream,
+                channels=max(1, int(args.channels)),
+                default_rate=args.default_rate,
+                default_format=args.default_format,
+            )
+            if not _is_supported_rate(sample_rate):
+                logger.warning("Unsupported rate detected: %s", sample_rate)
+            sync.update_local(
+                running=running,
+                mode=mode,
+                sample_rate=sample_rate,
+                fmt=fmt,
+                channels=max(1, int(channels)),
+            )
+            if args.verbose:
+                peer = sync.peer_status()
+                logger.debug(
+                    "local mode=%s rate=%d fmt=%s ch=%d synced=%s peer=%s",
+                    mode,
+                    sample_rate,
+                    fmt,
+                    channels,
+                    sync.is_synced(),
+                    peer.to_dict() if peer else None,
+                )
+            time.sleep(args.poll_interval)
+    finally:
+        sync.stop()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    sys.exit(main())

--- a/raspberry_pi/usb_i2s_bridge/control_plane.py
+++ b/raspberry_pi/usb_i2s_bridge/control_plane.py
@@ -1,0 +1,381 @@
+"""ZeroMQ ベースの I2S 制御プレーン同期ユーティリティ."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional
+
+import zmq
+
+logger = logging.getLogger(__name__)
+
+# 44.1k/48k 系 x 1/2/4/8/16
+ALLOWED_SAMPLE_RATES = {
+    44_100,
+    88_200,
+    176_400,
+    352_800,
+    705_600,
+    48_000,
+    96_000,
+    192_000,
+    384_000,
+    768_000,
+}
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _is_supported_rate(rate: int) -> bool:
+    return int(rate) in ALLOWED_SAMPLE_RATES
+
+
+@dataclass
+class ControlStatus:
+    """共有する状態."""
+
+    running: bool
+    mode: str  # capture / silence / none
+    sample_rate: int
+    fmt: str
+    channels: int
+    generation: int = 0
+    updated_at_ms: int = field(default_factory=_now_ms)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "running": bool(self.running),
+            "mode": str(self.mode),
+            "sample_rate": int(self.sample_rate),
+            "format": str(self.fmt),
+            "channels": int(self.channels),
+            "generation": int(self.generation),
+            "updated_at_ms": int(self.updated_at_ms),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ControlStatus":
+        return cls(
+            running=bool(data.get("running", False)),
+            mode=str(data.get("mode", "none")),
+            sample_rate=int(data.get("sample_rate", 0)),
+            fmt=str(data.get("format", "")),
+            channels=int(data.get("channels", 0)),
+            generation=int(data.get("generation", 0)),
+            updated_at_ms=int(data.get("updated_at_ms", _now_ms())),
+        )
+
+    def is_supported(self) -> bool:
+        return _is_supported_rate(self.sample_rate) and self.channels > 0
+
+
+class ControlPlaneServer:
+    """REQ/REP の REP 側."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        status_provider: Callable[[], ControlStatus],
+        on_peer_status: Optional[Callable[[ControlStatus], None]] = None,
+        timeout_ms: int = 2000,
+    ) -> None:
+        self._endpoint = endpoint
+        self._status_provider = status_provider
+        self._on_peer_status = on_peer_status
+        self._timeout_ms = max(500, int(timeout_ms))
+        self._ctx: zmq.Context | None = None
+        self._socket: zmq.Socket | None = None
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._ctx = zmq.Context()
+        sock = self._ctx.socket(zmq.REP)
+        sock.linger = 0
+        sock.rcvtimeo = self._timeout_ms
+        sock.sndtimeo = self._timeout_ms
+        sock.bind(self._endpoint)
+        self._socket = sock
+        self._thread = threading.Thread(
+            target=self._serve, name="i2s_control_rep", daemon=True
+        )
+        self._thread.start()
+        logger.info("I2S control-plane server started at %s", self._endpoint)
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=(self._timeout_ms / 1000) + 1)
+        if self._socket:
+            try:
+                self._socket.close(0)
+            except zmq.ZMQError:
+                pass
+        if self._ctx:
+            try:
+                self._ctx.term()
+            except zmq.ZMQError:
+                pass
+        self._socket = None
+        self._ctx = None
+        self._thread = None
+
+    def _serve(self) -> None:
+        assert self._socket is not None
+        sock = self._socket
+        while not self._stop.is_set():
+            try:
+                req = sock.recv_json(flags=0)
+            except zmq.Again:
+                continue
+            except zmq.ZMQError:
+                break
+            except ValueError:
+                continue
+
+            resp = self._handle(req if isinstance(req, dict) else {})
+            try:
+                sock.send_json(resp)
+            except zmq.ZMQError:
+                logger.warning("I2S control-plane: send failed")
+                continue
+
+    def _handle(self, req: Dict[str, Any]) -> Dict[str, Any]:
+        cmd = str(req.get("cmd", "")).upper()
+        if cmd not in {"STATUS", "SYNC"}:
+            return {"status": "error", "message": f"unknown cmd: {cmd or '<empty>'}"}
+
+        peer = req.get("peer")
+        if peer and isinstance(peer, dict) and self._on_peer_status:
+            try:
+                self._on_peer_status(ControlStatus.from_dict(peer))
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("failed to parse peer status: %s", exc)
+
+        status = self._status_provider()
+        return {"status": "ok", "data": status.to_dict()}
+
+
+class ControlPlaneSync:
+    """双方向同期と capture 許可判定を担う."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        peer_endpoint: Optional[str],
+        require_peer: bool = True,
+        poll_interval_sec: float = 1.0,
+        timeout_ms: int = 2000,
+    ) -> None:
+        self._local = ControlStatus(
+            running=False, mode="none", sample_rate=0, fmt="", channels=0, generation=0
+        )
+        self._peer: ControlStatus | None = None
+        self._peer_endpoint = peer_endpoint
+        self._require_peer = require_peer
+        self._poll_interval = max(0.2, float(poll_interval_sec))
+        self._timeout_ms = max(500, int(timeout_ms))
+        self._lock = threading.Lock()
+        self._synced = False
+        self._server = ControlPlaneServer(
+            endpoint=endpoint,
+            status_provider=self._get_local,
+            on_peer_status=self._set_peer,
+            timeout_ms=timeout_ms,
+        )
+        self._ctx: zmq.Context | None = None
+        self._client: zmq.Socket | None = None
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+
+    # --- lifecycle ---
+    def start(self) -> None:
+        self._server.start()
+        if self._peer_endpoint:
+            self._stop.clear()
+            self._ctx = zmq.Context()
+            self._client = None
+            self._thread = threading.Thread(
+                target=self._poll_peer, name="i2s_control_req", daemon=True
+            )
+            self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=self._poll_interval + 0.5)
+        self._reset_client()
+        if self._ctx:
+            try:
+                self._ctx.term()
+            except zmq.ZMQError:
+                pass
+        self._client = None
+        self._ctx = None
+        self._thread = None
+        self._server.stop()
+
+    # --- state ops ---
+    def update_local(
+        self,
+        *,
+        running: bool,
+        mode: str,
+        sample_rate: int,
+        fmt: str,
+        channels: int,
+    ) -> None:
+        """ローカル状態を更新し、生成番号を進める."""
+        with self._lock:
+            changed = (
+                running != self._local.running
+                or mode != self._local.mode
+                or sample_rate != self._local.sample_rate
+                or fmt != self._local.fmt
+                or channels != self._local.channels
+            )
+            if changed:
+                self._local.generation += 1
+            self._local.running = running
+            self._local.mode = mode
+            self._local.sample_rate = int(sample_rate)
+            self._local.fmt = fmt
+            self._local.channels = int(channels)
+            self._local.updated_at_ms = _now_ms()
+            if changed:
+                self._synced = False
+
+    def _get_local(self) -> ControlStatus:
+        with self._lock:
+            return ControlStatus(**self._local.__dict__)
+
+    def _set_peer(self, status: ControlStatus) -> None:
+        with self._lock:
+            self._peer = status
+            self._refresh_synced_locked()
+
+    def peer_status(self) -> ControlStatus | None:
+        with self._lock:
+            return self._peer
+
+    def is_synced(self) -> bool:
+        with self._lock:
+            return self._synced
+
+    def capture_allowed(self) -> bool:
+        """capture モードを許可するか判定."""
+        with self._lock:
+            if not _is_supported_rate(self._local.sample_rate):
+                return False
+            if not self._require_peer:
+                return True
+            return self._synced
+
+    # --- polling ---
+    def _poll_peer(self) -> None:
+        while not self._stop.wait(self._poll_interval):
+            sock = self._ensure_client()
+            if sock is None:
+                with self._lock:
+                    self._synced = False
+                continue
+            try:
+                sock.send_json({"cmd": "SYNC", "peer": self._get_local().to_dict()})
+                resp = sock.recv_json()
+            except zmq.Again:
+                # REQ/REP は timeout 後に EFSM になり得るため、ソケットを作り直す
+                self._reset_client()
+                with self._lock:
+                    self._synced = False
+                continue
+            except zmq.ZMQError:
+                self._reset_client()
+                with self._lock:
+                    self._synced = False
+                continue
+            except ValueError:
+                self._reset_client()
+                with self._lock:
+                    self._synced = False
+                continue
+
+            if not isinstance(resp, dict) or resp.get("status") != "ok":
+                with self._lock:
+                    self._synced = False
+                continue
+
+            data = resp.get("data") or {}
+            if not isinstance(data, dict):
+                # 想定外の型はプロトコル破損扱いとして同期解除＆リセット
+                with self._lock:
+                    self._synced = False
+                self._reset_client()
+                continue
+            try:
+                self._set_peer(ControlStatus.from_dict(data))
+            except Exception:  # noqa: BLE001
+                with self._lock:
+                    self._synced = False
+                # 破損した応答の可能性があるためリセット
+                self._reset_client()
+
+    def _ensure_client(self) -> zmq.Socket | None:
+        if not self._peer_endpoint:
+            return None
+        if self._ctx is None:
+            return None
+        if self._client is not None:
+            return self._client
+        try:
+            sock = self._ctx.socket(zmq.REQ)
+            sock.linger = 0
+            sock.rcvtimeo = self._timeout_ms
+            sock.sndtimeo = self._timeout_ms
+            sock.connect(self._peer_endpoint)
+            self._client = sock
+            return sock
+        except zmq.ZMQError:
+            self._reset_client()
+            return None
+
+    def _reset_client(self) -> None:
+        if self._client is None:
+            return
+        try:
+            self._client.close(0)
+        except zmq.ZMQError:
+            pass
+        self._client = None
+
+    # --- internal ---
+    def _refresh_synced_locked(self) -> None:
+        if self._peer is None:
+            self._synced = False
+            return
+        if not (self._local.is_supported() and self._peer.is_supported()):
+            self._synced = False
+            return
+        self._synced = (
+            self._peer.sample_rate == self._local.sample_rate
+            and self._peer.fmt == self._local.fmt
+            and self._peer.channels == self._local.channels
+        )
+
+
+__all__ = [
+    "ALLOWED_SAMPLE_RATES",
+    "ControlStatus",
+    "ControlPlaneServer",
+    "ControlPlaneSync",
+    "_is_supported_rate",
+]

--- a/raspberry_pi/usb_i2s_bridge/docker-compose.yml
+++ b/raspberry_pi/usb_i2s_bridge/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     ulimits:
       rtprio: 95
       memlock: -1
+    ports:
+      - "60100:60100"
     devices:
       - "/dev/snd:/dev/snd"
     group_add:
@@ -28,6 +30,11 @@ services:
       USB_I2S_ALSA_BUFFER_TIME_US: ${USB_I2S_ALSA_BUFFER_TIME_US:-200000}
       USB_I2S_ALSA_LATENCY_TIME_US: ${USB_I2S_ALSA_LATENCY_TIME_US:-20000}
       USB_I2S_QUEUE_TIME_NS: ${USB_I2S_QUEUE_TIME_NS:-100000000}
+      USB_I2S_CONTROL_ENDPOINT: ${USB_I2S_CONTROL_ENDPOINT:-tcp://0.0.0.0:60100}
+      USB_I2S_CONTROL_PEER: ${USB_I2S_CONTROL_PEER:-tcp://jetson:60101}
+      USB_I2S_CONTROL_REQUIRE_PEER: ${USB_I2S_CONTROL_REQUIRE_PEER:-true}
+      USB_I2S_CONTROL_POLL_INTERVAL_SEC: ${USB_I2S_CONTROL_POLL_INTERVAL_SEC:-1.0}
+      USB_I2S_CONTROL_TIMEOUT_MS: ${USB_I2S_CONTROL_TIMEOUT_MS:-2000}
     restart: always
     logging:
       driver: "json-file"


### PR DESCRIPTION
## Summary
- Pi/Jetson間で rate/format/ch を ZeroMQ で相互監視し、同期が取れるまで capture を抑止（silence にフォールバック）
- 通信断・再起動・設定変化時はパイプラインを安全に再構築し、復帰後に共通パラメータへ収束
- Docker/compose に制御プレーン用の env/port を追加し、コンテナ運用を前提に動作可能に

## Notes
- REQ/REP の EFSM を避けるため、timeout/例外時は REQ ソケットをリセットして自動復帰します。
- 対応レート: 44.1k/48k 系の 1/2/4/8/16（44100..768000）

## Test plan
- [x] `uv run pytest -q`（ローカル: 593 passed / 18 skipped）
- [x] pre-push hooks（mypy含む）を通過して push 済み