### PR TITLE
Fix #1022: 管理画面のデバイス選択をセレクトボックス化

### DIFF
--- a/web/services/alsa.py
+++ b/web/services/alsa.py
@@ -10,52 +10,71 @@ def get_alsa_devices() -> list[dict]:
     Returns list of dicts with keys: id, name, description
     """
     devices: list[dict] = []
+    seen: set[str] = set()
+
+    def add_device(device_id: str, name: str, description: str) -> None:
+        if not device_id or device_id in seen:
+            return
+        seen.add(device_id)
+        devices.append({"id": device_id, "name": name, "description": description})
 
     # Get card list
     try:
         result = subprocess.run(
             ["aplay", "-l"], capture_output=True, text=True, timeout=5
         )
-        if result.returncode != 0:
-            return devices
-
-        # Parse output
-        for line in result.stdout.split("\n"):
-            if line.startswith("card "):
+        if result.returncode == 0:
+            # Parse output
+            for line in result.stdout.split("\n"):
+                if not line.startswith("card "):
+                    continue
                 # Parse: "card 0: PCH [HDA Intel PCH], device 0: ALC897 Analog..."
                 parts = line.split(":")
-                if len(parts) >= 2:
-                    card_part = parts[0]  # "card 0"
-                    card_num = card_part.split()[1]
+                if len(parts) < 2:
+                    continue
+                card_part = parts[0]  # "card 0"
+                card_num = card_part.split()[1]
 
-                    # Get device number
-                    device_match = line.find("device ")
-                    if device_match != -1:
-                        device_part = line[device_match:].split(":")[0]
-                        device_num = device_part.split()[1]
+                # Card short id (e.g. "USB", "PCH") comes after ":"
+                card_id = parts[1].strip().split()[0] if parts[1].strip() else ""
 
-                        # Extract name
-                        name_start = parts[1].find("[")
-                        name_end = parts[1].find("]")
-                        if name_start != -1 and name_end != -1:
-                            card_name = parts[1][name_start + 1 : name_end]
-                        else:
-                            card_name = parts[1].strip().split(",")[0]
+                # Get device number
+                device_match = line.find("device ")
+                if device_match == -1:
+                    continue
+                device_part = line[device_match:].split(":")[0]
+                device_num = device_part.split()[1]
 
-                        device_id = f"hw:{card_num},{device_num}"
-                        devices.append(
-                            {
-                                "id": device_id,
-                                "name": card_name,
-                                "description": line.strip(),
-                            }
-                        )
+                # Extract card display name (prefer [...] content)
+                name_start = parts[1].find("[")
+                name_end = parts[1].find("]")
+                if name_start != -1 and name_end != -1:
+                    card_name = parts[1][name_start + 1 : name_end].strip()
+                else:
+                    card_name = parts[1].strip().split(",")[0].strip()
+
+                description = line.strip()
+
+                # Prefer showing card id + display name
+                display = card_name or card_id or f"card {card_num}"
+                if card_id and card_name and card_id not in card_name:
+                    display = f"{card_id} ({card_name})"
+
+                # Canonical numeric device id (always available)
+                add_device(f"hw:{card_num},{device_num}", display, description)
+
+                # Add card-id based aliases when available (helps users who use hw:USB, etc.)
+                if card_id:
+                    add_device(f"hw:{card_id},{device_num}", display, description)
+                    if device_num == "0":
+                        add_device(f"hw:{card_id}", display, description)
+                        add_device(f"hw:{card_num}", display, description)
     except (subprocess.SubprocessError, FileNotFoundError):
         pass
 
-    # Add default device
-    devices.insert(
-        0, {"id": "default", "name": "Default", "description": "System default"}
-    )
+    # Always include default device
+    default = {"id": "default", "name": "Default", "description": "System default"}
+    if "default" not in seen:
+        devices.insert(0, default)
 
     return devices

--- a/web/templates/pages/dashboard.html
+++ b/web/templates/pages/dashboard.html
@@ -72,10 +72,11 @@
             {% set form_select_options = '<template x-for="mode in outputMode.availableModes" :key="mode"><option :value="mode" x-text="mode.toUpperCase()"></option></template>' %}
             {% include 'components/form_group.html' %}
             {% set form_label = t.get('dashboard.output_mode.device_label') %}
-            {% set form_input_type = "text" %}
+            {% set form_input_type = "select" %}
+            {% set form_input_id = "preferredDevice" %}
             {% set form_input_model = "outputMode.preferredDevice" %}
-            {% set form_input_placeholder = "hw:USB" %}
-            {% set form_input_disabled = "outputMode.loading" %}
+            {% set form_input_disabled = "outputMode.loading || outputMode.devicesLoading" %}
+            {% set form_select_options = '<template x-for="dev in outputMode.devices" :key="dev.id"><option :value="dev.id" x-text="`${dev.id} — ${dev.name}`"></option></template>' %}
             {% include 'components/form_group.html' %}
             <div class="btn-row">
                 {% set button_label = t.get('dashboard.output_mode.save') %}
@@ -220,6 +221,8 @@ function dashboardData() {
             mode: 'usb',
             availableModes: ['usb'],
             preferredDevice: '',
+            devices: [{ id: 'default', name: 'Default', description: 'System default' }],
+            devicesLoading: false,
             loading: false,
         },
         messages: {
@@ -346,8 +349,50 @@ function dashboardData() {
                 this.outputMode.availableModes = data.available_modes || ['usb'];
                 this.outputMode.preferredDevice =
                     data.options?.usb?.preferred_device ?? '';
+                if (!this.outputMode.preferredDevice) {
+                    this.outputMode.preferredDevice = 'default';
+                }
             } catch (error) {
                 console.error('Failed to fetch output mode:', error);
+                if (!this.outputMode.preferredDevice) {
+                    this.outputMode.preferredDevice = 'default';
+                }
+            } finally {
+                await this.fetchOutputDevices();
+            }
+        },
+
+        async fetchOutputDevices() {
+            if (this.outputMode.devicesLoading) return;
+            this.outputMode.devicesLoading = true;
+            try {
+                const response = await fetch('/devices');
+                if (!response.ok) throw new Error('Failed to fetch devices');
+                const data = await response.json();
+                const devices = Array.isArray(data.devices) ? data.devices : [];
+
+                const current = (this.outputMode.preferredDevice || '').trim();
+                const ids = new Set(devices.map((d) => d?.id).filter(Boolean));
+                if (current && !ids.has(current)) {
+                    devices.unshift({
+                        id: current,
+                        name: 'Current (not detected)',
+                        description: '',
+                    });
+                }
+                if (!ids.has('default')) {
+                    devices.unshift({
+                        id: 'default',
+                        name: 'Default',
+                        description: 'System default',
+                    });
+                }
+                this.outputMode.devices = devices;
+            } catch (error) {
+                console.error('Failed to fetch ALSA devices:', error);
+                // keep existing devices list as fallback
+            } finally {
+                this.outputMode.devicesLoading = false;
             }
         },
 

--- a/web/tests/test_components.py
+++ b/web/tests/test_components.py
@@ -404,14 +404,14 @@ class TestFormGroupComponent:
         assert "<select" in html
 
     def test_form_group_with_text_input(self, client):
-        """Verify form group with text input type renders correctly."""
+        """Verify form group with select renders correctly for device choice."""
         response = client.get("/")
         assert response.status_code == 200
 
-        # Output Mode device input should be text type
+        # Output Mode device input should be select type (Issue #1022)
         html = response.text
-        assert 'type="text"' in html
-        assert "placeholder=" in html
+        assert '<select id="preferredDevice"' in html
+        assert 'x-model="outputMode.preferredDevice"' in html
 
     def test_form_group_with_textarea(self, client):
         """Verify form group with textarea type renders correctly."""


### PR DESCRIPTION
## Summary
- DashboardのOutput Mode設定で、優先ALSAデバイスをテキスト入力ではなく、実機から列挙した一覧(/devices)から選択できるように変更
- 既存設定値が一覧に無い場合でも先頭に保持して表示（\"Current (not detected)\"）し、意図せず空にしないように調整
- ALSAデバイス列挙は、hw:カード名系のエイリアスも返すよう改善し、aplay失敗時でもdefaultを返すよう堅牢化

## Test plan
- `uv run pytest -q web/tests`