### PR TITLE
#1131 Totton Audio ブランドページ（web_brand）初稿

### DIFF
--- a/web_brand/README.md
+++ b/web_brand/README.md
@@ -1,0 +1,21 @@
+## Totton Audio / web_brand
+
+`web_brand/` は、Totton Audio の **1枚ペラのブランドページ**（静的HTML）です。
+
+### 仕様
+
+- **htmx + Alpine.js** を読み込み（軽量なインタラクション用途）
+- **日本語 / 英語** の2言語
+- **ブラウザ言語が日本語以外の場合は英語がデフォルト表示**
+  - `?lang=ja|en` で上書き可能
+  - 手動切替は `localStorage (totton.lang)` に保存
+- お問い合わせリンクは Google Forms を使用
+
+### ローカルでの確認方法
+
+例えば以下で静的サーバーを立て、`web_brand/index.html` を開いてください。
+
+```bash
+cd web_brand
+python3 -m http.server 8080
+```

--- a/web_brand/assets/app.js
+++ b/web_brand/assets/app.js
@@ -1,0 +1,300 @@
+(() => {
+  const CONTACT_URL =
+    "https://docs.google.com/forms/d/e/1FAIpQLSc164tZdiH9-2xHKnkegs8amf0CdZmB1vjiSA34ckSL6ZiGmw/viewform";
+
+  const DICT = {
+    en: {
+      nav: { features: "Features", arch: "Architecture", contact: "Contact" },
+      cta: {
+        primary: "Contact",
+        explore: "Explore features",
+        contact: "Get in touch",
+      },
+      hero: {
+        eyebrow: "Ultra high-resolution realtime audio processing",
+        titleA: "A small box,",
+        titleB: "a huge leap in sound.",
+        lead:
+          "Totton Audio delivers a GPU-accelerated realtime audio pipeline for headphone users—ultra high-resolution upsampling, headphone EQ correction, and a simple control UI.",
+      },
+      meta: {
+        gpu: "GPU FFT convolution (CUDA)",
+        minphase: "Minimum phase FIR (640k taps)",
+        ui: "FastAPI control plane",
+      },
+      features: {
+        title: "What this project does",
+        subtitle:
+          "Designed for ultimate simplicity: connect the box, click a few settings, and enjoy better sound.",
+        f1: {
+          title: "GPU-accelerated upsampling",
+          text:
+            "Realtime upsampling powered by GPU convolution and high-quality resampling—built for low latency and stability.",
+        },
+        f2: {
+          title: "640k-tap minimum-phase FIR",
+          text:
+            "A long-tap minimum-phase FIR filter to achieve strong stopband attenuation while avoiding pre-ringing.",
+        },
+        f3: {
+          title: "Headphone EQ correction",
+          text:
+            "Headphone correction workflow leveraging OPRA data (CC BY-SA 4.0) and a target curve—aimed at consistent, pleasant tonality.",
+        },
+        f4: {
+          title: "Standalone DDC/DSP device",
+          text:
+            "Runs on Jetson Orin Nano (production) or PC (development) as a self-contained audio processing device.",
+        },
+        f5: {
+          title: "Simple control UI",
+          text:
+            "Control plane built with Python/FastAPI, designed for a clean web UI and operational clarity.",
+        },
+        f6: {
+          title: "Engine & streaming building blocks",
+          text:
+            "Data plane in C++/CUDA, plus interfaces like ZeroMQ and RTP notes for practical deployment and integration.",
+        },
+      },
+      arch: {
+        title: "Architecture",
+        subtitle: "Split into a friendly control plane and a fast data plane.",
+        diagramTitle: "High-level layout",
+        diagram:
+          "Control Plane (Python/FastAPI)     Data Plane (C++ Audio Engine)\n" +
+          "├── IR Generator (scipy)           ├── GPU FFT Convolution (CUDA)\n" +
+          "├── OPRA Integration               ├── libsoxr Resampling\n" +
+          "└── ZeroMQ Command Interface   <-> └── ALSA Output\n",
+        roadmapTitle: "Roadmap (high-level)",
+        steps: {
+          s1: { k: "Phase 1", v: "Core engine & middleware (in progress)" },
+          s2: { k: "Phase 2", v: "Control plane & Web UI" },
+          s3: { k: "Phase 3", v: "Jetson hardware integration" },
+        },
+        note:
+          "Totton Audio is being developed as an independent project, but collaboration for productization, hardware development, and DSP/AI support is possible.",
+      },
+      contact: {
+        title: "Contact",
+        subtitle:
+          "Partnerships, licensing, PoC/demo listening, or technical consultation—feel free to reach out.",
+        cardTitle: "Let’s build the next-level listening experience",
+        cardText:
+          "Use the contact form below. We’ll handle your inquiry carefully and only use it for communication regarding this project.",
+        form: "Open contact form",
+        copy: "Copy link",
+        hint:
+          "Tip: If your browser blocks pop-ups, right-click the button and open in a new tab.",
+        copied: "Copied the contact form link.",
+        copyFailed: "Could not copy. Please copy the link manually.",
+      },
+      footer: {
+        copy:
+          "© Totton Audio. Brand page draft for this repository.\nLanguage defaults to English unless your browser is set to Japanese.",
+        backToTop: "Back to top",
+      },
+    },
+    ja: {
+      nav: { features: "特徴", arch: "アーキテクチャ", contact: "お問い合わせ" },
+      cta: {
+        primary: "お問い合わせ",
+        explore: "特徴を見る",
+        contact: "相談する",
+      },
+      hero: {
+        eyebrow: "超高解像度・リアルタイム音声処理",
+        titleA: "小さな箱で、",
+        titleB: "音を大きく変える。",
+        lead:
+          "Totton Audio は、ヘッドホンユーザー向けのGPU加速リアルタイム音声処理システムです。超高解像度アップサンプリング、ヘッドホンEQ補正、そしてシンプルな管理UIを目指します。",
+      },
+      meta: {
+        gpu: "GPU FFT畳み込み（CUDA）",
+        minphase: "最小位相FIR（640k taps）",
+        ui: "FastAPIコントロール",
+      },
+      features: {
+        title: "このリポジトリの主な機能",
+        subtitle:
+          "究極のシンプルさ：箱をつなぐ → 管理画面でポチポチ → 最高の音。",
+        f1: {
+          title: "GPU加速アップサンプリング",
+          text:
+            "GPU畳み込みと高品質リサンプルにより、低遅延・安定動作を意識したリアルタイム処理を実現します。",
+        },
+        f2: {
+          title: "640k taps 最小位相FIR",
+          text:
+            "長タップの最小位相FIRで強い阻止帯域減衰を狙いつつ、プリリンギングを避ける設計です。",
+        },
+        f3: {
+          title: "ヘッドホンEQ補正",
+          text:
+            "OPRAデータ（CC BY-SA 4.0）とターゲットカーブを使った補正フローにより、自然で一貫した音作りを目指します。",
+        },
+        f4: {
+          title: "スタンドアロンDDC/DSP",
+          text:
+            "Jetson Orin Nano（本番）またはPC（開発）で動作する、自己完結したDDC/DSPデバイス構成です。",
+        },
+        f5: {
+          title: "シンプルな管理UI",
+          text:
+            "Python/FastAPIのコントロールプレーンで、見通しの良いWeb UIと運用性を重視します。",
+        },
+        f6: {
+          title: "エンジン/ストリーミングの土台",
+          text:
+            "C++/CUDAのデータプレーンに加え、ZeroMQやRTP周りの知見も含め、実運用で使える構成を整えます。",
+        },
+      },
+      arch: {
+        title: "アーキテクチャ",
+        subtitle: "扱いやすい制御系と、速い処理系に分割しています。",
+        diagramTitle: "全体像（概要）",
+        diagram:
+          "Control Plane (Python/FastAPI)     Data Plane (C++ Audio Engine)\n" +
+          "├── IR Generator (scipy)           ├── GPU FFT Convolution (CUDA)\n" +
+          "├── OPRA Integration               ├── libsoxr Resampling\n" +
+          "└── ZeroMQ Command Interface   <-> └── ALSA Output\n",
+        roadmapTitle: "ロードマップ（概要）",
+        steps: {
+          s1: { k: "Phase 1", v: "コアエンジン & ミドルウェア（進行中）" },
+          s2: { k: "Phase 2", v: "コントロールプレーン & Web UI" },
+          s3: { k: "Phase 3", v: "Jetsonハードウェア統合" },
+        },
+        note:
+          "現在は個人の副業として開発していますが、製品化・ハードウェア開発・DSP/AIの技術支援など、商用化や技術提供は柔軟に対応可能です。",
+      },
+      contact: {
+        title: "お問い合わせ",
+        subtitle:
+          "製品化の提携、ライセンス/技術支援、PoC/デモ機の試聴、技術相談など、お気軽にご連絡ください。",
+        cardTitle: "次の“最高の音”を一緒に作りませんか",
+        cardText:
+          "下記フォームからお問い合わせください。内容は厳重に管理し、本件の連絡以外には使用しません。",
+        form: "フォームを開く",
+        copy: "リンクをコピー",
+        hint: "ヒント：ポップアップブロックされる場合は、新しいタブで開いてください。",
+        copied: "お問い合わせフォームのリンクをコピーしました。",
+        copyFailed: "コピーに失敗しました。リンクを手動でコピーしてください。",
+      },
+      footer: {
+        copy:
+          "© Totton Audio. このリポジトリ向けのブランドページ初稿。\nブラウザ言語が日本語以外の場合は英語表示がデフォルトです。",
+        backToTop: "ページ上部へ",
+      },
+    },
+  };
+
+  function normalizeLang(raw) {
+    if (!raw) return "en";
+    const s = String(raw).trim().toLowerCase();
+    if (s === "ja" || s.startsWith("ja-")) return "ja";
+    return "en";
+  }
+
+  function detectLang() {
+    const params = new URLSearchParams(window.location.search);
+    const q = params.get("lang");
+    if (q) return normalizeLang(q);
+
+    const stored = localStorage.getItem("totton.lang");
+    if (stored) return normalizeLang(stored);
+
+    const candidates = []
+      .concat(navigator.languages || [])
+      .concat([navigator.language])
+      .filter(Boolean);
+    for (const c of candidates) {
+      const nl = normalizeLang(c);
+      if (nl === "ja") return "ja";
+    }
+    return "en";
+  }
+
+  function setHtmlLang(lang) {
+    try {
+      document.documentElement.setAttribute("lang", lang);
+    } catch {
+      // ignore
+    }
+  }
+
+  function getDict(lang) {
+    const base = DICT.en;
+    const pick = DICT[lang] || DICT.en;
+    return { base, pick };
+  }
+
+  function showToast(ctx, text) {
+    ctx.toastText = text;
+    ctx.toastOpen = true;
+    window.clearTimeout(ctx._toastTimer);
+    ctx._toastTimer = window.setTimeout(() => {
+      ctx.toastOpen = false;
+    }, 2200);
+  }
+
+  window.brandPage = function brandPage() {
+    const initial = detectLang();
+    setHtmlLang(initial);
+
+    const ctx = {
+      lang: initial,
+      toastOpen: false,
+      toastText: "",
+      _toastTimer: null,
+
+      init() {
+        document.addEventListener("totton:set-lang", (ev) => {
+          const next = normalizeLang(ev?.detail?.lang);
+          this.setLang(next);
+        });
+      },
+
+      setLang(next) {
+        const nl = normalizeLang(next);
+        this.lang = nl;
+        localStorage.setItem("totton.lang", nl);
+        setHtmlLang(nl);
+      },
+
+      t(key) {
+        const { base, pick } = getDict(this.lang);
+        const parts = String(key).split(".");
+        let cur = pick;
+        for (const p of parts) cur = cur?.[p];
+        if (typeof cur === "string") return cur;
+        cur = base;
+        for (const p of parts) cur = cur?.[p];
+        return typeof cur === "string" ? cur : String(key);
+      },
+
+      async copyContactLink() {
+        try {
+          if (navigator.clipboard?.writeText) {
+            await navigator.clipboard.writeText(CONTACT_URL);
+          } else {
+            // Fallback: selection-based copy
+            const ta = document.createElement("textarea");
+            ta.value = CONTACT_URL;
+            ta.setAttribute("readonly", "true");
+            ta.style.position = "fixed";
+            ta.style.top = "-9999px";
+            document.body.appendChild(ta);
+            ta.select();
+            document.execCommand("copy");
+            document.body.removeChild(ta);
+          }
+          showToast(this, this.t("contact.copied"));
+        } catch {
+          showToast(this, this.t("contact.copyFailed"));
+        }
+      },
+    };
+
+    return ctx;
+  };
+})();

--- a/web_brand/assets/main.css
+++ b/web_brand/assets/main.css
@@ -1,0 +1,587 @@
+/*
+  Totton Audio brand page (one-pager)
+  Cyber/HUD-inspired styling aligned with web/static/css/main.css
+*/
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: "Courier New", "SF Mono", "Consolas", monospace;
+  background: #0a0e12;
+  color: rgba(224, 224, 224, 0.95);
+  overflow-x: hidden;
+
+  background-image:
+    linear-gradient(rgba(0, 255, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 255, 255, 0.035) 1px, transparent 1px);
+  background-size: 22px 22px;
+}
+
+[x-cloak] {
+  display: none !important;
+}
+
+.bg-glow {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    radial-gradient(circle at 25% 25%, rgba(0, 255, 255, 0.07) 0%, transparent 55%),
+    radial-gradient(circle at 70% 65%, rgba(0, 255, 136, 0.06) 0%, transparent 55%);
+}
+
+.container {
+  position: relative;
+  z-index: 1;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 88px 24px 64px;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(10px);
+  background: rgba(10, 14, 18, 0.78);
+  border-bottom: 1px solid rgba(0, 255, 255, 0.18);
+}
+
+.topbar__inner {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 14px;
+  align-items: center;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+}
+
+.brand__mark {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(0, 255, 255, 0.35);
+  border-radius: 6px;
+  background: rgba(0, 255, 255, 0.07);
+  box-shadow: 0 0 18px rgba(0, 255, 255, 0.12);
+  color: #00ffff;
+}
+
+.brand__name {
+  color: #00ffff;
+  font-weight: 800;
+  letter-spacing: 1px;
+  text-shadow: 0 0 14px rgba(0, 255, 255, 0.35);
+}
+
+.nav {
+  display: flex;
+  gap: 14px;
+  justify-content: center;
+  align-items: center;
+}
+
+.nav__link {
+  font-size: 13px;
+  color: rgba(128, 160, 160, 0.9);
+  text-decoration: none;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  transition: all 160ms ease;
+}
+
+.nav__link:hover {
+  color: #00ffff;
+  background: rgba(0, 255, 255, 0.06);
+  border-color: rgba(0, 255, 255, 0.2);
+}
+
+.topbar__actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid rgba(0, 255, 255, 0.25);
+  background: rgba(10, 14, 18, 0.85);
+  color: rgba(224, 224, 224, 0.95);
+  font-family: inherit;
+  font-size: 13px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: all 160ms ease;
+  min-height: 42px;
+}
+
+.btn:focus-visible {
+  outline: 2px solid #00ffff;
+  outline-offset: 3px;
+  box-shadow: 0 0 14px rgba(0, 255, 255, 0.25);
+}
+
+.btn--ghost {
+  background: transparent;
+  border-color: rgba(0, 255, 255, 0.18);
+  color: rgba(128, 160, 160, 0.95);
+}
+
+.btn--ghost[aria-pressed="true"] {
+  border-color: rgba(0, 255, 136, 0.35);
+  background: rgba(0, 255, 136, 0.08);
+  color: #00ff88;
+  box-shadow: 0 0 14px rgba(0, 255, 136, 0.12);
+}
+
+.btn--primary {
+  background: linear-gradient(90deg, #38bdf8, #6366f1);
+  color: #0b1223;
+  border-color: rgba(99, 102, 241, 0.45);
+}
+
+.btn--primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 0 22px rgba(56, 189, 248, 0.25);
+}
+
+.btn--secondary {
+  border-color: rgba(0, 255, 255, 0.3);
+  background: rgba(0, 255, 255, 0.03);
+}
+
+.btn--secondary:hover {
+  border-color: rgba(0, 255, 255, 0.55);
+  background: rgba(0, 255, 255, 0.06);
+}
+
+.btn__icon {
+  filter: drop-shadow(0 0 10px rgba(0, 255, 255, 0.2));
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 26px;
+  align-items: center;
+  padding: 28px 0 10px;
+}
+
+.eyebrow {
+  display: inline-flex;
+  gap: 10px;
+  align-items: center;
+  font-size: 11px;
+  color: rgba(0, 255, 136, 0.9);
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  opacity: 0.9;
+  margin-bottom: 12px;
+}
+
+.hero__title {
+  margin: 0 0 14px;
+  line-height: 1.05;
+  font-size: clamp(32px, 4vw, 54px);
+  letter-spacing: 0.5px;
+  color: #e6feff;
+  text-shadow: 0 0 18px rgba(0, 255, 255, 0.16);
+}
+
+.hero__titleAccent {
+  display: inline-block;
+  margin-left: 10px;
+  color: #00ffff;
+  text-shadow: 0 0 22px rgba(0, 255, 255, 0.35);
+}
+
+.hero__lead {
+  margin: 0 0 18px;
+  font-size: 14px;
+  color: rgba(128, 160, 160, 0.95);
+  line-height: 1.75;
+}
+
+.hero__cta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.hero__meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.pill {
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 255, 255, 0.2);
+  background: rgba(0, 255, 255, 0.03);
+  color: rgba(224, 224, 224, 0.9);
+  font-size: 11px;
+  letter-spacing: 0.5px;
+}
+
+.hud {
+  border: 1px solid rgba(0, 255, 255, 0.22);
+  border-radius: 14px;
+  background: rgba(18, 22, 26, 0.78);
+  box-shadow:
+    0 0 24px rgba(0, 255, 255, 0.08),
+    inset 0 0 26px rgba(0, 255, 255, 0.02);
+  overflow: hidden;
+}
+
+.hud__title {
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(0, 255, 255, 0.12);
+  color: #00ffff;
+  font-weight: 800;
+  letter-spacing: 3px;
+  font-size: 12px;
+  text-shadow: 0 0 16px rgba(0, 255, 255, 0.25);
+}
+
+.hud__grid {
+  padding: 14px 16px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.hud__cell {
+  border: 1px solid rgba(0, 255, 255, 0.14);
+  border-radius: 10px;
+  background: rgba(10, 14, 18, 0.7);
+  padding: 12px 12px;
+}
+
+.hud__k {
+  font-size: 10px;
+  color: rgba(128, 160, 160, 0.8);
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+
+.hud__v {
+  font-size: 16px;
+  color: #00ff88;
+  font-weight: 800;
+  text-shadow: 0 0 12px rgba(0, 255, 136, 0.22);
+}
+
+.hud__footer {
+  padding: 12px 16px 14px;
+  border-top: 1px solid rgba(0, 255, 255, 0.12);
+  font-size: 10px;
+  color: rgba(0, 212, 255, 0.9);
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
+.section {
+  margin-top: 48px;
+}
+
+.section__header {
+  margin-bottom: 18px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid rgba(0, 255, 255, 0.18);
+}
+
+.section__title {
+  margin: 0 0 8px;
+  font-size: 22px;
+  color: #00ffff;
+  text-shadow: 0 0 16px rgba(0, 255, 255, 0.18);
+  letter-spacing: 0.5px;
+}
+
+.section__subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(128, 160, 160, 0.85);
+  line-height: 1.7;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.card {
+  border: 1px solid rgba(0, 255, 255, 0.18);
+  border-radius: 14px;
+  background: rgba(18, 22, 26, 0.72);
+  padding: 18px 18px;
+  box-shadow: inset 0 0 22px rgba(0, 255, 255, 0.02);
+  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(0, 255, 255, 0.35);
+  box-shadow:
+    0 0 20px rgba(0, 255, 255, 0.08),
+    inset 0 0 26px rgba(0, 255, 255, 0.03);
+}
+
+.card__icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  margin-bottom: 12px;
+  background: rgba(0, 255, 255, 0.06);
+  border: 1px solid rgba(0, 255, 255, 0.18);
+  color: #00d4ff;
+  filter: drop-shadow(0 0 14px rgba(0, 255, 255, 0.12));
+}
+
+.card__title {
+  margin: 0 0 8px;
+  font-size: 14px;
+  color: rgba(224, 224, 224, 0.95);
+  letter-spacing: 0.3px;
+}
+
+.card__text {
+  margin: 0;
+  font-size: 12px;
+  color: rgba(128, 160, 160, 0.85);
+  line-height: 1.7;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.panel {
+  border: 1px solid rgba(0, 255, 255, 0.18);
+  border-radius: 14px;
+  background: rgba(18, 22, 26, 0.72);
+  padding: 18px;
+}
+
+.panel__title {
+  font-size: 12px;
+  color: #00ff88;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+.diagram {
+  margin: 0;
+  padding: 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(0, 255, 255, 0.14);
+  background: rgba(10, 14, 18, 0.75);
+  color: rgba(224, 224, 224, 0.9);
+  overflow: auto;
+  line-height: 1.55;
+  font-size: 12px;
+}
+
+.steps {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 10px;
+}
+
+.steps__item {
+  list-style: decimal;
+  padding-left: 6px;
+}
+
+.steps__k {
+  color: rgba(224, 224, 224, 0.95);
+  font-weight: 800;
+  font-size: 13px;
+}
+
+.steps__v {
+  color: rgba(128, 160, 160, 0.85);
+  font-size: 12px;
+  line-height: 1.6;
+  margin-top: 4px;
+}
+
+.note {
+  margin-top: 14px;
+  padding: 12px 12px;
+  border-radius: 12px;
+  border: 1px dashed rgba(0, 255, 255, 0.22);
+  background: rgba(0, 255, 255, 0.03);
+  color: rgba(224, 224, 224, 0.86);
+  font-size: 12px;
+  line-height: 1.7;
+}
+
+.contact {
+  display: grid;
+  place-items: center;
+}
+
+.contact__card {
+  width: 100%;
+  max-width: 760px;
+  border: 1px solid rgba(0, 255, 255, 0.2);
+  border-radius: 16px;
+  background: rgba(18, 22, 26, 0.78);
+  padding: 20px;
+  box-shadow: 0 0 26px rgba(0, 255, 255, 0.08);
+}
+
+.contact__headline {
+  font-size: 16px;
+  color: #00ffff;
+  font-weight: 800;
+  margin-bottom: 8px;
+  text-shadow: 0 0 14px rgba(0, 255, 255, 0.2);
+}
+
+.contact__text {
+  margin: 0 0 16px;
+  font-size: 13px;
+  color: rgba(128, 160, 160, 0.9);
+  line-height: 1.7;
+}
+
+.contact__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.contact__hint {
+  margin: 12px 0 0;
+  font-size: 11px;
+  color: rgba(128, 160, 160, 0.75);
+  line-height: 1.6;
+}
+
+.toast {
+  margin: 12px 0 0;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(0, 255, 136, 0.28);
+  background: rgba(0, 255, 136, 0.08);
+  color: #00ff88;
+  font-size: 12px;
+  box-shadow: 0 0 18px rgba(0, 255, 136, 0.12);
+}
+
+.footer {
+  margin-top: 56px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(0, 255, 255, 0.18);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.footer__brand {
+  color: rgba(224, 224, 224, 0.95);
+  font-weight: 800;
+  letter-spacing: 0.5px;
+}
+
+.footer__copy {
+  margin-top: 6px;
+  font-size: 11px;
+  color: rgba(128, 160, 160, 0.75);
+  line-height: 1.6;
+}
+
+.footer__link {
+  font-size: 12px;
+  color: rgba(0, 212, 255, 0.95);
+  text-decoration: none;
+}
+
+.footer__link:hover {
+  color: #00ffff;
+  text-decoration: underline;
+}
+
+@media (max-width: 980px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .split {
+    grid-template-columns: 1fr;
+  }
+
+  .nav {
+    display: none;
+  }
+}
+
+@media (max-width: 560px) {
+  .topbar__inner {
+    grid-template-columns: auto 1fr;
+  }
+
+  .topbar__actions {
+    justify-content: flex-end;
+  }
+
+  .container {
+    padding-top: 78px;
+  }
+
+  .cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    scroll-behavior: auto !important;
+    transition: none !important;
+  }
+}

--- a/web_brand/index.html
+++ b/web_brand/index.html
@@ -1,0 +1,231 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark" />
+
+  <title>Totton Audio — Ultra High-Resolution Realtime Audio Processing</title>
+  <meta name="description" content="Totton Audio is a GPU-accelerated, realtime audio processing system for headphone users—ultra high-resolution upsampling, EQ correction, and a simple control UI." />
+
+  <meta property="og:title" content="Totton Audio" />
+  <meta property="og:description" content="GPU-accelerated realtime audio processing: ultra high-resolution upsampling, headphone EQ, and simple control UI." />
+  <meta property="og:type" content="website" />
+
+  <link rel="stylesheet" href="./assets/main.css" />
+
+  <!-- htmx 1.9.12 -->
+  <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+
+  <!-- Alpine.js 3.13.10 -->
+  <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.13.10/dist/cdn.min.js"></script>
+  <script defer src="./assets/app.js"></script>
+</head>
+<body hx-boost="true">
+  <div class="bg-glow" aria-hidden="true"></div>
+
+  <header class="topbar" x-data="brandPage()" x-cloak>
+    <div class="topbar__inner">
+      <a class="brand" href="#top" aria-label="Totton Audio">
+        <span class="brand__mark" aria-hidden="true">⬡</span>
+        <span class="brand__name">Totton Audio</span>
+      </a>
+
+      <nav class="nav" aria-label="Primary">
+        <a class="nav__link" href="#features" x-text="t('nav.features')"></a>
+        <a class="nav__link" href="#architecture" x-text="t('nav.arch')"></a>
+        <a class="nav__link" href="#contact" x-text="t('nav.contact')"></a>
+      </nav>
+
+      <div class="topbar__actions">
+        <button
+          class="btn btn--ghost"
+          type="button"
+          :aria-pressed="lang === 'ja'"
+          hx-on:click="document.dispatchEvent(new CustomEvent('totton:set-lang', { detail: { lang: 'ja' } }))"
+        >
+          日本語
+        </button>
+        <button
+          class="btn btn--ghost"
+          type="button"
+          :aria-pressed="lang === 'en'"
+          hx-on:click="document.dispatchEvent(new CustomEvent('totton:set-lang', { detail: { lang: 'en' } }))"
+        >
+          EN
+        </button>
+        <a class="btn btn--primary" href="#contact">
+          <span class="btn__icon" aria-hidden="true">✦</span>
+          <span class="btn__label" x-text="t('cta.primary')"></span>
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <main id="top" class="container" x-data="brandPage()" x-cloak>
+    <section class="hero">
+      <div class="hero__left">
+        <div class="eyebrow" x-text="t('hero.eyebrow')"></div>
+        <h1 class="hero__title">
+          <span x-text="t('hero.titleA')"></span>
+          <span class="hero__titleAccent" x-text="t('hero.titleB')"></span>
+        </h1>
+        <p class="hero__lead" x-text="t('hero.lead')"></p>
+        <div class="hero__cta">
+          <a class="btn btn--primary" href="#features">
+            <span class="btn__icon" aria-hidden="true">→</span>
+            <span class="btn__label" x-text="t('cta.explore')"></span>
+          </a>
+          <a class="btn btn--secondary" href="#contact">
+            <span class="btn__icon" aria-hidden="true">⌁</span>
+            <span class="btn__label" x-text="t('cta.contact')"></span>
+          </a>
+        </div>
+        <div class="hero__meta">
+          <div class="pill" x-text="t('meta.gpu')"></div>
+          <div class="pill" x-text="t('meta.minphase')"></div>
+          <div class="pill" x-text="t('meta.ui')"></div>
+        </div>
+      </div>
+
+      <div class="hero__right" aria-hidden="true">
+        <div class="hud">
+          <div class="hud__title">TOTTON AUDIO</div>
+          <div class="hud__grid">
+            <div class="hud__cell">
+              <div class="hud__k">UPSAMPLING</div>
+              <div class="hud__v">GPU</div>
+            </div>
+            <div class="hud__cell">
+              <div class="hud__k">FILTER</div>
+              <div class="hud__v">640k TAP</div>
+            </div>
+            <div class="hud__cell">
+              <div class="hud__k">PHASE</div>
+              <div class="hud__v">MINIMUM</div>
+            </div>
+            <div class="hud__cell">
+              <div class="hud__k">CONTROL</div>
+              <div class="hud__v">FASTAPI</div>
+            </div>
+          </div>
+          <div class="hud__footer">REALTIME / HEADPHONE FIRST</div>
+        </div>
+      </div>
+    </section>
+
+    <section id="features" class="section">
+      <div class="section__header">
+        <h2 class="section__title" x-text="t('features.title')"></h2>
+        <p class="section__subtitle" x-text="t('features.subtitle')"></p>
+      </div>
+
+      <div class="cards">
+        <article class="card">
+          <div class="card__icon" aria-hidden="true">⚡</div>
+          <h3 class="card__title" x-text="t('features.f1.title')"></h3>
+          <p class="card__text" x-text="t('features.f1.text')"></p>
+        </article>
+        <article class="card">
+          <div class="card__icon" aria-hidden="true">⟂</div>
+          <h3 class="card__title" x-text="t('features.f2.title')"></h3>
+          <p class="card__text" x-text="t('features.f2.text')"></p>
+        </article>
+        <article class="card">
+          <div class="card__icon" aria-hidden="true">◎</div>
+          <h3 class="card__title" x-text="t('features.f3.title')"></h3>
+          <p class="card__text" x-text="t('features.f3.text')"></p>
+        </article>
+        <article class="card">
+          <div class="card__icon" aria-hidden="true">⌬</div>
+          <h3 class="card__title" x-text="t('features.f4.title')"></h3>
+          <p class="card__text" x-text="t('features.f4.text')"></p>
+        </article>
+        <article class="card">
+          <div class="card__icon" aria-hidden="true">⎈</div>
+          <h3 class="card__title" x-text="t('features.f5.title')"></h3>
+          <p class="card__text" x-text="t('features.f5.text')"></p>
+        </article>
+        <article class="card">
+          <div class="card__icon" aria-hidden="true">⟠</div>
+          <h3 class="card__title" x-text="t('features.f6.title')"></h3>
+          <p class="card__text" x-text="t('features.f6.text')"></p>
+        </article>
+      </div>
+    </section>
+
+    <section id="architecture" class="section">
+      <div class="section__header">
+        <h2 class="section__title" x-text="t('arch.title')"></h2>
+        <p class="section__subtitle" x-text="t('arch.subtitle')"></p>
+      </div>
+
+      <div class="split">
+        <div class="panel">
+          <div class="panel__title" x-text="t('arch.diagramTitle')"></div>
+          <pre class="diagram" aria-label="Architecture diagram" x-text="t('arch.diagram')"></pre>
+        </div>
+        <div class="panel">
+          <div class="panel__title" x-text="t('arch.roadmapTitle')"></div>
+          <ol class="steps">
+            <li class="steps__item">
+              <div class="steps__k" x-text="t('arch.steps.s1.k')"></div>
+              <div class="steps__v" x-text="t('arch.steps.s1.v')"></div>
+            </li>
+            <li class="steps__item">
+              <div class="steps__k" x-text="t('arch.steps.s2.k')"></div>
+              <div class="steps__v" x-text="t('arch.steps.s2.v')"></div>
+            </li>
+            <li class="steps__item">
+              <div class="steps__k" x-text="t('arch.steps.s3.k')"></div>
+              <div class="steps__v" x-text="t('arch.steps.s3.v')"></div>
+            </li>
+          </ol>
+          <div class="note" x-text="t('arch.note')"></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="contact" class="section">
+      <div class="section__header">
+        <h2 class="section__title" x-text="t('contact.title')"></h2>
+        <p class="section__subtitle" x-text="t('contact.subtitle')"></p>
+      </div>
+
+      <div class="contact">
+        <div class="contact__card">
+          <div class="contact__headline" x-text="t('contact.cardTitle')"></div>
+          <p class="contact__text" x-text="t('contact.cardText')"></p>
+          <div class="contact__actions">
+            <a
+              class="btn btn--primary"
+              href="https://docs.google.com/forms/d/e/1FAIpQLSc164tZdiH9-2xHKnkegs8amf0CdZmB1vjiSA34ckSL6ZiGmw/viewform"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="btn__icon" aria-hidden="true">↗</span>
+              <span class="btn__label" x-text="t('contact.form')"></span>
+            </a>
+            <button class="btn btn--secondary" type="button" @click="copyContactLink()">
+              <span class="btn__icon" aria-hidden="true">⧉</span>
+              <span class="btn__label" x-text="t('contact.copy')"></span>
+            </button>
+          </div>
+          <p class="contact__hint" x-text="t('contact.hint')"></p>
+          <p class="toast" role="status" aria-live="polite" x-show="toastOpen" x-transition.opacity x-text="toastText"></p>
+        </div>
+      </div>
+    </section>
+
+    <footer class="footer">
+      <div class="footer__left">
+        <div class="footer__brand">Totton Audio</div>
+        <div class="footer__copy" x-text="t('footer.copy')"></div>
+      </div>
+      <div class="footer__right">
+        <a class="footer__link" href="#top" x-text="t('footer.backToTop')"></a>
+      </div>
+    </footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Closes #1131

## 追加内容
- `web_brand/` に静的1枚ペラのブランドページを追加
- htmx + Alpine.js + i18n（簡易辞書）
- 日本語/英語（ブラウザ言語が日本語以外なら英語デフォルト）
- 手動言語切替（localStorageに保存）
- お問い合わせ導線（Google Forms）

## 確認
- `web_brand/index.html` をブラウザで開く（または `python3 -m http.server`）
- `?lang=ja|en` で上書き可能

## お問い合わせ
- https://docs.google.com/forms/d/e/1FAIpQLSc164tZdiH9-2xHKnkegs8amf0CdZmB1vjiSA34ckSL6ZiGmw/viewform
