### PR TITLE
Fix #942: rpi-control-api が zmq 未導入で落ちる

### DIFF
--- a/raspberry_pi/tests/test_control_api_imports.py
+++ b/raspberry_pi/tests/test_control_api_imports.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import sys
+
+
+def test_control_api_import_does_not_import_control_plane():
+    # `raspi-control-api` コンテナでは zmq が無いことがあるため、
+    # control_api の import だけで control_plane(zmq) を要求しないことを保証する。
+    assert "raspberry_pi.usb_i2s_bridge.control_plane" not in sys.modules
+    __import__("raspberry_pi.control_api")
+    assert "raspberry_pi.usb_i2s_bridge.control_plane" not in sys.modules


### PR DESCRIPTION
## Summary
- `usb_i2s_bridge/bridge.py` の `ControlPlaneSync` を遅延 import に変更し、Pi Control API (`rpi-control-api`) コンテナが `pyzmq` 無しでも起動できるようにする
- import時に `raspberry_pi.usb_i2s_bridge.control_plane`（= `zmq`）を要求しないことをテストで担保

## Why
`rpi-control-api` が起動前に `ModuleNotFoundError: zmq` で落ちると、Pi側 8081 が listen されず Jetson Web からは 502/connection refused になるため。

## Test plan
- [x] `uv run pytest -q raspberry_pi/tests/test_control_api_imports.py`
- [x] push時の pre-push(diff-based-tests含む) 通過