### PR TITLE
Fix #984: クロスフェードONで無音になる問題を修正

### DIFF
--- a/src/gpu/four_channel_fir.cu
+++ b/src/gpu/four_channel_fir.cu
@@ -465,18 +465,14 @@ bool FourChannelFIR::processStreamBlock(const float* inputL, const float* inputR
             streamInputAccumulatedL = kept;
             streamInputAccumulatedR = kept;
         }
-
-        outputL.clear();
-        outputR.clear();
-        return false;
+    } else {
+        std::copy(inputL, inputL + inputFrames,
+                  streamInputBufferL.begin() + static_cast<std::ptrdiff_t>(streamInputAccumulatedL));
+        std::copy(inputR, inputR + inputFrames,
+                  streamInputBufferR.begin() + static_cast<std::ptrdiff_t>(streamInputAccumulatedR));
+        streamInputAccumulatedL += inputFrames;
+        streamInputAccumulatedR += inputFrames;
     }
-
-    std::copy(inputL, inputL + inputFrames,
-              streamInputBufferL.begin() + static_cast<std::ptrdiff_t>(streamInputAccumulatedL));
-    std::copy(inputR, inputR + inputFrames,
-              streamInputBufferR.begin() + static_cast<std::ptrdiff_t>(streamInputAccumulatedR));
-    streamInputAccumulatedL += inputFrames;
-    streamInputAccumulatedR += inputFrames;
 
     if (streamInputAccumulatedL < streamValidInputPerBlock_ ||
         streamInputAccumulatedR < streamValidInputPerBlock_) {


### PR DESCRIPTION
## Summary
- Fix #984: クロスフェード(HRTF 4ch FIR)が入力蓄積バッファ不足で処理継続できず無音化するケースを回復可能に修正
- EPIC #868 の方針に合わせ、HRTF関連の変更が `alsa_daemon.cpp` を肥大化させないよう **ALSA側の追加ロジックは撤回**し、修正範囲を `FourChannelFIR` 側に寄せた

## Notes
- HRTF(クロスフェード) と低遅延モード(partitionedConvolution)の排他は、ControlPlane 側で low-latency 有効時に `CROSSFEED_ENABLE` を拒否し、起動時も low-latency 有効ならクロスフェード初期化をスキップする実装になっていることを確認。
- Crossfeed 初期化/リセットのモジュール化は EPIC #868 の #873 に追従して別途実施する想定。

## Test plan
- `/usr/bin/cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `/usr/bin/cmake --build build -j$(nproc)`
- `/usr/bin/ctest --test-dir build --output-on-failure`