### PR TITLE
Fix #969: opt-in I2S->Loopback bridge input mode

### DIFF
--- a/docker/jetson/docker-compose.jetson.yml
+++ b/docker/jetson/docker-compose.jetson.yml
@@ -65,6 +65,18 @@ services:
       # Wait for ALSA devices to appear after cold boot
       - MAGICBOX_WAIT_AUDIO_SECS=8
       - MAGICBOX_WAIT_LOOPBACK=true
+      # Mitigation for Jetson I2S capture instability:
+      # - Start an arecord->aplay bridge into snd-aloop and feed the daemon from loopback.
+      # - Enable only when investigating #969-like symptoms.
+      - MAGICBOX_I2S_LOOPBACK_BRIDGE=false
+      # Optional overrides (defaults shown):
+      # - MAGICBOX_I2S_CAPTURE_DEVICE=hw:APE,0,0
+      # - MAGICBOX_LOOPBACK_PLAYBACK_DEVICE=hw:Loopback,0,0
+      # - MAGICBOX_LOOPBACK_CAPTURE_DEVICE=hw:Loopback,1,0
+      # - MAGICBOX_LOOPBACK_RATE=44100
+      # - MAGICBOX_LOOPBACK_FORMAT=S32_LE
+      # - MAGICBOX_LOOPBACK_PERIOD_FRAMES=1024
+      # - MAGICBOX_LOOPBACK_BUFFER_FRAMES=4096
       # Set MAGICBOX_RESET_CONFIG=true to restore default config on next start
       # - MAGICBOX_RTP_RTCP_SEND_ENABLED=0
       # - MAGICBOX_RTP_USE_RTPBIN=0


### PR DESCRIPTION
## Summary
- Jetson の APE/I2S capture がシビアで、daemon 経路で「短く鳴ってノイズ/断続」になり得るケース向けに、**opt-in の I2S→snd-aloop(Loopback) ブリッジ入力モード**を追加。
- env を有効化すると entrypoint が
  - daemon 入力を loopback に強制（`i2s.enabled=false`, `loopback.enabled=true`）
  - `arecord (APE/I2S) | aplay (Loopback playback)` の常駐ブリッジを起動
  し、I2S取り込みとdaemon処理を ALSA 側でデカップリングします。
- デフォルト挙動（I2S直結）は維持。

## How to use
- `MAGICBOX_I2S_LOOPBACK_BRIDGE=true` を設定。
- 必要に応じて以下を上書き可能（docker-compose にコメント追記済）:
  - `MAGICBOX_I2S_CAPTURE_DEVICE`
  - `MAGICBOX_LOOPBACK_PLAYBACK_DEVICE` (default: `hw:Loopback,0,0`)
  - `MAGICBOX_LOOPBACK_CAPTURE_DEVICE` (default: `hw:Loopback,1,0`)
  - `MAGICBOX_LOOPBACK_RATE` (44100/48000)
  - `MAGICBOX_LOOPBACK_FORMAT` (default: S32_LE)
  - `MAGICBOX_LOOPBACK_PERIOD_FRAMES` / `MAGICBOX_LOOPBACK_BUFFER_FRAMES`

## Background
Issue #969 の再現条件では `arecord|aplay` の直結は安定する一方、daemon 経路が不安定という観測がありました。
この場合、I2S capture を arecord に逃がし、loopback をバッファ層として挟むことで改善する可能性があります。

## Test plan
- [x] `bash -n docker/jetson/entrypoint.sh`