### PR TITLE
Fix #998: Docker/Jetson OPRAキャッシュ永続化

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -36,6 +36,10 @@ docker compose -f jetson/docker-compose.jetson.yml down
 - サービスを個別に起動したい場合: `docker compose -f jetson/docker-compose.jetson.yml up -d --build magicbox` のようにサービス名を指定
 - `restart: always` を指定済み。systemd で単体起動する場合も `Restart=always` を付け、片側クラッシュ時に自動復帰させてください。
 
+## OPRAキャッシュの永続化
+- Jetson Compose は `magicbox-opra-cache` ボリュームを `/data/opra` にマウントし、OPRA同期結果がコンテナの再ビルド/再起動後も保持されるようにしています。
+- データルートは `GPU_OS_DATA_DIR` で上書き可能（デフォルト `/data`）。エントリポイントがロック/versionsディレクトリを作成し、`magicbox` ユーザー所有に揃えます。
+
 ## Magic Box コンテナの事前ビルド（Jetson 本体で実行）
 `docker/jetson/Dockerfile.jetson` はホストでビルド済みのバイナリをコピーする前提です。コンテナを立ち上げる前に Jetson 上で以下を実行し、`build/gpu_upsampler_alsa` を用意してください。
 

--- a/docker/jetson/docker-compose.jetson.yml
+++ b/docker/jetson/docker-compose.jetson.yml
@@ -54,12 +54,16 @@ services:
       - ../../data/EQ:/opt/magicbox/data/EQ:rw
       # Persist runtime config outside the image (survives rebuilds)
       - magicbox-config:/opt/magicbox/config
+      # Persist OPRA sync cache outside the image
+      - magicbox-opra-cache:/data/opra
 
     # Environment (NVIDIA)
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
       - MAGICBOX_PROFILE=jetson
+      # Data root for OPRA cache (mounted as a volume)
+      - GPU_OS_DATA_DIR=/data
       # RTP はコードとして残すが、I2Sメイン運用ではデフォルトで無効化する。
       # 必要な場合のみ MAGICBOX_ENABLE_RTP=true にし、必要ならポートも公開する。
       - MAGICBOX_ENABLE_RTP=false
@@ -99,3 +103,4 @@ services:
 
 volumes:
   magicbox-config:
+  magicbox-opra-cache:

--- a/docker/jetson/entrypoint.sh
+++ b/docker/jetson/entrypoint.sh
@@ -20,6 +20,8 @@ CONFIG_SYMLINK="${MAGICBOX_CONFIG_SYMLINK:-/opt/magicbox/config.json}"
 DEFAULT_CONFIG="${MAGICBOX_DEFAULT_CONFIG:-/opt/magicbox/config-default/config.json}"
 RESET_CONFIG="${MAGICBOX_RESET_CONFIG:-false}"
 PROFILE="${MAGICBOX_PROFILE:-base}"
+DATA_ROOT="${GPU_OS_DATA_DIR:-${DATA_DIR:-/var/lib/gpu_upsampler}}"
+OPRA_CACHE_DIR="${DATA_ROOT}/opra"
 : "${MAGICBOX_ENABLE_RTP:=false}"
 : "${MAGICBOX_RTP_AUTOSTART:=false}"
 
@@ -39,6 +41,13 @@ log_warn() {
 
 log_error() {
     echo -e "${RED}[ERROR]${NC} $*"
+}
+
+prepare_opra_cache_dir() {
+    # Ensure OPRA cache layout exists on the mounted volume with writable perms
+    mkdir -p "${OPRA_CACHE_DIR}/versions" "${OPRA_CACHE_DIR}/lock"
+    chmod 775 "${OPRA_CACHE_DIR}" || true
+    chown -R magicbox:magicbox "${OPRA_CACHE_DIR}" 2>/dev/null || true
 }
 
 wait_for_alsa() {
@@ -119,6 +128,7 @@ configure_jetson_ape_i2s() {
 }
 
 prepare_config() {
+    prepare_opra_cache_dir
     mkdir -p "$CONFIG_DIR"
 
     if [[ ! -f "$DEFAULT_CONFIG" ]]; then

--- a/docs/specifications/opra-sync.md
+++ b/docs/specifications/opra-sync.md
@@ -74,6 +74,7 @@ Docker/Jetsonを想定し、永続化ボリュームに配置する。
 - **推奨パス（論理）**: `${DATA_DIR}/opra/`
   - 例（ホスト）: `/var/lib/gpu_upsampler/opra/`
   - 例（Docker）: `/data/opra/`（volume）
+  - Jetson Compose では `GPU_OS_DATA_DIR=/data` を指定し、`magicbox-opra-cache` ボリュームを `/data/opra` にマウントして永続化する。
 
 ### 2) ディレクトリ構成
 


### PR DESCRIPTION
## Summary
- Jetson Compose に `GPU_OS_DATA_DIR=/data` と `magicbox-opra-cache` volume を追加し、OPRA同期キャッシュをコンテナ再ビルド後も保持できるようにした
- エントリポイントで `/data/opra` 配下のレイアウト作成と `magicbox` 所有へ調整し、権限不足で同期が止まらないようにした
- OPRAキャッシュのデフォルトパス/volume化手順を Docker README と opra-sync 仕様に追記

## Test plan
- [x] git push 時の pre-push hooks（diff-based tests など）
- [ ] Jetson 実機での compose 再起動確認（未実施）