### PR TITLE
Fix #1138: Delimiter buffer margin

### DIFF
--- a/include/daemon/audio_pipeline/stream_buffer_sizing.h
+++ b/include/daemon/audio_pipeline/stream_buffer_sizing.h
@@ -25,8 +25,8 @@ inline size_t computeStreamBufferCapacity(const daemon_app::RuntimeState& state,
         frames = std::max(frames, static_cast<size_t>(state.config.loopback.periodFrames));
     }
     frames = std::max(frames, streamValidInputPerBlock);
-    // 2x safety margin for bursty upstream (no reallocation in RT path)
-    return frames * 2;
+    // 3x safety margin for bursty upstream (RT path + high-latency worker overlap, Fix #1138)
+    return frames * 3;
 }
 
 }  // namespace audio_pipeline

--- a/tests/cpp/daemon/test_stream_buffer_sizing.cpp
+++ b/tests/cpp/daemon/test_stream_buffer_sizing.cpp
@@ -26,7 +26,8 @@ TEST(StreamBufferSizingTest, UsesMaxOfRelevantSizesAndAppliesSafetyMargin) {
             frames = std::max(frames, static_cast<size_t>(state.config.loopback.periodFrames));
         }
         frames = std::max(frames, streamValidInputPerBlock);
-        return frames * 2;
+        // 3x margin to tolerate overlap of RT path and high-latency worker (Fix #1138)
+        return frames * 3;
     };
 
     size_t cap =


### PR DESCRIPTION
## Summary
- streaming input bufferの安全マージンを2xから3xへ拡大し、De-Limiter高遅延ワーカー重畳時の入力オーバーフローを防止
- stream buffer sizingの単体テスト期待値を新マージンに更新

## Testing
- cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
- pre-push hook (clang-format, clang-tidy, diff-based tests)
