### PR TITLE
#877 alsa_daemon: 抽出モジュールの単体テスト追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,11 +469,14 @@ add_executable(cpu_tests
     tests/cpp/audio/test_rate_family.cpp
     tests/cpp/audio/test_eq_parser.cpp
     tests/cpp/audio/test_eq_to_fir.cpp
+    tests/cpp/audio/test_filter_headroom_cache.cpp
     tests/cpp/core/test_config_loader.cpp
     tests/cpp/e2e/test_partition_plan.cpp
     tests/cpp/audio/test_phase_alignment.cpp
     tests/cpp/audio/test_playback_buffer_threshold.cpp
     tests/cpp/daemon/test_alsa_write_loop.cpp
+    tests/cpp/daemon/test_loopback_helpers.cpp
+    tests/cpp/daemon/test_pid_lock.cpp
     tests/cpp/daemon/test_runtime_stats.cpp
     tests/cpp/daemon/test_stream_buffer_sizing.cpp
     tests/cpp/daemon/test_playback_buffer_access.cpp
@@ -489,6 +492,7 @@ add_executable(cpu_tests
     src/daemon/audio_pipeline/soft_mute_runner.cpp
     src/daemon/audio_pipeline/switch_actions.cpp
     src/daemon/control/handlers/handler_registry.cpp
+    src/daemon/core/pid_lock.cpp
     src/daemon/input/loopback_capture.cpp
     src/daemon/input/i2s_capture.cpp
     src/daemon/metrics/stats_file.cpp

--- a/tests/cpp/audio/test_filter_headroom_cache.cpp
+++ b/tests/cpp/audio/test_filter_headroom_cache.cpp
@@ -1,0 +1,82 @@
+#include "audio/filter_headroom.h"
+#include "gtest/gtest.h"
+
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+class FilterHeadroomCacheTest : public ::testing::Test {
+   protected:
+    fs::path tempDir;
+
+    void SetUp() override {
+        const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+        std::string name = "filter_headroom";
+        if (info) {
+            name = std::string(info->test_suite_name()) + "_" + std::string(info->name());
+        }
+        for (char& c : name) {
+            if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-')) {
+                c = '_';
+            }
+        }
+        tempDir = fs::temp_directory_path() /
+                  ("gpu_upsampler_test_" + name + "_" + std::to_string(getpid()));
+        fs::create_directories(tempDir);
+    }
+
+    void TearDown() override {
+        fs::remove_all(tempDir);
+    }
+
+    fs::path writeMetadata(const fs::path& coeffPath, float maxCoeff, float l1Norm) {
+        fs::path metaPath = coeffPath;
+        metaPath.replace_extension(".json");
+        std::ofstream ofs(metaPath);
+        ofs << R"({"validation_results":{"normalization":{)"
+            << R"("max_coefficient_amplitude":)" << maxCoeff << R"(,)"
+            << R"("l1_norm":)" << l1Norm << R"(}}})";
+        return metaPath;
+    }
+};
+
+TEST_F(FilterHeadroomCacheTest, MissingMetadataUsesDefaults) {
+    FilterHeadroomCache cache(0.8f);
+    fs::path coeffPath = tempDir / "filter.bin";
+
+    FilterHeadroomInfo info = cache.get(coeffPath.string());
+    EXPECT_FALSE(info.metadataFound);
+    EXPECT_FLOAT_EQ(info.maxCoefficient, 1.0f);
+    EXPECT_FLOAT_EQ(info.safeGain, 0.8f);
+    EXPECT_FLOAT_EQ(info.targetPeak, 0.8f);
+    EXPECT_EQ(info.metadataPath, (tempDir / "filter.json").string());
+}
+
+TEST_F(FilterHeadroomCacheTest, LoadsMetadataAndComputesSafeGain) {
+    FilterHeadroomCache cache(0.9f);
+    fs::path coeffPath = tempDir / "filter.bin";
+    writeMetadata(coeffPath, 2.0f, 123.0f);
+
+    FilterHeadroomInfo info = cache.get(coeffPath.string());
+    EXPECT_TRUE(info.metadataFound);
+    EXPECT_FLOAT_EQ(info.maxCoefficient, 2.0f);
+    EXPECT_FLOAT_EQ(info.l1Norm, 123.0f);
+    EXPECT_FLOAT_EQ(info.safeGain, 0.45f);
+}
+
+TEST_F(FilterHeadroomCacheTest, TargetPeakChangeClearsCache) {
+    FilterHeadroomCache cache(0.9f);
+    fs::path coeffPath = tempDir / "filter.bin";
+    writeMetadata(coeffPath, 2.0f, 0.0f);
+
+    FilterHeadroomInfo first = cache.get(coeffPath.string());
+    EXPECT_FLOAT_EQ(first.safeGain, 0.45f);
+
+    cache.setTargetPeak(0.7f);
+    FilterHeadroomInfo second = cache.get(coeffPath.string());
+    EXPECT_FLOAT_EQ(second.safeGain, 0.35f);
+}

--- a/tests/cpp/daemon/test_loopback_helpers.cpp
+++ b/tests/cpp/daemon/test_loopback_helpers.cpp
@@ -1,0 +1,100 @@
+#include "core/daemon_constants.h"
+#include "daemon/input/loopback_capture.h"
+#include "gtest/gtest.h"
+
+TEST(LoopbackHelpersTest, ParseLoopbackFormatHandlesAliases) {
+    EXPECT_EQ(daemon_input::parseLoopbackFormat("S16_LE"), SND_PCM_FORMAT_S16_LE);
+    EXPECT_EQ(daemon_input::parseLoopbackFormat("s24_3le"), SND_PCM_FORMAT_S24_3LE);
+    EXPECT_EQ(daemon_input::parseLoopbackFormat("S32"), SND_PCM_FORMAT_S32_LE);
+    EXPECT_EQ(daemon_input::parseLoopbackFormat("unknown"), SND_PCM_FORMAT_UNKNOWN);
+}
+
+TEST(LoopbackHelpersTest, ValidateLoopbackConfigAcceptsValidSettings) {
+    AppConfig cfg;
+    cfg.loopback.enabled = true;
+    cfg.loopback.sampleRate = 44100;
+    cfg.loopback.channels = DaemonConstants::CHANNELS;
+    cfg.loopback.periodFrames = 1024;
+    cfg.loopback.format = "S16_LE";
+
+    EXPECT_TRUE(daemon_input::validateLoopbackConfig(cfg));
+}
+
+TEST(LoopbackHelpersTest, ValidateLoopbackConfigRejectsInvalidSettings) {
+    AppConfig cfg;
+    cfg.loopback.enabled = true;
+    cfg.loopback.sampleRate = 44100;
+    cfg.loopback.channels = DaemonConstants::CHANNELS;
+    cfg.loopback.periodFrames = 1024;
+    cfg.loopback.format = "S16_LE";
+
+    cfg.loopback.sampleRate = 96000;
+    EXPECT_FALSE(daemon_input::validateLoopbackConfig(cfg));
+
+    cfg.loopback.sampleRate = 44100;
+    cfg.loopback.channels = 1;
+    EXPECT_FALSE(daemon_input::validateLoopbackConfig(cfg));
+
+    cfg.loopback.channels = DaemonConstants::CHANNELS;
+    cfg.loopback.periodFrames = 0;
+    EXPECT_FALSE(daemon_input::validateLoopbackConfig(cfg));
+
+    cfg.loopback.periodFrames = 1024;
+    cfg.loopback.format = "BAD";
+    EXPECT_FALSE(daemon_input::validateLoopbackConfig(cfg));
+}
+
+TEST(LoopbackHelpersTest, ValidateLoopbackConfigAllowsDisabled) {
+    AppConfig cfg;
+    cfg.loopback.enabled = false;
+    cfg.loopback.sampleRate = 96000;
+    cfg.loopback.channels = 1;
+    cfg.loopback.periodFrames = 0;
+    cfg.loopback.format = "BAD";
+
+    EXPECT_TRUE(daemon_input::validateLoopbackConfig(cfg));
+}
+
+TEST(LoopbackHelpersTest, ConvertPcmToFloatHandlesS16) {
+    const int16_t samples[] = {0, 32767, -32768};
+    std::vector<float> dst;
+
+    ASSERT_TRUE(daemon_input::convertPcmToFloat(samples, SND_PCM_FORMAT_S16_LE, 3, 1, dst));
+    ASSERT_EQ(dst.size(), 3u);
+    EXPECT_NEAR(dst[0], 0.0f, 1e-6f);
+    EXPECT_NEAR(dst[1], 32767.0f / 32768.0f, 1e-6f);
+    EXPECT_NEAR(dst[2], -1.0f, 1e-6f);
+}
+
+TEST(LoopbackHelpersTest, ConvertPcmToFloatHandlesS32) {
+    const int32_t samples[] = {0, 2147483647, static_cast<int32_t>(0x80000000)};
+    std::vector<float> dst;
+
+    ASSERT_TRUE(daemon_input::convertPcmToFloat(samples, SND_PCM_FORMAT_S32_LE, 3, 1, dst));
+    ASSERT_EQ(dst.size(), 3u);
+    EXPECT_NEAR(dst[0], 0.0f, 1e-6f);
+    EXPECT_NEAR(dst[1], 2147483647.0f / 2147483648.0f, 1e-6f);
+    EXPECT_NEAR(dst[2], -1.0f, 1e-6f);
+}
+
+TEST(LoopbackHelpersTest, ConvertPcmToFloatHandlesS24_3LE) {
+    std::vector<uint8_t> samples = {
+        0x00, 0x00, 0x00,  // 0
+        0xFF, 0xFF, 0x7F,  // 0x7FFFFF
+        0x00, 0x00, 0x80   // 0x800000
+    };
+    std::vector<float> dst;
+
+    ASSERT_TRUE(daemon_input::convertPcmToFloat(samples.data(), SND_PCM_FORMAT_S24_3LE, 3, 1, dst));
+    ASSERT_EQ(dst.size(), 3u);
+    EXPECT_NEAR(dst[0], 0.0f, 1e-6f);
+    EXPECT_NEAR(dst[1], 8388607.0f / 8388608.0f, 1e-6f);
+    EXPECT_NEAR(dst[2], -1.0f, 1e-6f);
+}
+
+TEST(LoopbackHelpersTest, ConvertPcmToFloatRejectsUnknownFormat) {
+    const int16_t samples[] = {0, 1};
+    std::vector<float> dst;
+
+    EXPECT_FALSE(daemon_input::convertPcmToFloat(samples, SND_PCM_FORMAT_UNKNOWN, 2, 1, dst));
+}

--- a/tests/cpp/daemon/test_pid_lock.cpp
+++ b/tests/cpp/daemon/test_pid_lock.cpp
@@ -1,0 +1,66 @@
+#include "daemon/core/pid_lock.h"
+#include "gtest/gtest.h"
+
+#include <cctype>
+#include <filesystem>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+class PidLockTest : public ::testing::Test {
+   protected:
+    fs::path tempDir;
+
+    void SetUp() override {
+        const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+        std::string name = "pid_lock";
+        if (info) {
+            name = std::string(info->test_suite_name()) + "_" + std::string(info->name());
+        }
+        for (char& c : name) {
+            if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-')) {
+                c = '_';
+            }
+        }
+        tempDir = fs::temp_directory_path() /
+                  ("gpu_upsampler_test_" + name + "_" + std::to_string(getpid()));
+        fs::create_directories(tempDir);
+    }
+
+    void TearDown() override {
+        fs::remove_all(tempDir);
+    }
+};
+
+TEST_F(PidLockTest, AcquireAndReleaseRemovesFile) {
+    fs::path lockPath = tempDir / "gpu_upsampler.pid";
+
+    auto lock = daemon_core::PidLock::tryAcquire(lockPath.string());
+    ASSERT_TRUE(lock.has_value());
+    EXPECT_TRUE(fs::exists(lockPath));
+
+    lock.reset();
+    EXPECT_FALSE(fs::exists(lockPath));
+}
+
+TEST_F(PidLockTest, SecondProcessCannotAcquireWhileLocked) {
+    fs::path lockPath = tempDir / "gpu_upsampler.pid";
+
+    auto lock = daemon_core::PidLock::tryAcquire(lockPath.string());
+    ASSERT_TRUE(lock.has_value());
+
+    pid_t pid = fork();
+    ASSERT_GE(pid, 0);
+
+    if (pid == 0) {
+        auto second = daemon_core::PidLock::tryAcquire(lockPath.string());
+        _exit(second.has_value() ? 1 : 0);
+    }
+
+    int status = 0;
+    ASSERT_EQ(waitpid(pid, &status, 0), pid);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+}


### PR DESCRIPTION
## 概要
- PIDロック/loopbackヘルパ/FilterHeadroomCacheの単体テストを追加

## テスト
- pre-commit run --hook-stage pre-push

Fixes #877