### PR TITLE
#923/#926 Vulkan backend抽象とVkFFT選定メモ

### DIFF
--- a/docs/architecture/vulkan_backend_abstraction_926.md
+++ b/docs/architecture/vulkan_backend_abstraction_926.md
@@ -1,0 +1,69 @@
+## Vulkan移植: CUDA依存点の最小境界（Backend抽象）を定義する（Issue #926）
+
+### 目的
+CUDA前提で実装されているアップサンプラー/畳み込み（`src/gpu/*.cu`）を、まずは**最適化は後回し**で Vulkan compute に「単純置換」できるように、置換点（依存点）を**最小の境界**として切り出す。
+
+### 現状のCUDA依存点（依存の種類）
+実装上の依存は大きく以下に分類できる：
+
+- **メモリ**: `cudaMalloc/cudaFree`、（RT用）`cudaHostRegister/cudaHostUnregister`、（一部）一時 `cudaMalloc`（非RT）
+- **コピー**: `cudaMemcpy/cudaMemcpyAsync`（H2D/D2H/D2D）
+- **同期/キュー**: `cudaStream_t`、`cudaStreamSynchronize`、（RTパイプライン）`cudaEvent*` と `cudaEventQuery`
+- **FFT**: `cufftHandle`、`cufftPlan1d`、`cufftExec*`、`cufftSetStream`
+- **カーネル**: 複素数pointwise乗算・スケール、ゼロ埋め、型変換（float32<->float64）、オーバーラップ処理 等
+
+主な該当ファイル（例）:
+
+- `src/gpu/gpu_upsampler_core.cu`
+- `src/gpu/gpu_upsampler_streaming.cu`
+- `src/gpu/gpu_upsampler_eq.cu`
+- `src/gpu/gpu_upsampler_multi_rate.cu`
+- `src/gpu/four_channel_fir.cu`
+- `include/gpu/cuda_utils.h` / `src/gpu/cuda_utils.cu`
+
+### 最小境界（必須スコープ）
+Issue #926 のスコープに合わせ、Vulkanバックエンド実装で「まず必要になる責務」を次に限定する：
+
+- **バッファ確保/解放**
+  - Device local 相当（CUDAのdevice memory）
+  - サイズ管理（bytes）
+- **H2D/D2H 相当のコピー**
+  - 同期/非同期の両方（ただし初期は “非同期APIでも内部同期” でも可）
+  - ストリーム/キュー指定（nullable）
+- **1D FFT**
+  - `R2C`（forward）と `C2R`（inverse）
+  - バッチ実行（将来のパーティション/複数チャネルのため）
+  - ストリーム/キュー指定（nullable）
+- **複素数pointwise 乗算 + スケール**
+  - `out[i] = a[i] * b[i] * scale`
+  - （注意）C2R 後の 1/N スケーリングをどこでやるかは backend 側で吸収して良い
+- **同期**
+  - 最低限 `stream/queue synchronize` があればよい
+
+### 任意（後続Issueへ回すもの）
+EPIC #921 の「まず動く」段階では不要、また Issue #926 の任意スコープと整合するため、以下は**後続Issue**へ送る：
+
+- **ストリーミング/イベントパイプライン**
+  - CUDA: `cudaEventRecord/cudaEventQuery` で in-flight 管理
+  - Vulkan: timeline semaphore / fence に置換するが、初期は “同期実行” で良い
+- **最適化**
+  - GPU常駐リング、転送削減、カーネル融合、同期削減
+
+### 抽象の形（提案）
+**backend層**を `CudaBackend` / `VulkanBackend` に分け、上位（畳み込み/アップサンプルのアルゴリズム）は backend に依存する。
+
+- **Backend API案**: `include/gpu/backend/gpu_backend.h`
+  - CUDA/Vulkan 型をヘッダに漏らさないため、opaque handle で統一
+  - 必須スコープ（alloc/copy/fft/mul+scale/sync）だけをまず定義
+  - event は optional として stub（NOT_IMPLEMENTED）で置く
+
+### CUDA版 / Vulkan版の責務分離（見通し）
+単純置換の最短経路は以下：
+
+- **CUDA実装（既存）**は「現状の `cudaMalloc/cufftExec/...` を backend 実装に移す」だけに寄せる
+- **Vulkan実装（新規）**は同じ backend API を VkFFT（FFT）+ compute kernel（mul/scale 等）で実装する
+- 上位の `GPUUpsampler` / `FourChannelFIR` は **「FFT + pointwise + copy」** を backend 呼び出しに置換することで、最小変更で差し替え可能になる
+
+### 次の一手（EPIC #921 への接続）
+- FFTはまず VkFFT を採用（Issue #923）。
+- その後、`VulkanBackend` の最小実装（alloc/copy/fft/mul+scale/sync）を作り、**オフライン 1ch overlap-save** で動作確認へ進める。

--- a/docs/architecture/vulkan_fft_selection_923.md
+++ b/docs/architecture/vulkan_fft_selection_923.md
@@ -1,0 +1,57 @@
+## Vulkan: FFTライブラリ選定（VkFFT候補）と要件/ライセンス確認（Issue #923）
+
+### 結論（採用方針）
+- **第一候補: VkFFT を採用する**
+  - 目的（EPIC #921）で必要な **1D FFT（R2C/C2R）** を Vulkan compute 上で提供できる
+  - 「CUDA実装の構造に近い形」での単純置換に向く（plan/execute のモデルが近い）
+  - 多バックエンド対応（Vulkan以外も視野）で、将来の検証/移植リスクを下げられる
+
+参照: `https://github.com/DTolm/VkFFT`
+
+### ライセンス（配布/商用/同梱の可否）
+- **MIT License**
+  - 商用利用・同梱配布は基本的に可能
+  - **必要条件**: 著作権表示とライセンス文を同梱（NOTICE/THIRD_PARTY_NOTICES等でも可）
+
+※実装取り込み時の運用案:
+- `third_party/vkfft/` にソースを配置し、`LICENSE` を必ず含める
+- もしくは submodule で管理し、配布物にライセンス同梱を行う
+
+### 要件（Pi5 / Docker / 将来Androidを見据えた整理）
+Issue #923 の受け入れ条件に合わせ、最小限の要件を列挙する。
+
+#### 必須（EPIC #921 の「まず動く」段階）
+- **Vulkan compute が動作すること**
+  - compute queue が取得できる
+  - storage buffer を使える（FFTの入出力・作業領域）
+- **メモリ要件**
+  - device local のバッファ確保（FFT作業領域）
+  - host-visible の staging（Docker/ファイルI/O からの入力/出力）
+- **実装要件**
+  - 1D R2C / C2R を実行できる
+  - バッチ実行（将来のパーティション/複数ch）に拡張できる
+
+#### 推奨（性能/拡張の余地）
+- **非同期実行 + 明示同期**
+  - fence / timeline semaphore で in-flight を管理できる（ストリーミング化で必要）
+- **サブグループ（subgroup）最適化**
+  - 利用できれば性能面の伸びが期待できる（ただし必須にはしない）
+- **FP16/INT8 系**
+  - 初期は FP32 前提で進め、後から必要なら検討
+
+### Vulkan機能（箇条書き）
+「必須」ではなく「期待する前提」として整理（実装段階で `vkGetPhysicalDeviceFeatures*` により確認する）。
+
+- **必須（初期）**
+  - compute pipeline / descriptor set / push constants（基本機能）
+  - storage buffer（`VK_DESCRIPTOR_TYPE_STORAGE_BUFFER`）
+  - host-visible memory（staging）
+  - device-local memory（作業領域）
+- **任意（将来の最適化）**
+  - timeline semaphore（`VK_KHR_timeline_semaphore` または Vulkan 1.2 相当）
+  - subgroup（`VkPhysicalDeviceSubgroupProperties`）
+  - buffer device address（最適化で必要になれば）
+
+### 次のアクション（EPIC #921）
+- Pi5 上で **VkFFTの最小サンプル（1D R2C/C2R）** を Docker 環境で起動し、FFT実行が通ることを確認する。
+- その結果を踏まえ、Issue #926 の backend 抽象（alloc/copy/fft/mul+scale/sync）に沿って VulkanBackend 実装へ進む。

--- a/include/gpu/backend/gpu_backend.h
+++ b/include/gpu/backend/gpu_backend.h
@@ -1,0 +1,152 @@
+// Vulkan移植に向けた GPU Backend 抽象（設計用ヘッダ）
+//
+// NOTE:
+// - 現時点では既存のCUDA実装を置換しません（Issue #926 の「最小境界の定義」をコード化する目的）。
+// - CUDA/Vulkan の型（cudaStream_t / VkQueue 等）をヘッダに漏らさないため、すべて opaque handle
+// にしています。
+// - 実装は将来 `src/gpu/backend/{cuda,vulkan}_backend.*` として追加する想定です。
+//
+// スコープ（Issue #926 必須）:
+// - バッファ確保/解放
+// - H2D / D2H 相当（同期/非同期）
+// - 1D FFT（R2C / C2R）、forward/inverse
+// - 複素数 pointwise 乗算（+スケール）
+// - 同期
+//
+// 任意（後続Issue）:
+// - ストリーミング/イベントによるパイプライン（timeline semaphore / cudaEvent）
+// - カーネル融合・最適化、常駐リング、メモリ転送削減
+
+#ifndef GPU_BACKEND_GPU_BACKEND_H
+#define GPU_BACKEND_GPU_BACKEND_H
+
+#include "core/error_codes.h"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace ConvolutionEngine {
+namespace GpuBackend {
+
+enum class BackendKind : uint8_t {
+    Cuda = 0,
+    Vulkan = 1,
+};
+
+// Opaque handles to avoid leaking backend-specific types.
+// - CUDA: handle may point to cudaStream_t/cufftHandle wrappers.
+// - Vulkan: handle may store VkDevice/VkQueue/VkBuffer/VkFence/VkSemaphore wrappers.
+struct OpaqueHandle {
+    void* ptr = nullptr;
+};
+
+struct DeviceBuffer {
+    OpaqueHandle handle{};
+    size_t bytes = 0;
+};
+
+struct Stream {
+    OpaqueHandle handle{};
+};
+
+struct Event {
+    OpaqueHandle handle{};
+};
+
+enum class CopyKind : uint8_t {
+    HostToDevice = 0,
+    DeviceToHost = 1,
+    DeviceToDevice = 2,
+};
+
+enum class FftDomain : uint8_t {
+    RealToComplex = 0,
+    ComplexToReal = 1,
+    ComplexToComplex = 2,
+};
+
+enum class FftDirection : uint8_t {
+    Forward = 0,
+    Inverse = 1,
+};
+
+// FFT plan handle. 実装は VkFFT / cuFFT 等の plan を保持する。
+struct FftPlan {
+    OpaqueHandle handle{};
+    int fftSize = 0;  // N
+    int batch = 1;
+    FftDomain domain = FftDomain::RealToComplex;
+};
+
+// Backend interface for minimal Vulkan port.
+class IGpuBackend {
+   public:
+    virtual ~IGpuBackend() = default;
+
+    virtual BackendKind kind() const = 0;
+    virtual const char* name() const = 0;
+
+    // -------- Memory / buffers --------
+    virtual AudioEngine::ErrorCode allocateDeviceBuffer(DeviceBuffer& out, size_t bytes,
+                                                        const char* context) = 0;
+    virtual AudioEngine::ErrorCode freeDeviceBuffer(DeviceBuffer& buffer, const char* context) = 0;
+
+    // -------- Streams / sync --------
+    // stream == nullptr の場合はデフォルトキュー/同期実行で良い（最適化は後回し）。
+    virtual AudioEngine::ErrorCode createStream(Stream& out, const char* context) = 0;
+    virtual AudioEngine::ErrorCode destroyStream(Stream& stream, const char* context) = 0;
+    virtual AudioEngine::ErrorCode streamSynchronize(const Stream* stream, const char* context) = 0;
+
+    // -------- Copies --------
+    // 非同期コピーを許容。stream == nullptr の場合は同期でも良い。
+    virtual AudioEngine::ErrorCode copy(void* dst, const void* src, size_t bytes, CopyKind kind,
+                                        const Stream* stream, const char* context) = 0;
+
+    // -------- FFT --------
+    // 1D FFT (R2C/C2R/C2C) の plan を作り、execute で実行する。
+    virtual AudioEngine::ErrorCode createFftPlan1d(FftPlan& out, int fftSize, int batch,
+                                                   FftDomain domain, const char* context) = 0;
+    virtual AudioEngine::ErrorCode destroyFftPlan(FftPlan& plan, const char* context) = 0;
+    virtual AudioEngine::ErrorCode executeFft(const FftPlan& plan, const DeviceBuffer& in,
+                                              DeviceBuffer& out, FftDirection direction,
+                                              const Stream* stream, const char* context) = 0;
+
+    // -------- Pointwise complex operations --------
+    // out[i] = a[i] * b[i] * scale  （複素数、要素数 = complexCount）
+    // ※ complexCount は "N/2+1" 等のR2Cサイズを想定。
+    virtual AudioEngine::ErrorCode complexPointwiseMulScale(
+        DeviceBuffer& out, const DeviceBuffer& a, const DeviceBuffer& b, size_t complexCount,
+        float scale, const Stream* stream, const char* context) = 0;
+
+    // -------- Optional (future) --------
+    // timeline semaphore / cudaEvent 相当。Issue #926 の必須ではないので、当面は未実装でもOK。
+    virtual AudioEngine::ErrorCode createEvent(Event& out, const char* context) {
+        (void)out;
+        (void)context;
+        return AudioEngine::ErrorCode::NOT_IMPLEMENTED;
+    }
+    virtual AudioEngine::ErrorCode destroyEvent(Event& event, const char* context) {
+        (void)event;
+        (void)context;
+        return AudioEngine::ErrorCode::NOT_IMPLEMENTED;
+    }
+    virtual AudioEngine::ErrorCode recordEvent(Event& event, const Stream* stream,
+                                               const char* context) {
+        (void)event;
+        (void)stream;
+        (void)context;
+        return AudioEngine::ErrorCode::NOT_IMPLEMENTED;
+    }
+    virtual AudioEngine::ErrorCode queryEvent(const Event& event, bool& outReady,
+                                              const char* context) {
+        (void)event;
+        (void)outReady;
+        (void)context;
+        return AudioEngine::ErrorCode::NOT_IMPLEMENTED;
+    }
+};
+
+}  // namespace GpuBackend
+}  // namespace ConvolutionEngine
+
+#endif  // GPU_BACKEND_GPU_BACKEND_H


### PR DESCRIPTION
## Summary
- Vulkan/Vulkan差し替えを見据えた GPU backend 抽象IFの雛形を追加（opaque handle で alloc/copy/fft/complex-mul/sync の最小境界）
- CUDA依存点の分類と最小スコープを整理したドキュメントを追加（Issue #926）
- VkFFT採用方針・要件・MITライセンス確認をまとめたドキュメントを追加（Issue #923）

## Test plan
- ./scripts/deployment/run_tests.sh

Closes #923
Closes #926