### PR TITLE
#873 alsa_daemon: crossfeed初期化のモジュール化

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ add_executable(gpu_upsampler_alsa
     src/alsa_daemon.cpp
     src/core/partition_runtime_utils.cpp
     src/daemon/app/process_resources.cpp
+    src/daemon/audio/crossfeed_manager.cpp
     src/daemon/audio/upsampler_builder.cpp
     src/daemon/audio_pipeline/audio_pipeline.cpp
     src/daemon/audio_pipeline/filter_manager.cpp
@@ -471,6 +472,7 @@ add_executable(cpu_tests
     tests/cpp/daemon/test_runtime_stats.cpp
     tests/cpp/audio/test_audio_pipeline.cpp
     tests/cpp/core/test_precision_traits.cpp
+    src/daemon/audio/crossfeed_manager.cpp
     src/daemon/audio_pipeline/audio_pipeline.cpp
     src/daemon/audio_pipeline/filter_manager.cpp
     src/daemon/audio_pipeline/rate_switcher.cpp

--- a/docs/architecture/crossfeed_integration.md
+++ b/docs/architecture/crossfeed_integration.md
@@ -21,7 +21,7 @@ EPIC #884 で掲げた既存畳み込みエンジンへの Crossfeed/HRTF 4ch FI
 - Crossfeed で生成される出力も `enqueueOutputFramesLocked` を通じて `PlaybackBufferManager::enqueue` されるため、バッファはアップサンプル出力と同一のキャパシティ管理ロジックを共有します。
 
 ## ON/OFF 切替と状態リセット
-1. `alsa_daemon.cpp` の `reset_crossfeed_stream_state_locked` はクロスフィードのストリーミングバッファ（蓄積量のみ）と `ConvolutionEngine::FourChannelFIR::resetStreaming()` をクリアし、切替時の残留データから生じる軋み音やバッファ膨張を防ぎます。
+1. `daemon/audio/crossfeed_manager.cpp` の `resetCrossfeedStreamStateLocked` はクロスフィードのストリーミングバッファ（蓄積量のみ）と `ConvolutionEngine::FourChannelFIR::resetStreaming()` をクリアし、切替時の残留データから生じる軋み音やバッファ膨張を防ぎます。
 2. `control_plane`（`src/daemon/control/control_plane.cpp`）では `deps_.crossfeed.enabledFlag`/`mutex` を介して `ConvolutionEngine::FourChannelFIR` へのアクセスを保護しており、`CROSSFEED_ENABLE/DISABLE` API は `resetStreamingState` を呼ぶことで状態を同期させます。
 3. Crossfeed を有効化するタイミングでは `StreamingCacheManager::onCrossfeedReset` を通じて playback buffer をリセットし、ソフトミュートと `softMute::Controller` が `renderOutput` 側で連動してポップ音を吸収します。
 4. 無効化後は `deps_.cfStreamInput*` の蓄積量をリセットして新しいアップサンプルブロックを待ち、次回有効化時にも `processStreamBlock` が新しいブロックから再スタートするよう整合性をとります。

--- a/include/daemon/audio/crossfeed_manager.h
+++ b/include/daemon/audio/crossfeed_manager.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "core/config_loader.h"
+#include "daemon/app/runtime_state.h"
+
+namespace daemon_audio {
+
+struct CrossfeedInitResult {
+    bool initialized = false;
+    bool skipped = false;
+};
+
+enum class CrossfeedSwitchStatus { NotInitialized, Switched, Failed };
+
+CrossfeedInitResult initializeCrossfeed(daemon_app::RuntimeState& state,
+                                        bool partitionedConvolutionEnabled);
+
+void resetCrossfeedStreamStateLocked(daemon_app::CrossfeedState& state);
+
+void clearCrossfeedRuntimeBuffers(daemon_app::CrossfeedState& state);
+
+CrossfeedSwitchStatus switchCrossfeedRateFamilyLocked(daemon_app::CrossfeedState& state,
+                                                      const AppConfig& config,
+                                                      ConvolutionEngine::RateFamily targetFamily);
+
+void shutdownCrossfeed(daemon_app::CrossfeedState& state);
+
+}  // namespace daemon_audio

--- a/src/daemon/audio/crossfeed_manager.cpp
+++ b/src/daemon/audio/crossfeed_manager.cpp
@@ -1,0 +1,185 @@
+#include "daemon/audio/crossfeed_manager.h"
+
+#include "core/daemon_constants.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <iostream>
+
+namespace daemon_audio {
+namespace {
+
+size_t computeStreamBufferCapacity(const AppConfig& config, size_t streamValidInputPerBlock) {
+    using namespace DaemonConstants;
+    size_t frames = static_cast<size_t>(DEFAULT_BLOCK_SIZE);
+    if (config.blockSize > 0) {
+        frames = std::max(frames, static_cast<size_t>(config.blockSize));
+    }
+    if (config.periodSize > 0) {
+        frames = std::max(frames, static_cast<size_t>(config.periodSize));
+    }
+    if (config.loopback.periodFrames > 0) {
+        frames = std::max(frames, static_cast<size_t>(config.loopback.periodFrames));
+    }
+    frames = std::max(frames, streamValidInputPerBlock);
+    // 2x safety margin for bursty upstream (no reallocation in RT path)
+    return frames * 2;
+}
+
+void allocateCrossfeedBuffers(daemon_app::CrossfeedState& state, const AppConfig& config,
+                              size_t streamValidInputPerBlock, size_t validOutputPerBlock,
+                              bool logCapacity) {
+    size_t bufferCapacity = computeStreamBufferCapacity(config, streamValidInputPerBlock);
+    state.cfStreamInputLeft.resize(bufferCapacity, 0.0f);
+    state.cfStreamInputRight.resize(bufferCapacity, 0.0f);
+    state.cfStreamAccumulatedLeft = 0;
+    state.cfStreamAccumulatedRight = 0;
+    state.cfOutputLeft.clear();
+    state.cfOutputRight.clear();
+    state.cfOutputBufferLeft.clear();
+    state.cfOutputBufferRight.clear();
+
+    size_t outputCapacity = std::max(bufferCapacity, validOutputPerBlock);
+    state.cfOutputLeft.reserve(outputCapacity);
+    state.cfOutputRight.reserve(outputCapacity);
+    state.cfOutputBufferLeft.reserve(outputCapacity);
+    state.cfOutputBufferRight.reserve(outputCapacity);
+
+    if (logCapacity) {
+        std::cout << "  Crossfeed buffer capacity: " << bufferCapacity << " samples" << '\n';
+    }
+}
+
+ConvolutionEngine::RateFamily resolveRateFamily(int inputSampleRate) {
+    ConvolutionEngine::RateFamily family = ConvolutionEngine::detectRateFamily(inputSampleRate);
+    if (family == ConvolutionEngine::RateFamily::RATE_UNKNOWN) {
+        family = ConvolutionEngine::RateFamily::RATE_44K;
+    }
+    return family;
+}
+
+}  // namespace
+
+CrossfeedInitResult initializeCrossfeed(daemon_app::RuntimeState& state,
+                                        bool partitionedConvolutionEnabled) {
+    CrossfeedInitResult result{};
+
+    if (partitionedConvolutionEnabled) {
+        std::cout << "[Partition] Crossfeed initialization skipped (low-latency mode)" << '\n';
+        result.skipped = true;
+        return result;
+    }
+
+    std::string hrtfDir = "data/crossfeed/hrtf";
+    if (!std::filesystem::exists(hrtfDir)) {
+        std::cout << "HRTF directory not found (" << hrtfDir << "), crossfeed feature disabled"
+                  << '\n';
+        std::cout << "  Hint: Run 'uv run python scripts/filters/generate_hrtf.py' to "
+                     "generate HRTF "
+                     "filters"
+                  << '\n';
+        return result;
+    }
+
+    std::cout << "Initializing HRTF processor for crossfeed..." << '\n';
+    state.crossfeed.processor = new ConvolutionEngine::FourChannelFIR();
+
+    ConvolutionEngine::RateFamily rateFamily = resolveRateFamily(state.rates.inputSampleRate);
+    ConvolutionEngine::HeadSize initialHeadSize =
+        ConvolutionEngine::stringToHeadSize(state.config.crossfeed.headSize);
+
+    if (!state.crossfeed.processor->initialize(hrtfDir, state.config.blockSize, initialHeadSize,
+                                               rateFamily)) {
+        std::cerr << "  HRTF: Failed to initialize processor" << '\n';
+        std::cerr << "  Hint: Run 'uv run python scripts/filters/generate_hrtf.py' to "
+                     "generate HRTF "
+                     "filters"
+                  << '\n';
+        delete state.crossfeed.processor;
+        state.crossfeed.processor = nullptr;
+        return result;
+    }
+
+    if (!state.crossfeed.processor->initializeStreaming()) {
+        std::cerr << "  HRTF: Failed to initialize streaming mode" << '\n';
+        delete state.crossfeed.processor;
+        state.crossfeed.processor = nullptr;
+        return result;
+    }
+
+    std::cout << "  HRTF processor ready (head size: "
+              << ConvolutionEngine::headSizeToString(initialHeadSize) << ", rate family: "
+              << (rateFamily == ConvolutionEngine::RateFamily::RATE_44K ? "44k" : "48k") << ")"
+              << '\n';
+
+    allocateCrossfeedBuffers(state.crossfeed, state.config,
+                             state.crossfeed.processor->getStreamValidInputPerBlock(),
+                             state.crossfeed.processor->getValidOutputPerBlock(), true);
+
+    state.crossfeed.enabled.store(false);
+    state.crossfeed.processor->setEnabled(false);
+    std::cout << "  Crossfeed: initialized (disabled by default)" << '\n';
+
+    result.initialized = true;
+    return result;
+}
+
+void resetCrossfeedStreamStateLocked(daemon_app::CrossfeedState& state) {
+    if (!state.cfStreamInputLeft.empty()) {
+        std::fill(state.cfStreamInputLeft.begin(), state.cfStreamInputLeft.end(), 0.0f);
+    }
+    if (!state.cfStreamInputRight.empty()) {
+        std::fill(state.cfStreamInputRight.begin(), state.cfStreamInputRight.end(), 0.0f);
+    }
+    state.cfStreamAccumulatedLeft = 0;
+    state.cfStreamAccumulatedRight = 0;
+    state.cfOutputLeft.clear();
+    state.cfOutputRight.clear();
+    if (state.processor) {
+        state.processor->resetStreaming();
+    }
+}
+
+void clearCrossfeedRuntimeBuffers(daemon_app::CrossfeedState& state) {
+    state.cfStreamInputLeft.clear();
+    state.cfStreamInputRight.clear();
+    state.cfStreamAccumulatedLeft = 0;
+    state.cfStreamAccumulatedRight = 0;
+    state.cfOutputBufferLeft.clear();
+    state.cfOutputBufferRight.clear();
+}
+
+CrossfeedSwitchStatus switchCrossfeedRateFamilyLocked(daemon_app::CrossfeedState& state,
+                                                      const AppConfig& config,
+                                                      ConvolutionEngine::RateFamily targetFamily) {
+    if (!state.processor) {
+        return CrossfeedSwitchStatus::NotInitialized;
+    }
+
+    if (!state.processor->switchRateFamily(targetFamily)) {
+        return CrossfeedSwitchStatus::Failed;
+    }
+
+    resetCrossfeedStreamStateLocked(state);
+
+    allocateCrossfeedBuffers(state, config, state.processor->getStreamValidInputPerBlock(),
+                             state.processor->getValidOutputPerBlock(), false);
+
+    return CrossfeedSwitchStatus::Switched;
+}
+
+void shutdownCrossfeed(daemon_app::CrossfeedState& state) {
+    delete state.processor;
+    state.processor = nullptr;
+    state.enabled.store(false);
+    state.cfStreamInputLeft.clear();
+    state.cfStreamInputRight.clear();
+    state.cfOutputLeft.clear();
+    state.cfOutputRight.clear();
+    state.cfOutputBufferLeft.clear();
+    state.cfOutputBufferRight.clear();
+    state.cfStreamAccumulatedLeft = 0;
+    state.cfStreamAccumulatedRight = 0;
+}
+
+}  // namespace daemon_audio


### PR DESCRIPTION
## Summary
- crossfeed初期化/バッファ管理/リセットを`daemon/audio/crossfeed_manager`へ移管
- rate switch時のHRTF切替・バッファ再構築を共通化
- クロスフィード統合のドキュメント参照先を更新

## Testing
- /usr/bin/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
- /usr/bin/cmake --build build -j$(nproc)
- /usr/bin/ctest --output-on-failure
- uv run pre-commit run --hook-stage pre-push
