### PR TITLE
#874 alsa_daemon: headroom/effective gain を責務分離

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ add_executable(gpu_upsampler_alsa
     src/daemon/audio/upsampler_builder.cpp
     src/daemon/audio_pipeline/audio_pipeline.cpp
     src/daemon/audio_pipeline/filter_manager.cpp
+    src/daemon/audio_pipeline/headroom_controller.cpp
     src/daemon/audio_pipeline/rate_switcher.cpp
     src/daemon/audio_pipeline/soft_mute_runner.cpp
     src/daemon/input/loopback_capture.cpp
@@ -475,6 +476,7 @@ add_executable(cpu_tests
     src/daemon/audio/crossfeed_manager.cpp
     src/daemon/audio_pipeline/audio_pipeline.cpp
     src/daemon/audio_pipeline/filter_manager.cpp
+    src/daemon/audio_pipeline/headroom_controller.cpp
     src/daemon/audio_pipeline/rate_switcher.cpp
     src/daemon/audio_pipeline/soft_mute_runner.cpp
     src/daemon/control/handlers/handler_registry.cpp

--- a/include/daemon/app/runtime_state.h
+++ b/include/daemon/app/runtime_state.h
@@ -17,6 +17,7 @@ namespace audio_pipeline {
 class AudioPipeline;
 class RateSwitcher;
 class FilterManager;
+class HeadroomController;
 class SoftMuteRunner;
 }  // namespace audio_pipeline
 
@@ -136,6 +137,7 @@ struct ManagerState {
 
     std::unique_ptr<audio_pipeline::RateSwitcher> rateSwitcher;
     std::unique_ptr<audio_pipeline::FilterManager> filterManager;
+    std::unique_ptr<audio_pipeline::HeadroomController> headroomController;
     std::unique_ptr<audio_pipeline::SoftMuteRunner> softMuteRunner;
     std::unique_ptr<daemon_output::AlsaOutput> alsaOutputInterface;
     std::unique_ptr<daemon_control::handlers::HandlerRegistry> handlerRegistry;

--- a/include/daemon/audio_pipeline/headroom_controller.h
+++ b/include/daemon/audio_pipeline/headroom_controller.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "audio/filter_headroom.h"
+#include "core/config_loader.h"
+#include "daemon/api/events.h"
+
+#include <atomic>
+#include <functional>
+#include <string>
+
+namespace audio_pipeline {
+
+struct HeadroomControllerDependencies {
+    daemon_core::api::EventDispatcher* dispatcher = nullptr;
+    AppConfig* config = nullptr;
+    FilterHeadroomCache* headroomCache = nullptr;
+    std::atomic<float>* headroomGain = nullptr;
+    std::atomic<float>* outputGain = nullptr;
+    std::atomic<float>* effectiveGain = nullptr;
+    std::function<ConvolutionEngine::RateFamily()> activeRateFamily;
+    std::function<PhaseType()> activePhaseType;
+};
+
+class HeadroomController {
+   public:
+    explicit HeadroomController(HeadroomControllerDependencies deps);
+
+    void start();
+    void handle(const daemon_core::api::FilterSwitchRequested& event);
+
+    std::string currentFilterPath() const;
+    void refreshCurrentHeadroom(const std::string& reason) const;
+    void setTargetPeak(float targetPeak);
+    void resetEffectiveGain(const std::string& reason) const;
+
+   private:
+    std::string resolveFilterPathFor(ConvolutionEngine::RateFamily family, PhaseType phase) const;
+    void updateEffectiveGain(float headroomGain, const std::string& reason) const;
+    void applyHeadroomForPath(const std::string& path, const std::string& reason) const;
+
+    HeadroomControllerDependencies deps_;
+};
+
+}  // namespace audio_pipeline

--- a/src/daemon/audio_pipeline/filter_manager.cpp
+++ b/src/daemon/audio_pipeline/filter_manager.cpp
@@ -19,10 +19,6 @@ void FilterManager::handle(const daemon_core::api::FilterSwitchRequested& event)
     lastPath_ = event.filterPath;
     lastPhase_ = event.phaseType;
 
-    if (deps_.deps.refreshHeadroom) {
-        deps_.deps.refreshHeadroom(event.filterPath);
-    }
-
     LOG_INFO("[FilterManager] Filter switch requested: path={}, phase={}, reloadHeadroom={}",
              event.filterPath, static_cast<int>(event.phaseType), event.reloadHeadroom);
 }

--- a/src/daemon/audio_pipeline/headroom_controller.cpp
+++ b/src/daemon/audio_pipeline/headroom_controller.cpp
@@ -1,0 +1,111 @@
+#include "daemon/audio_pipeline/headroom_controller.h"
+
+#include "logging/logger.h"
+
+#include <utility>
+
+namespace audio_pipeline {
+
+HeadroomController::HeadroomController(HeadroomControllerDependencies deps)
+    : deps_(std::move(deps)) {}
+
+void HeadroomController::start() {
+    if (deps_.dispatcher) {
+        deps_.dispatcher->subscribe(
+            [this](const daemon_core::api::FilterSwitchRequested& event) { handle(event); });
+    }
+}
+
+void HeadroomController::handle(const daemon_core::api::FilterSwitchRequested& event) {
+    if (!event.reloadHeadroom) {
+        return;
+    }
+
+    applyHeadroomForPath(event.filterPath, "filter switch");
+}
+
+std::string HeadroomController::currentFilterPath() const {
+    if (!deps_.config) {
+        return {};
+    }
+
+    ConvolutionEngine::RateFamily family = ConvolutionEngine::RateFamily::RATE_44K;
+    PhaseType phase = PhaseType::Minimum;
+    if (deps_.activeRateFamily) {
+        family = deps_.activeRateFamily();
+    }
+    if (deps_.activePhaseType) {
+        phase = deps_.activePhaseType();
+    }
+    return resolveFilterPathFor(family, phase);
+}
+
+void HeadroomController::refreshCurrentHeadroom(const std::string& reason) const {
+    applyHeadroomForPath(currentFilterPath(), reason);
+}
+
+void HeadroomController::setTargetPeak(float targetPeak) {
+    if (deps_.headroomCache) {
+        deps_.headroomCache->setTargetPeak(targetPeak);
+    }
+}
+
+void HeadroomController::resetEffectiveGain(const std::string& reason) const {
+    updateEffectiveGain(1.0f, reason);
+}
+
+std::string HeadroomController::resolveFilterPathFor(ConvolutionEngine::RateFamily family,
+                                                     PhaseType phase) const {
+    if (!deps_.config) {
+        return {};
+    }
+
+    if (phase == PhaseType::Linear) {
+        return (family == ConvolutionEngine::RateFamily::RATE_44K)
+                   ? deps_.config->filterPath44kLinear
+                   : deps_.config->filterPath48kLinear;
+    }
+    return (family == ConvolutionEngine::RateFamily::RATE_44K) ? deps_.config->filterPath44kMin
+                                                               : deps_.config->filterPath48kMin;
+}
+
+void HeadroomController::updateEffectiveGain(float headroomGain, const std::string& reason) const {
+    if (deps_.headroomGain) {
+        deps_.headroomGain->store(headroomGain, std::memory_order_relaxed);
+    }
+    float userGain = (deps_.config) ? deps_.config->gain : 1.0f;
+    float effective = userGain * headroomGain;
+    if (deps_.outputGain) {
+        deps_.outputGain->store(effective, std::memory_order_relaxed);
+    }
+    LOG_INFO("Gain [{}]: user {:.4f} * headroom {:.4f} = {:.4f}", reason, userGain, headroomGain,
+             effective);
+}
+
+void HeadroomController::applyHeadroomForPath(const std::string& path,
+                                              const std::string& reason) const {
+    if (path.empty()) {
+        LOG_WARN("Headroom [{}]: empty filter path, falling back to unity gain", reason);
+        updateEffectiveGain(1.0f, reason);
+        return;
+    }
+
+    if (!deps_.headroomCache) {
+        LOG_WARN("Headroom [{}]: headroom cache missing, falling back to unity gain", reason);
+        updateEffectiveGain(1.0f, reason);
+        return;
+    }
+
+    FilterHeadroomInfo info = deps_.headroomCache->get(path);
+    updateEffectiveGain(info.safeGain, reason);
+
+    if (!info.metadataFound) {
+        LOG_WARN("Headroom [{}]: metadata missing for {} (using safe gain {:.4f})", reason, path,
+                 info.safeGain);
+    } else {
+        LOG_INFO("Headroom [{}]: {} max_coef={:.6f} safeGain={:.4f} target={:.2f}", reason, path,
+                 info.maxCoefficient, info.safeGain, info.targetPeak);
+    }
+}
+
+}  // namespace audio_pipeline


### PR DESCRIPTION
## 概要\n- HeadroomController を追加し、headroom/gain 更新と filter path 解決を alsa_daemon から移設\n- FilterSwitchRequested の reloadHeadroom に合わせて headroom 更新を実施\n- 設定ロード/ControlPlane からの headroom 更新を HeadroomController 経由に統一\n\n## テスト\n- diff-based-tests (pre-push)