### PR TITLE
#927 Vulkanビルド依存の共通化とサンプルガード

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,9 @@ if(ENABLE_VULKAN AND NOT GPU_UPSAMPLER_BUILD_VKFFT_SAMPLE)
     # Vulkan有効時は最小サンプルを自動ビルドしてツールチェーン確認を行う
     set(GPU_UPSAMPLER_BUILD_VKFFT_SAMPLE ON CACHE BOOL "Build VkFFT Vulkan minimal sample (Issue #1108)" FORCE)
 endif()
+if(GPU_UPSAMPLER_BUILD_VKFFT_SAMPLE AND NOT ENABLE_VULKAN)
+    message(FATAL_ERROR "GPU_UPSAMPLER_BUILD_VKFFT_SAMPLE=ON requires ENABLE_VULKAN=ON")
+endif()
 if(GPU_UPSAMPLER_USE_FLOAT64)
     add_compile_definitions(GPU_UPSAMPLER_USE_FLOAT64)
     message(STATUS "GPU upsampler precision: float64 (double)")
@@ -93,6 +96,59 @@ endif()
 
 # Fetch dependencies
 include(FetchContent)
+
+# Vulkan dependencies (VkFFT + glslang) are only needed when Vulkan backend is enabled.
+if(ENABLE_VULKAN)
+    find_package(Vulkan REQUIRED)
+
+    set(VKFFT_GIT_TAG "v1.3.4" CACHE STRING "VkFFT git tag/commit to fetch")
+
+    # Thin glslang build: disable optional tools/tests to speed up fetch content builds.
+    set(GLSLANG_TESTS OFF CACHE BOOL "" FORCE)
+    set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+    set(ENABLE_GLSLANG_BINARIES OFF CACHE BOOL "" FORCE)
+    set(ENABLE_OPT OFF CACHE BOOL "" FORCE)
+    set(ENABLE_HLSL OFF CACHE BOOL "" FORCE)
+    set(ENABLE_SPVREMAPPER OFF CACHE BOOL "" FORCE)
+
+    FetchContent_Declare(
+        glslang
+        GIT_REPOSITORY https://github.com/KhronosGroup/glslang.git
+        GIT_TAG 12.3.1
+    )
+    FetchContent_MakeAvailable(glslang)
+
+    FetchContent_Declare(
+        vkfft
+        GIT_REPOSITORY https://github.com/DTolm/VkFFT.git
+        GIT_TAG ${VKFFT_GIT_TAG}
+    )
+    FetchContent_GetProperties(vkfft)
+    if(NOT vkfft_POPULATED)
+        FetchContent_Populate(vkfft)
+    endif()
+
+    # Header-only interface for VkFFT includes.
+    add_library(vkfft_headers INTERFACE)
+    target_include_directories(vkfft_headers INTERFACE
+        ${vkfft_SOURCE_DIR}/vkFFT
+    )
+
+    # Common Vulkan shader/FFT deps used by Vulkan targets (sample and future backend).
+    add_library(vulkan_shader_libs INTERFACE)
+    target_link_libraries(vulkan_shader_libs INTERFACE
+        Vulkan::Vulkan
+        glslang
+        OGLCompiler
+        OSDependent
+        glslang-default-resource-limits
+        SPIRV
+        vkfft_headers
+    )
+    target_include_directories(vulkan_shader_libs INTERFACE
+        ${glslang_SOURCE_DIR}/glslang/Include
+    )
+endif()
 
 # cppzmq (C++ bindings for ZeroMQ - header-only)
 FetchContent_Declare(

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ cmake --build build -j$(nproc)
   cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_CUDA=OFF -DENABLE_VULKAN=ON
   cmake --build build -j$(nproc) vkfft_minimal  # VkFFT最小サンプル
   ```
-  - `ENABLE_VULKAN=ON` で `GPU_UPSAMPLER_BUILD_VKFFT_SAMPLE` が自動有効化され、VkFFT最小サンプル `vkfft_minimal` でVulkan toolchainを確認できます。
+  - `ENABLE_VULKAN=ON` で `GPU_UPSAMPLER_BUILD_VKFFT_SAMPLE` が自動有効化され、VkFFT最小サンプル `vkfft_minimal` でVulkan toolchainを確認できます（`VKFFT_GIT_TAG` で取得バージョンを上書き可能）。
 - CUDAとVulkanを併用する場合
   ```bash
   cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_CUDA=ON -DENABLE_VULKAN=ON

--- a/docs/jetson/vkfft_minimal_sample.md
+++ b/docs/jetson/vkfft_minimal_sample.md
@@ -1,12 +1,12 @@
 # VkFFT 最小サンプル (Issue #1108)
 
-Jetson Orin Nano と PC (RTX2070S) の双方で **VkFFT の 1D R2C/C2R** が実行できるか確認するための最小サンプルを追加した。`GPU_UPSAMPLER_BUILD_VKFFT_SAMPLE=ON` で有効化すると、`samples/vkfft_minimal/vkfft_minimal` がビルドされる。
+Jetson Orin Nano と PC (RTX2070S) の双方で **VkFFT の 1D R2C/C2R** が実行できるか確認するための最小サンプルを追加した。`ENABLE_VULKAN=ON` で Vulkan バックエンドを有効化すると自動で `GPU_UPSAMPLER_BUILD_VKFFT_SAMPLE` が ON になり、`samples/vkfft_minimal/vkfft_minimal` がビルドされる（個別に ON にする場合も `ENABLE_VULKAN=ON` が必須）。
 
 ## 依存関係
 - Vulkan ランタイム/開発ヘッダ (`libvulkan-dev`) が導入済みであること
 - 最新ドライバ (Jetson/PC ともに `vulkaninfo` が通る状態)
 - CMake 3.18+ / Ninja (任意)
-- glslang は FetchContent で自動取得するため追加インストール不要
+- glslang / VkFFT は `ENABLE_VULKAN=ON` 時に FetchContent で自動取得するため追加インストール不要（`VKFFT_GIT_TAG` でバージョン上書き可）
 
 Jetson/PC 共通の追加パッケージ例:
 ```bash
@@ -15,7 +15,7 @@ sudo apt-get install -y libvulkan-dev vulkan-validationlayers-dev
 
 ## ビルド手順
 ```bash
-cmake -B build-vkfft -DCMAKE_BUILD_TYPE=Release -DGPU_UPSAMPLER_BUILD_VKFFT_SAMPLE=ON
+cmake -B build-vkfft -DCMAKE_BUILD_TYPE=Release -DENABLE_VULKAN=ON
 cmake --build build-vkfft -j"$(nproc)"
 ```
 

--- a/samples/vkfft_minimal/CMakeLists.txt
+++ b/samples/vkfft_minimal/CMakeLists.txt
@@ -1,51 +1,13 @@
-cmake_minimum_required(VERSION 3.18)
-
-include(FetchContent)
-
-set(VKFFT_GIT_TAG "v1.3.4" CACHE STRING "VkFFT git tag/commit to fetch")
-
-set(GLSLANG_TESTS OFF CACHE BOOL "" FORCE)
-set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
-set(ENABLE_GLSLANG_BINARIES OFF CACHE BOOL "" FORCE)
-set(ENABLE_OPT OFF CACHE BOOL "" FORCE)
-set(ENABLE_HLSL OFF CACHE BOOL "" FORCE)
-set(ENABLE_SPVREMAPPER OFF CACHE BOOL "" FORCE)
-
-FetchContent_Declare(
-    glslang
-    GIT_REPOSITORY https://github.com/KhronosGroup/glslang.git
-    GIT_TAG 12.3.1
-)
-FetchContent_MakeAvailable(glslang)
-
-FetchContent_Declare(
-    vkfft
-    GIT_REPOSITORY https://github.com/DTolm/VkFFT.git
-    GIT_TAG ${VKFFT_GIT_TAG}
-)
-FetchContent_GetProperties(vkfft)
-if(NOT vkfft_POPULATED)
-    FetchContent_Populate(vkfft)
-endif()
-
-find_package(Vulkan REQUIRED)
-
 add_executable(vkfft_minimal
     vkfft_minimal.cpp
 )
 
 target_include_directories(vkfft_minimal PRIVATE
-    ${vkfft_SOURCE_DIR}/vkFFT
     ${glslang_SOURCE_DIR}/glslang/Include
 )
 
 target_compile_definitions(vkfft_minimal PRIVATE VKFFT_BACKEND=0 VK_API_VERSION=11)
 
 target_link_libraries(vkfft_minimal PRIVATE
-    Vulkan::Vulkan
-    glslang
-    OGLCompiler
-    OSDependent
-    glslang-default-resource-limits
-    SPIRV
+    vulkan_shader_libs
 )


### PR DESCRIPTION
## Summary\n- ENABLE_VULKANを前提にVkFFT/glslang依存をトップレベルでFetchContent化し、共有インタフェースライブラリ(vulkan_shader_libs)を追加\n- GPU_UPSAMPLER_BUILD_VKFFT_SAMPLEのみONの誤設定を禁止し、Vulkan有効時にサンプル自動ONを明示\n- READMEとVkFFTサンプルドキュメントをENABLE_VULKAN前提/overrideオプション(VKFFT_GIT_TAG)に合わせて更新\n\n## Testing\n- not run (Vulkan開発パッケージが手元環境に無いため)