### PR TITLE
Fix #1027: クロスフェード切替直後の音飛び + 頭サイズがMに戻る

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1990,6 +1990,7 @@
           "head_size": {
             "type": "string",
             "enum": [
+              "xs",
               "s",
               "m",
               "l",
@@ -2026,6 +2027,7 @@
               {
                 "type": "string",
                 "enum": [
+                  "xs",
                   "s",
                   "m",
                   "l",

--- a/web/models.py
+++ b/web/models.py
@@ -18,7 +18,8 @@ from pydantic import (
 # ============================================================================
 
 # HeadSize type for crossfeed settings (validated by Pydantic)
-HeadSize = Literal["s", "m", "l", "xl"]
+# Note: C++ side supports 5 sizes (xs/s/m/l/xl) and the UI exposes them.
+HeadSize = Literal["xs", "s", "m", "l", "xl"]
 
 # Common constrained types
 SessionId = constr(

--- a/web/templates/pages/dashboard.html
+++ b/web/templates/pages/dashboard.html
@@ -333,8 +333,14 @@ function dashboardData() {
                 const response = await fetch('/crossfeed/status');
                 if (!response.ok) throw new Error('Failed to fetch crossfeed status');
                 const data = await response.json();
-                this.crossfeed.enabled = data.enabled || false;
-                this.crossfeed.headSize = data.head_size || 'm';
+                const enabled = Boolean(data.enabled);
+                this.crossfeed.enabled = enabled;
+                // Keep status card in sync (it does not read config.json)
+                this.status.crossfeed_enabled = enabled;
+
+                const headSize = data.headSize ?? data.head_size ?? 'm';
+                this.crossfeed.headSize =
+                    typeof headSize === 'string' ? headSize.toLowerCase() : 'm';
             } catch (error) {
                 console.error('Failed to fetch crossfeed status:', error);
             }


### PR DESCRIPTION
## Summary
- Crossfeed 有効化直後に 4ch FIR がまだ出力できず enqueue が空になって PlaybackBuffer が枯渇し、underflow 起因で音が暴れる問題を緩和（ウォームアップ中は無音を enqueue してタイムライン維持）。
- Crossfeed enable/disable の切替時に十分にミュートしてから切り替えるよう、soft-mute 制御を調整（フェード時間を filter-switch 相当に拡張）。
- 管理画面が `/crossfeed/status` の `headSize` を `head_size` と誤読して常に M に戻る表示不整合を修正。
- `xs` を含む head size を Web の設定モデル/ OpenAPI に反映。

## Test plan
- `uv run pytest -q web/tests/test_models.py web/tests/test_components.py tests/python/test_crossfeed_ui.py tests/python/test_crossfeed_api.py tests/python/test_filter_switch_soft_mute.py`
- `/usr/bin/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && /usr/bin/cmake --build build -j$(nproc)`
- `/usr/bin/ctest --test-dir build --output-on-failure`