### PR TITLE
Fix #1143: 出力バッファ枯渇後の復旧

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,6 +543,7 @@ if(ENABLE_CUDA)
         tests/cpp/daemon/test_loopback_helpers.cpp
         tests/cpp/daemon/test_pid_lock.cpp
         tests/cpp/daemon/test_runtime_stats.cpp
+        tests/cpp/daemon/test_playback_buffer_manager.cpp
         tests/cpp/daemon/test_stream_buffer_sizing.cpp
         tests/cpp/daemon/test_playback_buffer_access.cpp
         tests/cpp/daemon/test_switch_actions.cpp

--- a/tests/cpp/daemon/test_playback_buffer_manager.cpp
+++ b/tests/cpp/daemon/test_playback_buffer_manager.cpp
@@ -1,0 +1,42 @@
+#include "daemon/output/playback_buffer_manager.h"
+#include "gtest/gtest.h"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+TEST(PlaybackBufferManagerTest, ThrottleBlocksUntilQueueDrains) {
+    constexpr std::size_t kCapacity = 100;
+    constexpr int kOutputRate = 1000;
+
+    daemon_output::PlaybackBufferManager manager([]() { return kCapacity; });
+
+    std::vector<float> data(kCapacity, 1.0f);
+    std::size_t stored = 0;
+    std::size_t dropped = 0;
+    ASSERT_TRUE(manager.enqueue(data.data(), data.data(), kCapacity, kOutputRate, stored, dropped));
+    EXPECT_EQ(manager.queuedFramesLocked(), kCapacity);
+
+    std::atomic<bool> running{true};
+    std::atomic<bool> throttling{false};
+
+    std::thread producer([&]() {
+        throttling.store(true, std::memory_order_release);
+        manager.throttleProducerIfFull(running, []() { return kOutputRate; });
+        throttling.store(false, std::memory_order_release);
+    });
+
+    std::this_thread::sleep_for(50ms);
+    EXPECT_TRUE(throttling.load(std::memory_order_acquire));
+
+    std::vector<float> outLeft(kCapacity);
+    std::vector<float> outRight(kCapacity);
+    ASSERT_TRUE(manager.readPlanar(outLeft.data(), outRight.data(), 80));
+
+    producer.join();
+    EXPECT_FALSE(throttling.load(std::memory_order_acquire));
+    EXPECT_LT(manager.queuedFramesLocked(), kCapacity);
+}


### PR DESCRIPTION
## 概要\n- PlaybackBufferManager が消費後にプロデューサを再開できず音途切れが継続する問題を修正\n- Throttle待機をループ化し、read側で通知を発火\n- 再現防止のユニットテストを追加\n\n## 変更内容\n- 出力リングバッファ読み取り時に  を通知し、スロットル解除を即時反映\n- スロットル待機を while ループ化してヒステリシス閾値まで確実に待機\n-  を追加\n\n## テスト\n- [  1%] Built target soft_mute
[  7%] Built target dac_capability
[  7%] Built target gtest
[ 16%] Built target spdlog
[ 18%] Built target gtest_main
[ 22%] Built target logging
[ 26%] Built target delimiter_inference
[ 28%] Built target filter_headroom
[ 33%] Built target fallback_manager
[ 37%] Built target eq_support
[ 49%] Built target gpu_upsampler_core
[ 49%] Building CXX object CMakeFiles/cpu_tests.dir/tests/cpp/daemon/test_playback_buffer_manager.cpp.o
[ 49%] Linking CUDA device code CMakeFiles/cpu_tests.dir/cmake_device_link.o
[ 50%] Linking CXX executable cpu_tests
[100%] Built target cpu_tests\n- Test project /home/michihito/Working/gpu_os/worktrees/1143-output-buffer