### PR TITLE
#929 Vulkan: ステレオ対応（2ch）

### DIFF
--- a/samples/vkfft_overlap_save/vulkan_overlap_save.h
+++ b/samples/vkfft_overlap_save/vulkan_overlap_save.h
@@ -30,5 +30,11 @@ bool processOverlapSaveBuffer(const std::vector<float>& inputMono,
                               const std::vector<float>& filterTaps, uint32_t upsampleRatio,
                               uint32_t fftSize, uint32_t chunkFrames, std::vector<float>& output);
 
+// ステレオ入力（インターリーブ）をVulkan Overlap-Saveで処理する
+bool processOverlapSaveStereoBuffer(const std::vector<float>& inputInterleaved,
+                                    const std::vector<float>& filterTaps, uint32_t upsampleRatio,
+                                    uint32_t fftSize, uint32_t chunkFrames,
+                                    std::vector<float>& outputInterleaved);
+
 // WAV入出力付きの高レベルCLI処理
 int runVulkanOverlapSave(const VulkanOverlapSaveOptions& opts);

--- a/samples/vkfft_overlap_save/vulkan_overlap_save_tests.cpp
+++ b/samples/vkfft_overlap_save/vulkan_overlap_save_tests.cpp
@@ -13,6 +13,17 @@ bool runImpulseCase(std::vector<float>& out) {
     return processOverlapSaveBuffer(input, filter, ratio, fftSize, /*chunkFrames=*/4, out);
 }
 
+bool runStereoImpulseCase(std::vector<float>& out) {
+    const std::vector<float> filter = {1.f, 2.f, 3.f, 2.f, 1.f};
+    const std::vector<float> input = {1.f, 2.f,  //
+                                      0.f, 0.f,  //
+                                      0.f, 0.f,  //
+                                      0.f, 0.f};
+    const uint32_t ratio = 2;
+    const uint32_t fftSize = 64;
+    return processOverlapSaveStereoBuffer(input, filter, ratio, fftSize, /*chunkFrames=*/4, out);
+}
+
 }  // namespace
 
 TEST(VulkanOverlapSave, ImpulseMatchesFilter) {
@@ -24,5 +35,22 @@ TEST(VulkanOverlapSave, ImpulseMatchesFilter) {
     const std::vector<float> expected = {1.f, 2.f, 3.f, 2.f, 1.f};
     for (std::size_t i = 0; i < expected.size(); ++i) {
         EXPECT_NEAR(output[i], expected[i], 1e-4);
+    }
+}
+
+TEST(VulkanOverlapSave, StereoChannelsIndependent) {
+    std::vector<float> output;
+    if (!runStereoImpulseCase(output)) {
+        GTEST_SKIP() << "Vulkan backend not available";
+    }
+    ASSERT_EQ(output.size() % 2, 0u);
+    const std::size_t frames = output.size() / 2;
+    ASSERT_GE(frames, 5u);
+
+    const std::vector<float> expectedLeft = {1.f, 2.f, 3.f, 2.f, 1.f};
+    const std::vector<float> expectedRight = {2.f, 4.f, 6.f, 4.f, 2.f};
+    for (std::size_t i = 0; i < expectedLeft.size(); ++i) {
+        EXPECT_NEAR(output[i * 2], expectedLeft[i], 1e-4);
+        EXPECT_NEAR(output[i * 2 + 1], expectedRight[i], 1e-4);
     }
 }


### PR DESCRIPTION
## 概要\n- Vulkan Overlap-Saveサンプルでステレオ入力(L/R)を独立処理する経路を追加\n- WAV CLIでチャンネル数を判別して1ch/2chを自動処理、出力チャンネル数を維持\n- ステレオ入力がチャンネルを取り違えず通ることを確認するテストを追加\n\n## テスト\n- cmake --build build --target vulkan_overlap_save_tests -j4\n- ./build/samples/vkfft_overlap_save/vulkan_overlap_save_tests\n\nCloses #929