### PR TITLE
Fix #969: env overrides for partitioned convolution

### DIFF
--- a/docker/jetson/docker-compose.jetson.yml
+++ b/docker/jetson/docker-compose.jetson.yml
@@ -65,6 +65,12 @@ services:
       # Wait for ALSA devices to appear after cold boot
       - MAGICBOX_WAIT_AUDIO_SECS=8
       - MAGICBOX_WAIT_LOOPBACK=true
+      # Debug toggles for Issue #969 investigations:
+      # - Disable/limit partitioned convolution (low-latency mode)
+      # - If disabling this changes the symptom or removes huge peaks, the bug is likely in the
+      #   partitioned convolution path (tail handling / mixing / alignment).
+      - MAGICBOX_PARTITIONED_CONVOLUTION_ENABLED=true
+      # - MAGICBOX_PARTITIONED_CONVOLUTION_MAX_PARTITIONS=1
       # Set MAGICBOX_RESET_CONFIG=true to restore default config on next start
       # - MAGICBOX_RTP_RTCP_SEND_ENABLED=0
       # - MAGICBOX_RTP_USE_RTPBIN=0


### PR DESCRIPTION
## Summary
- partitioned convolution（低遅延モード）を env で強制OFF/制限できるようにしました。
  - `MAGICBOX_PARTITIONED_CONVOLUTION_ENABLED` (true/false)
  - `MAGICBOX_PARTITIONED_CONVOLUTION_MAX_PARTITIONS` (>0)

## Why
Issue #969 の観測では XRUN/ドロップが増えていない一方で、upsamplerピークが異常値になるケースがあり、
ALSA/I2Sではなく partitioned convolution（tail の合成/アラインメント等）側が疑わしいため、
Jetson/Dockerで即A/Bできるようにするのが目的です。

## How to test
- `MAGICBOX_PARTITIONED_CONVOLUTION_ENABLED=false` で起動
- もしくは `MAGICBOX_PARTITIONED_CONVOLUTION_MAX_PARTITIONS=1` で tail を殺して挙動変化を見る