### PR TITLE
#1129 Vulkan overlap-save segfault fix

### DIFF
--- a/samples/vkfft_overlap_save/vulkan_overlap_save.cpp
+++ b/samples/vkfft_overlap_save/vulkan_overlap_save.cpp
@@ -222,15 +222,17 @@ void destroyBuffer(VulkanContext& ctx, BufferResource& buf) {
     }
 }
 
-VkFFTResult createFftApp(VulkanContext& ctx, VkBuffer buffer, uint64_t bufferSize, uint32_t fftSize,
+VkFFTResult createFftApp(VulkanContext& ctx, BufferResource& resource, uint32_t fftSize,
                          VkFFTApplication& outApp) {
     VkFFTConfiguration conf{};
     conf.FFTdim = 1;
     conf.size[0] = fftSize;
+    conf.size[1] = 1;
+    conf.size[2] = 1;
     conf.performR2C = 1;
     conf.normalize = 1;
-    conf.buffer = &buffer;
-    conf.bufferSize = &bufferSize;
+    conf.buffer = &resource.buffer;
+    conf.bufferSize = reinterpret_cast<uint64_t*>(&resource.size);
     conf.device = &ctx.device;
     conf.queue = &ctx.queue;
     conf.commandPool = &ctx.commandPool;
@@ -624,8 +626,8 @@ bool processOverlapSaveBuffer(const std::vector<float>& inputMono,
         return false;
     }
 
-    if (createFftApp(ctx, inputBuf.buffer, bufferBytes, fftSize, inputApp) != VKFFT_SUCCESS ||
-        createFftApp(ctx, filterBuf.buffer, bufferBytes, fftSize, filterApp) != VKFFT_SUCCESS) {
+    if (createFftApp(ctx, inputBuf, fftSize, inputApp) != VKFFT_SUCCESS ||
+        createFftApp(ctx, filterBuf, fftSize, filterApp) != VKFFT_SUCCESS) {
         LOG_ERROR("Failed to initialize VkFFT");
         cleanup();
         return false;


### PR DESCRIPTION
## 概要
- Vulkan overlap-save オフラインツールで実フィルタ（640k taps）使用時に Segfault が発生していた問題を修正
- VkFFT 設定で 1D FFT のバッファを正しく関連付け、in-place R2C/C2R のバッファサイズと次元を明示

## 変更点
- VkFFTConfiguration に  を設定し、BufferResource の size を参照させるよう修正
- FFT app 作成呼び出しを BufferResource ベースに揃えてバッファ参照のずれを防止

## 動作確認
- cmake -B build-vulkan -DCMAKE_BUILD_TYPE=Release -DENABLE_VULKAN=ON -DENABLE_CUDA=OFF
- cmake --build build-vulkan --target vulkan_overlap_save_tool vulkan_overlap_save_tests -j8
- ./build-vulkan/samples/vkfft_overlap_save/vulkan_overlap_save_tool --input test_output/sine_1k_5s_96k_mono.wav --output /tmp/out.wav --filter data/coefficients/filter_48k_8x_2m_min_phase.bin
  - 正常終了を確認（出力生成）
- ctest -C Release -R VulkanOverlapSave --output-on-failure --test-dir build-vulkan
  - 1/1 パス
- ./scripts/deployment/run_tests.sh
  - すべてパス