### PR TITLE
Fix #969: make GPU streaming non-blocking mode configurable

### DIFF
--- a/docker/jetson/docker-compose.jetson.yml
+++ b/docker/jetson/docker-compose.jetson.yml
@@ -65,6 +65,10 @@ services:
       # Wait for ALSA devices to appear after cold boot
       - MAGICBOX_WAIT_AUDIO_SECS=8
       - MAGICBOX_WAIT_LOOPBACK=true
+      # Debug switch: disable Issue #899 non-blocking GPU completion (event-based pipelining).
+      # If disabling this makes #969 symptoms disappear, the root cause is likely in the
+      # non-blocking streaming path (cudaEventQuery-based delivery) rather than ALSA/I2S.
+      - MAGICBOX_GPU_STREAMING_NONBLOCKING=true
       # Set MAGICBOX_RESET_CONFIG=true to restore default config on next start
       # - MAGICBOX_RTP_RTCP_SEND_ENABLED=0
       # - MAGICBOX_RTP_USE_RTPBIN=0


### PR DESCRIPTION
## Summary
- Issue #899 の non-blocking GPUストリーミング（cudaEventQueryベースの完了待ち）を、env でON/OFF切替できるようにしました。
- `MAGICBOX_GPU_STREAMING_NONBLOCKING` で切替可能（default: true）。

## Why
Issue #969 の症状が I2S/ALSA ではなく、#899 の non-blocking 完了通知/パイプライン化のバグで起きている可能性があるため、
legacy（blocking / per-block 同期待ち）との A/B がすぐ出来るようにします。

## How to test (Jetson Docker)
- `MAGICBOX_GPU_STREAMING_NONBLOCKING=false` にして起動
  - 症状が消える/大きく変わる → #899 非同期パスが主因の可能性が高い
  - 変わらない → 別要因（partitioned tail など）を疑う

## Test plan
- [x] `/usr/bin/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
- [x] `/usr/bin/cmake --build build -j$(nproc)`
- [x] `/usr/bin/ctest --test-dir build --output-on-failure`