### PR TITLE
#1142 De-Limiter出力バッファのスロットリング強化

### DIFF
--- a/include/daemon/output/playback_buffer_manager.h
+++ b/include/daemon/output/playback_buffer_manager.h
@@ -37,7 +37,8 @@ class PlaybackBufferManager {
     void reset();
 
     void throttleProducerIfFull(const std::atomic<bool>& running,
-                                const std::function<int()>& currentOutputRate);
+                                const std::function<int()>& currentOutputRate,
+                                size_t incomingFramesHint = 0);
 
    private:
     void ensureCapacityLocked();

--- a/src/daemon/audio_pipeline/audio_pipeline.cpp
+++ b/src/daemon/audio_pipeline/audio_pipeline.cpp
@@ -1401,8 +1401,13 @@ void AudioPipeline::workerLoop() {
                 }
 
                 if (deps_.buffer.playbackBuffer && deps_.running) {
-                    deps_.buffer.playbackBuffer->throttleProducerIfFull(*deps_.running,
-                                                                        deps_.currentOutputRate);
+                    int ratio = DaemonConstants::DEFAULT_UPSAMPLE_RATIO;
+                    if (deps_.config && deps_.config->upsampleRatio > 0) {
+                        ratio = deps_.config->upsampleRatio;
+                    }
+                    size_t incomingFramesHint = frames * static_cast<size_t>(ratio);
+                    deps_.buffer.playbackBuffer->throttleProducerIfFull(
+                        *deps_.running, deps_.currentOutputRate, incomingFramesHint);
                 }
 
                 (void)processDirect(downstreamInterleaved_.data(), static_cast<uint32_t>(frames));


### PR DESCRIPTION
## 概要\n- 出力バッファのスロットリングにincomingフレームヒントを導入し、大きなバーストに備えてヘッドルームを確保\n- デリミター高遅延ワーカーからアップサンプル比を加味したヒントを渡し、ログにもヒントを表示\n- headroom保持のユニットテストを追加\n\n## テスト\n- ./scripts/deployment/run_tests.sh