### PR TITLE
Fix #899: partition streamingでsampleOffsetを反映

### DIFF
--- a/include/convolution_engine.h
+++ b/include/convolution_engine.h
@@ -696,7 +696,8 @@ class GPUUpsampler {
                                        StreamFloatVector& streamInputBuffer,
                                        size_t& streamInputAccumulated);
     bool processPartitionBlock(PartitionState& state, cudaStream_t stream,
-                               const DeviceSample* d_newSamples, int newSamples,
+                               const DeviceSample* d_history, size_t historySize,
+                               size_t historyStartIndex, int newSamples,
                                DeviceSample* d_channelOverlap, StreamFloatVector& partitionOutput);
     void setActiveHostCoefficients(const std::vector<float>& source);
     bool updateActiveImpulseFromSpectrum(const DeviceFftComplex* spectrum,


### PR DESCRIPTION
## Summary
- Partitioned streaming経路でパーティション係数の`sampleOffset`が入力に反映されず、fast+tailの時間整合が崩れる可能性があったため、アップサンプル後入力のヒストリ（リングバッファ）を導入して、各パーティションをoffset分だけ遅延した入力で畳み込むように修正。
- reset時にヒストリもクリアし、古いサンプル混入を防止。

## Why
`sampleOffset`不整合があると、tail寄与がズレた形で混ざり、数秒後に音が崩壊/ピーク異常などの症状に繋がり得るため。

## Test plan
- `/usr/bin/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
- `/usr/bin/cmake --build build -j$(nproc)`