### PR TITLE
Fix #1100: デリミタ高遅延統合とフェイルセーフ

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,6 +544,7 @@ if(ENABLE_CUDA)
         tests/cpp/daemon/test_switch_actions.cpp
         tests/cpp/daemon/test_i2s_capture_config.cpp
         tests/cpp/audio/test_audio_pipeline.cpp
+        tests/cpp/audio/test_audio_pipeline_high_latency.cpp
         tests/cpp/core/test_precision_traits.cpp
         src/daemon/audio/crossfeed_manager.cpp
         src/daemon/audio_pipeline/audio_pipeline.cpp

--- a/src/delimiter/safety_controller.cpp
+++ b/src/delimiter/safety_controller.cpp
@@ -270,8 +270,13 @@ float SafetyController::fadeValue(std::size_t index) const {
 }
 
 void SafetyController::lockBypass(FallbackReason reason, const std::string& detail) {
+    recordDetail(reason, detail);
     bypassLocked_ = true;
-    requestBypass(reason, detail);
+    mode_ = ProcessingMode::Bypass;
+    targetMode_ = ProcessingMode::Bypass;
+    inTransition_ = false;
+    fadeIndex_ = 0;
+    LOG_WARN("Delimiter: locking bypass ({})", fallbackReasonToString(reason));
 }
 
 void SafetyController::recordDetail(FallbackReason reason, const std::string& detail) {

--- a/tests/cpp/audio/test_audio_pipeline_high_latency.cpp
+++ b/tests/cpp/audio/test_audio_pipeline_high_latency.cpp
@@ -60,6 +60,69 @@ class AlternatingGainBackend final : public delimiter::InferenceBackend {
     int callCount_ = 0;
 };
 
+class ConstantGainBackend final : public delimiter::InferenceBackend {
+   public:
+    ConstantGainBackend(uint32_t expectedSampleRate, float gain)
+        : expectedSampleRate_(expectedSampleRate), gain_(gain) {}
+
+    const char* name() const override {
+        return "test_constant_gain";
+    }
+
+    uint32_t expectedSampleRate() const override {
+        return expectedSampleRate_;
+    }
+
+    delimiter::InferenceResult process(const delimiter::StereoPlanarView& input,
+                                       std::vector<float>& outLeft,
+                                       std::vector<float>& outRight) override {
+        if (!input.valid() || input.frames == 0) {
+            return {delimiter::InferenceStatus::InvalidConfig, "invalid input"};
+        }
+        outLeft.resize(input.frames);
+        outRight.resize(input.frames);
+        for (std::size_t i = 0; i < input.frames; ++i) {
+            outLeft[i] = input.left[i] * gain_;
+            outRight[i] = input.right[i] * gain_;
+        }
+        return {delimiter::InferenceStatus::Ok, ""};
+    }
+
+    void reset() override {}
+
+   private:
+    uint32_t expectedSampleRate_{44100};
+    float gain_ = 1.0f;
+};
+
+class FailingBackend final : public delimiter::InferenceBackend {
+   public:
+    explicit FailingBackend(uint32_t expectedSampleRate)
+        : expectedSampleRate_(expectedSampleRate) {}
+
+    const char* name() const override {
+        return "test_fail";
+    }
+
+    uint32_t expectedSampleRate() const override {
+        return expectedSampleRate_;
+    }
+
+    delimiter::InferenceResult process(const delimiter::StereoPlanarView& input,
+                                       std::vector<float>& outLeft,
+                                       std::vector<float>& outRight) override {
+        (void)input;
+        outLeft.clear();
+        outRight.clear();
+        return {delimiter::InferenceStatus::Error, "intentional failure"};
+    }
+
+    void reset() override {}
+
+   private:
+    uint32_t expectedSampleRate_{44100};
+};
+
 bool waitForQueuedFrames(daemon_output::PlaybackBufferManager& buffer, std::size_t frames,
                          std::chrono::milliseconds timeout) {
     auto deadline = std::chrono::steady_clock::now() + timeout;
@@ -195,6 +258,238 @@ TEST(AudioPipelineHighLatency, OutputsAfterInitialChunkAndCrossfades) {
         EXPECT_FLOAT_EQ(outLeft2[i], 1.0f);
         EXPECT_FLOAT_EQ(outRight2[i], -1.0f);
     }
+
+    running.store(false, std::memory_order_release);
+}
+
+TEST(AudioPipelineHighLatency, RunsInferenceWithSampleRateResample) {
+    AppConfig config;
+    config.upsampleRatio = 1;
+    config.delimiter.enabled = true;
+    config.delimiter.backend = "ort";
+    config.delimiter.expectedSampleRate = 44100;
+    config.delimiter.chunkSec = 0.020f;    // 20ms @ 48k -> 960 frames
+    config.delimiter.overlapSec = 0.005f;  // 5ms @ 48k -> 240 frames
+
+    std::atomic<bool> running{true};
+    std::atomic<bool> fallbackActive{false};
+    std::atomic<bool> outputReady{true};
+    std::atomic<bool> crossfeedEnabled{false};
+    std::atomic<bool> crossfeedResetRequested{false};
+
+    constexpr std::size_t kBufferFrames = 4096;
+    daemon_output::PlaybackBufferManager playbackBuffer([]() { return kBufferFrames; });
+
+    ConvolutionEngine::StreamFloatVector streamInputLeft;
+    ConvolutionEngine::StreamFloatVector streamInputRight;
+    std::size_t streamAccumLeft = 0;
+    std::size_t streamAccumRight = 0;
+    ConvolutionEngine::StreamFloatVector upsamplerOutputLeft;
+    ConvolutionEngine::StreamFloatVector upsamplerOutputRight;
+
+    ConvolutionEngine::StreamFloatVector cfStreamInputLeft;
+    ConvolutionEngine::StreamFloatVector cfStreamInputRight;
+    std::size_t cfAccumLeft = 0;
+    std::size_t cfAccumRight = 0;
+    ConvolutionEngine::StreamFloatVector cfOutputLeft;
+    ConvolutionEngine::StreamFloatVector cfOutputRight;
+
+    std::atomic<int> delimiterMode(static_cast<int>(delimiter::ProcessingMode::Active));
+    std::atomic<int> delimiterReason(static_cast<int>(delimiter::FallbackReason::None));
+    std::atomic<bool> delimiterLocked(false);
+
+    audio_pipeline::Dependencies deps{};
+    deps.config = &config;
+    deps.running = &running;
+    deps.fallbackActive = &fallbackActive;
+    deps.outputReady = &outputReady;
+    deps.crossfeedEnabled = &crossfeedEnabled;
+    deps.crossfeedResetRequested = &crossfeedResetRequested;
+    deps.crossfeedProcessor = nullptr;
+    deps.cfStreamInputLeft = &cfStreamInputLeft;
+    deps.cfStreamInputRight = &cfStreamInputRight;
+    deps.cfStreamAccumulatedLeft = &cfAccumLeft;
+    deps.cfStreamAccumulatedRight = &cfAccumRight;
+    deps.cfOutputLeft = &cfOutputLeft;
+    deps.cfOutputRight = &cfOutputRight;
+    deps.streamInputLeft = &streamInputLeft;
+    deps.streamInputRight = &streamInputRight;
+    deps.streamAccumulatedLeft = &streamAccumLeft;
+    deps.streamAccumulatedRight = &streamAccumRight;
+    deps.upsamplerOutputLeft = &upsamplerOutputLeft;
+    deps.upsamplerOutputRight = &upsamplerOutputRight;
+    deps.streamingCacheManager = nullptr;
+    deps.buffer.playbackBuffer = &playbackBuffer;
+    deps.maxOutputBufferFrames = []() { return kBufferFrames; };
+    deps.currentInputRate = []() { return 48000; };
+    deps.currentOutputRate = []() { return 48000; };
+    deps.delimiterMode = &delimiterMode;
+    deps.delimiterFallbackReason = &delimiterReason;
+    deps.delimiterBypassLocked = &delimiterLocked;
+    deps.delimiterBackendFactory = [](const AppConfig::DelimiterConfig& cfg) {
+        return std::make_unique<ConstantGainBackend>(44100, 2.0f);
+    };
+
+    deps.upsampler.available = true;
+    deps.upsampler.streamLeft = nullptr;
+    deps.upsampler.streamRight = nullptr;
+    deps.upsampler.process = [](const float* inputData, std::size_t inputFrames,
+                                ConvolutionEngine::StreamFloatVector& outputData,
+                                cudaStream_t /*stream*/,
+                                ConvolutionEngine::StreamFloatVector& /*streamInput*/,
+                                std::size_t& /*streamAccumulated*/) {
+        outputData.assign(inputData, inputData + inputFrames);
+        return true;
+    };
+
+    audio_pipeline::AudioPipeline pipeline(std::move(deps));
+
+    const std::size_t chunkFrames =
+        static_cast<std::size_t>(std::lround(config.delimiter.chunkSec * 48000));
+    const std::size_t overlapFrames =
+        static_cast<std::size_t>(std::lround(config.delimiter.overlapSec * 48000));
+    const std::size_t hopFrames = chunkFrames - overlapFrames;
+
+    std::vector<float> input(chunkFrames * 2, 0.0f);
+    for (std::size_t i = 0; i < chunkFrames; ++i) {
+        input[i * 2] = 1.0f;
+        input[i * 2 + 1] = 1.0f;
+    }
+
+    ASSERT_TRUE(pipeline.process(input.data(), static_cast<uint32_t>(chunkFrames)));
+    ASSERT_TRUE(waitForQueuedFrames(playbackBuffer, hopFrames, std::chrono::milliseconds(1000)));
+
+    std::vector<float> outLeft(hopFrames);
+    std::vector<float> outRight(hopFrames);
+    ASSERT_TRUE(playbackBuffer.readPlanar(outLeft.data(), outRight.data(), hopFrames));
+
+    for (std::size_t i = 0; i < hopFrames; ++i) {
+        EXPECT_NEAR(outLeft[i], 2.0f, 1e-3f);
+        EXPECT_NEAR(outRight[i], 2.0f, 1e-3f);
+    }
+    EXPECT_EQ(static_cast<delimiter::ProcessingMode>(delimiterMode.load()),
+              delimiter::ProcessingMode::Active);
+    EXPECT_EQ(static_cast<delimiter::FallbackReason>(delimiterReason.load()),
+              delimiter::FallbackReason::None);
+    EXPECT_FALSE(delimiterLocked.load());
+
+    running.store(false, std::memory_order_release);
+}
+
+TEST(AudioPipelineHighLatency, FallbackTriggersBypassLockOnRepeatedFailures) {
+    AppConfig config;
+    config.upsampleRatio = 1;
+    config.delimiter.enabled = true;
+    config.delimiter.backend = "ort";
+    config.delimiter.expectedSampleRate = 1000;
+    config.delimiter.chunkSec = 0.010f;  // shorter to speed up test
+    config.delimiter.overlapSec = 0.002f;
+
+    std::atomic<bool> running{true};
+    std::atomic<bool> fallbackActive{false};
+    std::atomic<bool> outputReady{true};
+    std::atomic<bool> crossfeedEnabled{false};
+    std::atomic<bool> crossfeedResetRequested{false};
+
+    constexpr std::size_t kBufferFrames = 4096;
+    daemon_output::PlaybackBufferManager playbackBuffer([]() { return kBufferFrames; });
+
+    ConvolutionEngine::StreamFloatVector streamInputLeft;
+    ConvolutionEngine::StreamFloatVector streamInputRight;
+    std::size_t streamAccumLeft = 0;
+    std::size_t streamAccumRight = 0;
+    ConvolutionEngine::StreamFloatVector upsamplerOutputLeft;
+    ConvolutionEngine::StreamFloatVector upsamplerOutputRight;
+
+    ConvolutionEngine::StreamFloatVector cfStreamInputLeft;
+    ConvolutionEngine::StreamFloatVector cfStreamInputRight;
+    std::size_t cfAccumLeft = 0;
+    std::size_t cfAccumRight = 0;
+    ConvolutionEngine::StreamFloatVector cfOutputLeft;
+    ConvolutionEngine::StreamFloatVector cfOutputRight;
+
+    std::atomic<int> delimiterMode(static_cast<int>(delimiter::ProcessingMode::Active));
+    std::atomic<int> delimiterReason(static_cast<int>(delimiter::FallbackReason::None));
+    std::atomic<bool> delimiterLocked(false);
+
+    audio_pipeline::Dependencies deps{};
+    deps.config = &config;
+    deps.running = &running;
+    deps.fallbackActive = &fallbackActive;
+    deps.outputReady = &outputReady;
+    deps.crossfeedEnabled = &crossfeedEnabled;
+    deps.crossfeedResetRequested = &crossfeedResetRequested;
+    deps.crossfeedProcessor = nullptr;
+    deps.cfStreamInputLeft = &cfStreamInputLeft;
+    deps.cfStreamInputRight = &cfStreamInputRight;
+    deps.cfStreamAccumulatedLeft = &cfAccumLeft;
+    deps.cfStreamAccumulatedRight = &cfAccumRight;
+    deps.cfOutputLeft = &cfOutputLeft;
+    deps.cfOutputRight = &cfOutputRight;
+    deps.streamInputLeft = &streamInputLeft;
+    deps.streamInputRight = &streamInputRight;
+    deps.streamAccumulatedLeft = &streamAccumLeft;
+    deps.streamAccumulatedRight = &streamAccumRight;
+    deps.upsamplerOutputLeft = &upsamplerOutputLeft;
+    deps.upsamplerOutputRight = &upsamplerOutputRight;
+    deps.streamingCacheManager = nullptr;
+    deps.buffer.playbackBuffer = &playbackBuffer;
+    deps.maxOutputBufferFrames = []() { return kBufferFrames; };
+    deps.currentInputRate = []() { return 1000; };
+    deps.currentOutputRate = []() { return 1000; };
+    deps.delimiterMode = &delimiterMode;
+    deps.delimiterFallbackReason = &delimiterReason;
+    deps.delimiterBypassLocked = &delimiterLocked;
+    deps.delimiterBackendFactory = [](const AppConfig::DelimiterConfig& cfg) {
+        return std::make_unique<FailingBackend>(cfg.expectedSampleRate);
+    };
+
+    deps.upsampler.available = true;
+    deps.upsampler.streamLeft = nullptr;
+    deps.upsampler.streamRight = nullptr;
+    deps.upsampler.process = [](const float* inputData, std::size_t inputFrames,
+                                ConvolutionEngine::StreamFloatVector& outputData,
+                                cudaStream_t /*stream*/,
+                                ConvolutionEngine::StreamFloatVector& /*streamInput*/,
+                                std::size_t& /*streamAccumulated*/) {
+        outputData.assign(inputData, inputData + inputFrames);
+        return true;
+    };
+
+    audio_pipeline::AudioPipeline pipeline(std::move(deps));
+
+    const std::size_t chunkFrames =
+        static_cast<std::size_t>(std::lround(config.delimiter.chunkSec * 1000));
+    const std::size_t overlapFrames =
+        static_cast<std::size_t>(std::lround(config.delimiter.overlapSec * 1000));
+    const std::size_t hopFrames = chunkFrames - overlapFrames;
+
+    std::vector<float> input(chunkFrames * 2, 0.1f);
+
+    for (int i = 0; i < 4; ++i) {
+        ASSERT_TRUE(pipeline.process(input.data(), static_cast<uint32_t>(chunkFrames)));
+        ASSERT_TRUE(waitForQueuedFrames(playbackBuffer, hopFrames, std::chrono::milliseconds(500)));
+        std::vector<float> discardL(hopFrames);
+        std::vector<float> discardR(hopFrames);
+        ASSERT_TRUE(playbackBuffer.readPlanar(discardL.data(), discardR.data(), hopFrames));
+    }
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+    while (std::chrono::steady_clock::now() < deadline) {
+        auto mode =
+            static_cast<delimiter::ProcessingMode>(delimiterMode.load(std::memory_order_relaxed));
+        bool locked = delimiterLocked.load(std::memory_order_relaxed);
+        if (locked && mode == delimiter::ProcessingMode::Bypass) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    EXPECT_TRUE(delimiterLocked.load());
+    EXPECT_EQ(static_cast<delimiter::ProcessingMode>(delimiterMode.load()),
+              delimiter::ProcessingMode::Bypass);
+    EXPECT_EQ(static_cast<delimiter::FallbackReason>(delimiterReason.load()),
+              delimiter::FallbackReason::InferenceFailure);
 
     running.store(false, std::memory_order_release);
 }


### PR DESCRIPTION
## Summary
- delimiter高遅延ワーカーで推論実行時にSR不一致をリサンプルで吸収し、処理/バイパス理由をSafetyControllerへ連携
- SafetyControllerのバイパスロックを即時反映して状態/telemetryに理由付きで載せるよう調整
- 高遅延パスのUTを拡充（SRリサンプル経路と失敗時のバイパスロックを検証）

## Testing
- cmake --build build -j8
- ./build/cpu_tests --gtest_filter=AudioPipelineHighLatency.*
