### PR TITLE
#1077 SystemページのDACをセレクトボックスに固定

### DIFF
--- a/web/templates/pages/system_settings.html
+++ b/web/templates/pages/system_settings.html
@@ -69,6 +69,7 @@
             {% set form_input_type = "select" %}
             {% set form_input_model = "dac.selected" %}
             {% set form_input_disabled = "actionInProgress || dac.loading" %}
+            {% set form_on_change = "dac.userSelected = true" %}
             {% set form_select_options = '<template x-for="device in dac.devices" :key="device.id"><option :value="device.id" x-text="device.name ? `${device.name} (${device.id})` : device.id"></option></template>' %}
             {% include 'components/form_group.html' %}
         </div>
@@ -192,7 +193,7 @@
 function systemPage() {
     return {
         health: { daemon_running: false, input_rate: 0, output_rate: 0 },
-        dac: { devices: [], runtime: null, loading: false, selected: '' },
+        dac: { devices: [], runtime: null, loading: false, selected: '', userSelected: false },
         currentLang: "{{ lang }}",
         partitioned: {
             enabled: false,
@@ -302,7 +303,10 @@ function systemPage() {
                 const res = await fetch('/dac/state');
                 if (!res.ok) return;
                 this.dac.runtime = await res.json();
-                if (!this.dac.selected && this.dac.runtime?.active_device) {
+                if (
+                    this.dac.runtime?.active_device &&
+                    (!this.dac.userSelected || !this.dac.selected)
+                ) {
                     this.dac.selected = this.dac.runtime.active_device;
                 }
             } catch (err) {

--- a/web/tests/test_system_settings_page.py
+++ b/web/tests/test_system_settings_page.py
@@ -67,6 +67,8 @@ def test_system_dac_uses_select_box_not_list():
     # Select box is rendered via form_group.html
     assert "<select" in html
     assert 'x-model="dac.selected"' in html
+    assert "selectDac(dac.selected)" in html
+    assert "selectDac(device.id)" not in html
     assert "/dac/devices" in html
     assert "/dac/select" in html
 


### PR DESCRIPTION
## Summary
- SystemページのDAC切替で、未選択/現行DAC選択時は切替を実行しないようガードを追加
- DAC UI が一覧ではなくセレクトボックスであることを回帰テストで固定

Fixes #1077

## Test plan
- `uv run pytest -q web/tests/test_system_settings_page.py`