### PR TITLE
#647 Dockerサイズの抑制

### DIFF
--- a/docker/jetson/Dockerfile.jetson
+++ b/docker/jetson/Dockerfile.jetson
@@ -3,7 +3,7 @@
 # This Dockerfile is designed to run NATIVELY on Jetson Orin (ARM64).
 # Do NOT try to build this on x86_64 without cross-compilation setup.
 #
-# Base Image: NVIDIA L4T CUDA (JetPack 6.1 / L4T r36.4)
+# Base Image: NVIDIA L4T CUDA Runtime (JetPack 6.1 / L4T r36.4)
 # Target: Jetson Orin Nano Super (SM 8.7 Ampere, 1024 CUDA cores)
 #
 # Build on Jetson:
@@ -16,7 +16,7 @@
 # =============================================================================
 # Runtime Image - Uses pre-built binaries from host
 # =============================================================================
-FROM nvcr.io/nvidia/l4t-jetpack:r36.4.0
+FROM nvcr.io/nvidia/l4t-cuda:r36.4.0-runtime
 
 LABEL maintainer="Magic Box Project"
 LABEL description="Magic Box Audio Processor for Jetson Orin Nano Super"

--- a/docker/jetson_pcm_receiver/Dockerfile.jetson
+++ b/docker/jetson_pcm_receiver/Dockerfile.jetson
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/l4t-jetpack:r36.4.0
+FROM nvcr.io/nvidia/l4t-cuda:r36.4.0-runtime
 
 LABEL org.opencontainers.image.source="https://github.com/michihitoTakami/michy_os"
 LABEL org.opencontainers.image.description="jetson-pcm-receiver (PCM over TCP -> ALSA Loopback)"


### PR DESCRIPTION
## 概要
- Jetson向けDockerのベースイメージを l4t-jetpack から l4t-cuda:r36.4.0-runtime に変更し、イメージサイズを削減
- CUDAランタイム（cuFFT/cuBLAS等）を含む最小構成で、ビルド済みバイナリの実行に必要なものを維持

## テスト
- なし（Dockerfileのみ変更）