### PR TITLE
Fix #949: UAC2入力の実レートに追従し誤リサンプルを防止

### DIFF
--- a/tests/python/test_usb_i2s_bridge.py
+++ b/tests/python/test_usb_i2s_bridge.py
@@ -10,6 +10,11 @@ def test_parse_hw_params_rate_returns_value() -> None:
     assert bridge._parse_hw_params_rate(content) == 44100
 
 
+def test_parse_hw_params_rate_tolerates_leading_spaces() -> None:
+    content = "access: RW_INTERLEAVED\n   rate: 44100 (44100/1)\n"
+    assert bridge._parse_hw_params_rate(content) == 44100
+
+
 def test_parse_hw_params_rate_closed_is_none() -> None:
     assert bridge._parse_hw_params_rate("closed\nrate: 48000") is None
 
@@ -17,6 +22,11 @@ def test_parse_hw_params_rate_closed_is_none() -> None:
 def test_parse_hw_params_format_returns_value() -> None:
     content = "access: RW_INTERLEAVED\nformat: S24_3LE\nrate: 48000\n"
     assert bridge._parse_hw_params_format(content) == "S24_3LE"
+
+
+def test_parse_hw_params_format_tolerates_leading_spaces() -> None:
+    content = "access: RW_INTERLEAVED\n  format: S32_LE\nrate: 48000\n"
+    assert bridge._parse_hw_params_format(content) == "S32_LE"
 
 
 def test_parse_hw_params_format_closed_is_none() -> None:


### PR DESCRIPTION
## Summary
- /proc/asound の hw_params を sub0 固定で読むことで、active substream を見逃して rate/format が None のまま fallback(48k) + plughw 変換に固定されるケースを修正
- hw_params の行頭空白を許容し、rate/format を確実にパース

## Why
Issue #949: 44.1k系/48k系の勝手なリサンプルはプロジェクトの根幹を破壊するため、入力デバイスが実際に動作している sample rate に確実に追従させる。

## Changes
- `raspberry_pi/usb_i2s_bridge/bridge.py`
  - hw_params の rate/format パースを堅牢化（行頭空白 + closed 判定）
  - `sub*/hw_params` を探索して active substream を拾う
- `tests/python/test_usb_i2s_bridge.py`
  - 行頭空白のパースをテスト追加

## Test plan
- [x] 既存 pre-commit / mypy / diff-based tests を push 時に通過
- [ ] Pi5 実機で UAC2 44.1k 入力時に I2S が 44.1k になり、ログで conversion=False を確認