### PR TITLE
#1159 Jetson: De-Limiter defaults (ort/cuda, start OFF)

### DIFF
--- a/config.json
+++ b/config.json
@@ -37,13 +37,13 @@
   },
   "delimiter": {
     "enabled": false,
-    "backend": "onnx",
+    "backend": "ort",
     "chunkSec": 6.0,
     "overlapSec": 0.25,
     "expectedSampleRate": 44100,
     "ort": {
       "modelPath": "data/delimiter/weights/jeonchangbin49-de-limiter/44100/delimiter.onnx",
-      "provider": "gpu",
+      "provider": "cuda",
       "intraOpThreads": 0
     }
   },

--- a/src/alsa_daemon.cpp
+++ b/src/alsa_daemon.cpp
@@ -486,6 +486,9 @@ static void load_runtime_config() {
         g_state.rates.inputSampleRate = DEFAULT_INPUT_SAMPLE_RATE;
     }
 
+    // De-limiterは起動時に必ずOFFから始める（手動で明示ONするまで有効化しない）
+    g_state.config.delimiter.enabled = false;
+
     g_state.delimiter.enabled.store(g_state.config.delimiter.enabled, std::memory_order_relaxed);
     g_state.delimiter.warmup.store(g_state.config.delimiter.enabled, std::memory_order_relaxed);
     g_state.delimiter.backendAvailable.store(g_state.config.delimiter.enabled,


### PR DESCRIPTION
## Summary
- set De-Limiter backend to ort with cuda provider in default config for Jetson
- force delimiter.enabled=false at daemon startup so it never auto-enables on restart
- keep model path/44.1k SR unchanged, manual toggle required

## Testing
- cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
- pre-push hook (clang-format, clang-tidy, diff-based tests)