### PR TITLE
Fix #888: クロスフィード切替の安全化（ソフトミュート/キャッシュリセット）

### DIFF
--- a/include/daemon/control/control_plane.h
+++ b/include/daemon/control/control_plane.h
@@ -44,6 +44,9 @@ struct ControlPlaneDependencies {
     std::function<runtime_stats::Dependencies()> buildRuntimeStats;
     std::function<size_t()> bufferCapacityFrames;
     std::function<void(std::function<bool()>)> applySoftMuteForFilterSwitch;
+    // Clear playback + streaming caches without touching soft mute (caller wraps with soft mute).
+    // Used for glitch-free transitions that must not mix old/new audio blocks (Issue #888).
+    std::function<bool()> resetStreamingCachesForSwitch;
     std::function<void(const std::string&)> refreshHeadroom;
     std::function<bool()> reinitializeStreamingForLegacyMode;
     std::function<void(AppConfig&, const std::string&)> setPreferredOutputDevice;


### PR DESCRIPTION
Fixes #888\nRelates-to: #884\n\n## 変更内容\n- CROSSFEED_ENABLE/DISABLE 実行時にソフトミュート（fade out/in）を適用\n- 切替直前に playback buffer / upsampler streaming / crossfeed streaming のキャッシュを一括リセットし、未処理/処理済み音声の混在・ループ/グリッチを抑止\n\n## 動作確認\n- /usr/bin/cmake でビルド完了\n- gtest: build/cpu_tests (AudioPipeline) 実行\n- git push 時の pre-push hooks (clang-tidy/diff-based-tests 等) パス\n