### PR TITLE
Fix #976: RTP診断入力(Loopback)の復活

### DIFF
--- a/docker/jetson/docker-compose.jetson.yml
+++ b/docker/jetson/docker-compose.jetson.yml
@@ -37,6 +37,11 @@ services:
     # RTP はデフォルト無効。必要なら MAGICBOX_ENABLE_RTP=true にし、UDP(46000/46001/46002) を公開する。
     ports:
       - "80:80"
+      # RTP diagnostic (GStreamer rtpbin): RTP/RTCP ports
+      # NOTE: MAGICBOX_ENABLE_RTP はデフォルト false のため、通常運用では単に開いているだけ。
+      - "46000:46000/udp"
+      - "46001:46001/udp"
+      - "46002:46002/udp"
 
     # Shared memory for audio buffers
     shm_size: '256m'
@@ -56,15 +61,18 @@ services:
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
       # RTP はコードとして残すが、I2Sメイン運用ではデフォルトで無効化する。
       # 必要な場合のみ MAGICBOX_ENABLE_RTP=true にし、必要ならポートも公開する。
-      - MAGICBOX_ENABLE_RTP=false
-      - MAGICBOX_RTP_AUTOSTART=false
+      - MAGICBOX_ENABLE_RTP=${MAGICBOX_ENABLE_RTP:-false}
+      - MAGICBOX_RTP_AUTOSTART=${MAGICBOX_RTP_AUTOSTART:-false}
+      # 診断用: RTP受信 → ALSA Loopback playback → daemon が Loopback capture から取り込む
+      # これを true にすると entrypoint が (1) RTP有効化 (2) RTP自動起動 (3) loopback入力へ切替 を行う
+      - MAGICBOX_RTP_DIAGNOSTIC_LOOPBACK=${MAGICBOX_RTP_DIAGNOSTIC_LOOPBACK:-false}
       # USB直結構成では mDNS(raspberrypi.local) が見えないことがあるため、IPで固定
-      - MAGICBOX_RTP_SENDER_HOST=192.168.55.100
+      - MAGICBOX_RTP_SENDER_HOST=${MAGICBOX_RTP_SENDER_HOST:-192.168.55.100}
       # ZeroMQ ブリッジを使う場合（任意）
-      - RTP_BRIDGE_ENDPOINT=tcp://192.168.55.100:60000
+      - RTP_BRIDGE_ENDPOINT=${RTP_BRIDGE_ENDPOINT:-tcp://192.168.55.100:60000}
       # Wait for ALSA devices to appear after cold boot
-      - MAGICBOX_WAIT_AUDIO_SECS=8
-      - MAGICBOX_WAIT_LOOPBACK=true
+      - MAGICBOX_WAIT_AUDIO_SECS=${MAGICBOX_WAIT_AUDIO_SECS:-8}
+      - MAGICBOX_WAIT_LOOPBACK=${MAGICBOX_WAIT_LOOPBACK:-true}
       # Set MAGICBOX_RESET_CONFIG=true to restore default config on next start
       # - MAGICBOX_RTP_RTCP_SEND_ENABLED=0
       # - MAGICBOX_RTP_USE_RTPBIN=0


### PR DESCRIPTION
## Summary
- I2S経路を疑わずにGPUパスの音確認ができるよう、RTP受信→ALSA Loopback→daemon(loopback capture) の**診断モード**を追加
- Jetson Docker ComposeでRTP用UDPポート(46000/46001/46002)を公開し、envで切替できるように整理

## 使い方（診断用RTP入力）

### Jetson側

前提: ホスト側でALSA Loopbackを有効化（未ロードなら）

```bash
sudo modprobe snd-aloop
```

起動（診断モード）

```bash
cd docker
export MAGICBOX_RTP_DIAGNOSTIC_LOOPBACK=true
export MAGICBOX_RTP_SAMPLE_RATE=44100   # 48000でも可
export MAGICBOX_RTP_SENDER_HOST=192.168.55.100  # Raspberry PiのIP(USB直結の想定)
# export MAGICBOX_RTP_DEVICE=hw:Loopback,0,0    # RTP受信の書き込み先(既定)

docker compose -f jetson/docker-compose.jetson.yml up -d --build
```

確認（Webはコンテナ内でport 80）

```bash
curl -s http://<jetson-ip>/api/rtp-input/status | jq
```

補足:
- `MAGICBOX_RTP_DIAGNOSTIC_LOOPBACK=true` のとき、entrypointが `config.json` を診断用に上書きします（`i2s.enabled=false`, `loopback.enabled=true`, `loopback.format=S32_LE`, `loopback.sampleRate=44100/48000`）。
- 併せて `MAGICBOX_ENABLE_RTP` / `MAGICBOX_RTP_AUTOSTART` もコンテナ内で強制的に有効化します（誤設定で無音にならないため）。

### Raspberry Pi側

#### A) docker compose profile で起動（推奨）

```bash
cd raspberry_pi
# RTP系は profiles: [rtp] のため、明示が必要
RTP_SENDER_HOST=<jetson-ip> docker compose --profile rtp up -d --build rtp-sender rtp-bridge
```

#### B) 直接起動（最小）

```bash
python3 -m raspberry_pi.rtp_sender \
  --device hw:3,0 \
  --host <jetson-ip> \
  --rtp-port 46000 \
  --rtcp-port 46001 \
  --rtcp-listen-port 46002 \
  --format S24_3BE \
  --payload-type 96 \
  --latency-ms 100
```

送受の前提:
- RTP L16/L24/L32 はネットワークバイトオーダー（BE）
- payload type は 96

## Test plan
- [ ] `docker compose -f docker/jetson/docker-compose.jetson.yml config` でenv展開を確認
- [ ] Jetsonで `MAGICBOX_RTP_DIAGNOSTIC_LOOPBACK=true` 起動し、`/api/rtp-input/status` が running になることを確認
- [ ] Raspberry Piから送出し、Loopback入力→GPUパスで音が出ることを確認

Fixes #976