### PR TITLE
Fix #942: Pi Control API bind 自動検出を強化

### DIFF
--- a/raspberry_pi/README.md
+++ b/raspberry_pi/README.md
@@ -105,7 +105,8 @@ Jetson 側も `raspberry_pi/usb_i2s_bridge/control_agent.py` を `python3 -m ras
 Pi 側に軽量の FastAPI を常駐させ、Jetson から USB 経由で制御します。
 
 - Docker Compose では `raspi-control-api` サービスとして起動します。
-- デフォルト bind は `usb0` を自動検出します。**検出に失敗した場合は到達不能になるため、プロセスを終了（非0）して restart で再試行します。**
+- デフォルト bind は `RPI_CONTROL_BIND_INTERFACE`（既定 `usb0`）を自動検出し、失敗した場合は **`RPI_CONTROL_BIND_SUBNET`（既定 `192.168.55.0/24`）に属するIPを持つインターフェースを探索**します。
+  - それでも検出に失敗した場合は到達不能になるため、プロセスを終了（非0）して restart で再試行します。
   - 環境によりインターフェース名や起動順が異なる場合は `RPI_CONTROL_BIND_HOST`（例: `192.168.55.100`）を明示してください。
 - **ポート 80 は使用しない**（Jetson 側 nginx へ戻るため）。既定は `8081`。
 - `raspi-control-api` は **docker.sock をマウントすることが前提**（再起動/反映に必須）。

--- a/raspberry_pi/docker-compose.yml
+++ b/raspberry_pi/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     environment:
       RPI_CONTROL_BIND_INTERFACE: ${RPI_CONTROL_BIND_INTERFACE:-usb0}
       RPI_CONTROL_BIND_HOST: ${RPI_CONTROL_BIND_HOST:-}
+      RPI_CONTROL_BIND_SUBNET: ${RPI_CONTROL_BIND_SUBNET:-192.168.55.0/24}
       RPI_CONTROL_PORT: ${RPI_CONTROL_PORT:-8081}
       RPI_CONTROL_CONFIG_PATH: /var/lib/usb-i2s-bridge/config.env
       RPI_CONTROL_STATUS_PATH: /var/run/usb-i2s-bridge/status.json

--- a/raspberry_pi/tests/test_control_api_bind.py
+++ b/raspberry_pi/tests/test_control_api_bind.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+
+def test_resolve_any_interface_in_subnet_picks_matching_ip():
+    from raspberry_pi import control_api
+
+    mapping = {
+        "eth0": "10.0.0.2",
+        "enx1234": "192.168.55.100",
+        "lo": "127.0.0.1",
+    }
+
+    def resolver(name: str):
+        return mapping.get(name)
+
+    host = control_api._resolve_any_interface_in_subnet(
+        "192.168.55.0/24",
+        interface_names=["lo", "eth0", "enx1234"],
+        resolver=resolver,
+    )
+    assert host == "192.168.55.100"
+
+
+def test_resolve_any_interface_in_subnet_returns_none_when_no_match():
+    from raspberry_pi import control_api
+
+    mapping = {
+        "eth0": "10.0.0.2",
+        "wlan0": "192.168.1.10",
+    }
+
+    def resolver(name: str):
+        return mapping.get(name)
+
+    host = control_api._resolve_any_interface_in_subnet(
+        "192.168.55.0/24",
+        interface_names=["eth0", "wlan0"],
+        resolver=resolver,
+    )
+    assert host is None
+
+
+def test_resolve_any_interface_in_subnet_skips_invalid_ips():
+    from raspberry_pi import control_api
+
+    mapping = {
+        "enx1": "not-an-ip",
+        "enx2": "192.168.55.101",
+    }
+
+    def resolver(name: str):
+        return mapping.get(name)
+
+    host = control_api._resolve_any_interface_in_subnet(
+        "192.168.55.0/24",
+        interface_names=["enx1", "enx2"],
+        resolver=resolver,
+    )
+    assert host == "192.168.55.101"
+
+
+def test_resolve_any_interface_in_subnet_invalid_subnet_returns_none():
+    from raspberry_pi import control_api
+
+    def resolver(_: str):
+        return "192.168.55.100"
+
+    host = control_api._resolve_any_interface_in_subnet(
+        "not-a-cidr",
+        interface_names=["enx0"],
+        resolver=resolver,
+    )
+    assert host is None

--- a/raspberry_pi/usb_i2s_bridge/docker-compose.yml
+++ b/raspberry_pi/usb_i2s_bridge/docker-compose.yml
@@ -40,6 +40,7 @@ services:
     environment:
       RPI_CONTROL_BIND_INTERFACE: ${RPI_CONTROL_BIND_INTERFACE:-usb0}
       RPI_CONTROL_BIND_HOST: ${RPI_CONTROL_BIND_HOST:-}
+      RPI_CONTROL_BIND_SUBNET: ${RPI_CONTROL_BIND_SUBNET:-192.168.55.0/24}
       RPI_CONTROL_PORT: ${RPI_CONTROL_PORT:-8081}
       RPI_CONTROL_CONFIG_PATH: /var/lib/usb-i2s-bridge/config.env
       RPI_CONTROL_STATUS_PATH: /var/run/usb-i2s-bridge/status.json


### PR DESCRIPTION
## Summary
- Pi側 `raspi-control-api` の bind 自動検出を改善し、インターフェース名が `usb0` でない環境でも `192.168.55.0/24` に属するIPを持つIFを探索して bind
- `RPI_CONTROL_BIND_SUBNET` を追加（既定 `192.168.55.0/24`）
- 起動ログに bind 情報（host/port/interface/subnet）を出力
- 選択ロジックのユニットテストを追加

## Why
`/pi/status` が 502 (connection refused) になるケースは、Pi側APIが loopback/別IFに bind して外部から到達できないことが原因になり得るため。#942 の「JetsonがPi APIを代理」前提で、設定なしでも“動く”確率を上げる。

## Test plan
- [x] `uv run pytest -q raspberry_pi/tests/test_control_api_bind.py`
- [x] push時の pre-push(diff-based-tests含む) 通過

## Notes
- 明示したい場合は `.env` に `RPI_CONTROL_BIND_HOST=192.168.55.100` を設定して固定可能