### PR TITLE
#983 OPRA履歴をSaved EQ Profilesから除外

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ cmake --build build -j$(nproc)
 | `/api/opra/search` | GET | OPRAヘッドホン検索 |
 | `/api/dac/capability/{id}` | GET | DAC性能取得 |
 
+> Note: OPRAから適用したプロファイルの履歴はSaved EQ Profilesには表示せず、`/api/eq/profiles` のレスポンスからも除外されます。
+
 ### ZeroMQコマンド
 
 | コマンド | 説明 |

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -54,6 +54,8 @@ EQプロファイル管理
 | DELETE | `/eq/profiles/{name}` | プロファイル削除 |
 | GET | `/eq/active` | アクティブプロファイル取得 |
 
+> Note: OPRAから自動生成される一時プロファイルは履歴に出さないため、`/eq/profiles` では除外されます。
+
 ### OPRA (`/opra`)
 OPRAヘッドホンEQデータベース連携
 

--- a/docs/setup/web_ui.md
+++ b/docs/setup/web_ui.md
@@ -170,6 +170,8 @@ async def dashboard_page(lang: str = "en"):
 | POST | `/eq/import` | プロファイルインポート |
 | DELETE | `/eq/profiles/{name}` | プロファイル削除 |
 
+> Note: OPRAから適用したプロファイルの履歴はSaved EQ Profilesに表示しない仕様のため、`/eq/profiles` の一覧には含まれません。
+
 ## ファイアウォール設定
 
 UFW を使用している場合:

--- a/web/routers/eq.py
+++ b/web/routers/eq.py
@@ -119,21 +119,23 @@ async def list_eq_profiles():
     if EQ_PROFILES_DIR.exists():
         for f in EQ_PROFILES_DIR.iterdir():
             if f.is_file() and f.suffix == ".txt":
-                # Determine profile type by checking content
                 profile_type = "custom"
                 filter_count = 0
                 try:
                     content = f.read_text(encoding="utf-8")
-                    if "# OPRA:" in content:
-                        profile_type = "opra"
-                    # Count filter lines
+                except IOError:
+                    content = None
+
+                if content and "# OPRA:" in content:
+                    # Hide OPRA-generated profiles from the saved list (issue #983)
+                    continue
+
+                if content:
                     filter_count = sum(
                         1
                         for line in content.split("\n")
                         if line.strip().startswith("Filter ")
                     )
-                except IOError:
-                    pass
 
                 stat = f.stat()
                 profiles.append(


### PR DESCRIPTION
## 概要\n- /eq/profiles で OPRA 生成プロファイルを一覧から除外し、Saved EQ Profiles に履歴を出さないように変更\n- 仕様変更を README / docs に追記\n- OPRA プロファイル除外のユニットテストを追加\n\nFixes #983\n\n## テスト\n- uv run python -m pytest tests/python/test_eq_api.py::TestProfilesEndpoint