### PR TITLE
#1136 Allow runtime De-Limiter enablement from Web

### DIFF
--- a/include/daemon/audio_pipeline/audio_pipeline.h
+++ b/include/daemon/audio_pipeline/audio_pipeline.h
@@ -159,6 +159,7 @@ class AudioPipeline {
     void trimInternal(size_t minFramesToRemove);
     float computeStereoPeak(const float* left, const float* right, size_t frames) const;
     float applyOutputLimiter(float* interleaved, size_t frames);
+    bool startDelimiterBackend();
 
     template <typename Container>
     size_t enqueueOutputFramesLocked(const Container& left, const Container& right);

--- a/src/daemon/control/control_plane.cpp
+++ b/src/daemon/control/control_plane.cpp
@@ -755,15 +755,14 @@ std::string ControlPlane::handleDelimiterEnable(const daemon_ipc::ZmqRequest& re
         return buildErrorResponse(request, "DELIMITER_UNAVAILABLE",
                                   "Delimiter control unavailable");
     }
-    auto status = deps_.delimiterStatus();
-    if (!status.backendAvailable) {
-        return buildErrorResponse(request, "DELIMITER_UNAVAILABLE", "Delimiter backend not ready");
-    }
     if (!deps_.delimiterEnable()) {
         return buildErrorResponse(request, "DELIMITER_ENABLE_FAILED",
                                   "Failed to enable De-limiter");
     }
     auto updated = deps_.delimiterStatus();
+    if (!updated.backendAvailable) {
+        return buildErrorResponse(request, "DELIMITER_UNAVAILABLE", "Delimiter backend not ready");
+    }
     return buildOkResponse(request, "Delimiter enabled", buildDelimiterStatusJson(updated));
 }
 
@@ -771,10 +770,6 @@ std::string ControlPlane::handleDelimiterDisable(const daemon_ipc::ZmqRequest& r
     if (!deps_.delimiterDisable || !deps_.delimiterStatus) {
         return buildErrorResponse(request, "DELIMITER_UNAVAILABLE",
                                   "Delimiter control unavailable");
-    }
-    auto status = deps_.delimiterStatus();
-    if (!status.backendAvailable) {
-        return buildErrorResponse(request, "DELIMITER_UNAVAILABLE", "Delimiter backend not ready");
     }
     if (!deps_.delimiterDisable()) {
         return buildErrorResponse(request, "DELIMITER_DISABLE_FAILED",

--- a/web/templates/pages/delimiter.html
+++ b/web/templates/pages/delimiter.html
@@ -19,7 +19,7 @@
             {% set toggle_desc = t.get('system.delimiter.desc') %}
             {% set alpine_model = "delimiter.enabled" %}
             {% set alpine_click = "toggleDelimiter()" %}
-            {% set alpine_disabled = "delimiter.loading || actionInProgress || !health.daemon_running || !delimiter.backendAvailable" %}
+            {% set alpine_disabled = "delimiter.loading || actionInProgress || !health.daemon_running" %}
             {% include 'components/toggle_switch.html' %}
             {{ buttons.btn_primary(t.get('system.delimiter.refresh'), icon='🔄', click='fetchDelimiter()', disabled='delimiter.loading', extra_class='btn-secondary') }}
         </div>


### PR DESCRIPTION
## Summary
- デーモン起動時に無効でも、WebのenableリクエストでDe-Limiterバックエンドを起動できるようにlazy初期化を追加
- backendAvailable事前チェックで弾かれていたEnable API/UIの制約を緩和
- トグルのdisable条件をdaemon稼働のみとし、warmup/telemetryを初期化

## Testing
- cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
- cmake --build build -j4
- git push (pre-push hooks: clang-tidy, diff-based tests)