### PR TITLE
#902 RTパスのCUDAエラーハンドリングを非例外化

### DIFF
--- a/src/gpu/cuda_utils.cu
+++ b/src/gpu/cuda_utils.cu
@@ -141,9 +141,9 @@ AudioEngine::ErrorCode checkCudaErrorCode(cudaError_t error, const char* context
 
     // Log the error
     if (context) {
-        LOG_ERROR("CUDA Error in {}: {}", context, cudaGetErrorString(error));
+        LOG_EVERY_N(ERROR, 100, "CUDA Error in {}: {}", context, cudaGetErrorString(error));
     } else {
-        LOG_ERROR("CUDA Error: {}", cudaGetErrorString(error));
+        LOG_EVERY_N(ERROR, 100, "CUDA Error: {}", cudaGetErrorString(error));
     }
 
     return cudaErrorToErrorCode(error);
@@ -156,9 +156,9 @@ AudioEngine::ErrorCode checkCufftErrorCode(cufftResult result, const char* conte
 
     // Log the error
     if (context) {
-        LOG_ERROR("cuFFT Error in {}: {}", context, static_cast<int>(result));
+        LOG_EVERY_N(ERROR, 100, "cuFFT Error in {}: {}", context, static_cast<int>(result));
     } else {
-        LOG_ERROR("cuFFT Error: {}", static_cast<int>(result));
+        LOG_EVERY_N(ERROR, 100, "cuFFT Error: {}", static_cast<int>(result));
     }
 
     return AudioEngine::ErrorCode::GPU_CUFFT_ERROR;


### PR DESCRIPTION
## 概要\n- RTパスのCUDA/cuFFTエラーを例外ではなく戻り値で扱うよう整理\n- エラー時はレート制限ログ + サイレンス出力へフェイルセーフ\n- partitioned streaming のRT経路も非例外化\n\n## テスト\n- cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON\n- .venv/bin/pre-commit run --hook-stage pre-push\n- git push (pre-push hook 実行)\n