### PR TITLE
Fix #966: I2S device string fallback + docker config migration

### DIFF
--- a/docker/jetson/config.docker.json
+++ b/docker/jetson/config.docker.json
@@ -55,7 +55,7 @@
   "i2s": {
     "enabled": true,
     "_comment_device": "Jetson Orin Nano の APE(=I2S RX) を想定。環境により 'hw:APE,0' などに調整してください。",
-    "device": "hw:APE,0,0",
+    "device": "hw:APE,0",
     "sampleRate": 0,
     "channels": 2,
     "format": "S32_LE",


### PR DESCRIPTION
## Summary
- Jetson I2S(APE) の ALSA device 表記ゆれ（`hw:APE,0` / `hw:APE,0,0`）に対し、daemon の capture open で両方を試すフォールバックを追加
- Jetson Docker の default config を `hw:APE,0` に寄せつつ、永続configが旧デフォルト(`hw:APE,0,0`)のときだけ entrypoint で自動マイグレーション

## Background
Issue #966（継続）: #964 の症状が PR #965 マージ後も改善しない件。
- #964 コメントで `arecord -D hw:APE,0 ...` は長時間安定という観測があり、docker default の `i2s.device=hw:APE,0,0` / 永続config不整合が疑わしい
- ただし環境により `hw:APE,0,0` でも動くため、コード側で両方を許容してハマりを潰す

## Test plan
- [x] `/usr/bin/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
- [x] `/usr/bin/cmake --build build -j$(nproc)`
- [x] `/usr/bin/ctest --test-dir build --output-on-failure`