### PR TITLE
Fix #1052: 公開戦略決定（Private→Public分離）

### DIFF
--- a/docs/releases/public_repo.md
+++ b/docs/releases/public_repo.md
@@ -103,7 +103,12 @@ Public Repo は “利用/運用/仕様” を目的とし、Private実装に直
 
 ### 同期の粒度
 
-- 原則: Private `main` の安定点（リリース/タグ/明示トリガー）で Public を更新
+- **推奨（初期運用）**: **リリースタグ時のみ** Public を更新する
+  - `v*` タグの push、または GitHub Release の `published` をトリガーにする
+  - 目的: 「公開して良い状態」を人間が宣言したタイミングだけ同期し、無駄な実行・枠消費・事故（意図しない公開）を避ける
+- **代替案**: **prod（production）へデプロイ成功したタイミングのみ** Public を更新する
+  - 前提: 既存のデプロイパイプラインが GitHub の `deployment` / `deployment_status`（environment=production）を発行できる、または `workflow_run` で “deploy workflow 成功” を検知できる
+  - 目的: 「本番に出たもの＝公開して良いもの」という運用に揃える
 - Public のコミットメッセージは以下に統一：
   - `Public export from private@<SHA>`
 


### PR DESCRIPTION
Fix #1052 / Epic #1051

## 変更内容
- Private→Public 分離の方針を `docs/releases/public_repo.md` に明文化（公開範囲/非公開範囲/同期方針）

## 受け入れ条件
- [x] Public側に含める範囲（docs/OpenAPI/UI/compose/ライセンス）を明文化
- [x] Public側に含めない範囲（src/scripts/秘密情報/ビルド手順の私物化）を明文化
- [x] Private→Publicへの同期手段（export or CI push）の方針を決定（CIのallowlist exportを採用）