### PR TITLE
Fix #1161: De-limiter toggle restart

### DIFF
--- a/web/services/config.py
+++ b/web/services/config.py
@@ -215,6 +215,22 @@ def save_phase_type(phase_type: str) -> bool:
         return False
 
 
+def save_delimiter_enabled(enabled: bool) -> bool:
+    """Persist the De-limiter enabled flag in config.json."""
+    try:
+        existing = load_raw_config()
+        delimiter_section = existing.get("delimiter", {})
+        if not isinstance(delimiter_section, dict):
+            delimiter_section = {}
+        delimiter_section["enabled"] = bool(enabled)
+        existing["delimiter"] = delimiter_section
+        with open(CONFIG_PATH, "w") as f:
+            json.dump(existing, f, indent=2)
+        return True
+    except IOError:
+        return False
+
+
 def save_config(settings: Settings) -> bool:
     """Save configuration to JSON file, preserving existing fields.
 

--- a/web/services/daemon.py
+++ b/web/services/daemon.py
@@ -277,8 +277,13 @@ def stop_daemon() -> tuple[bool, str]:
                 break
 
         if check_daemon_running():
-            logger.error("Daemon is still running after stop attempt")
-            return False, "Daemon did not stop"
+            logger.warning("Daemon is still running after SIGTERM, forcing stop")
+            _force_stop_daemon()
+            if check_daemon_running():
+                logger.error("Daemon is still running after SIGKILL fallback")
+                return False, "Daemon did not stop"
+            logger.info("Daemon stopped via SIGKILL fallback")
+            return True, "Daemon stopped (forced)"
 
         logger.info("Daemon stopped successfully")
         return True, "Daemon stopped"

--- a/web/tests/test_config_delimiter.py
+++ b/web/tests/test_config_delimiter.py
@@ -1,0 +1,25 @@
+import json
+
+from web.services import config
+
+
+def test_save_delimiter_enabled_creates_section(monkeypatch, tmp_path):
+    cfg_path = tmp_path / "config.json"
+    monkeypatch.setattr(config, "CONFIG_PATH", cfg_path)
+
+    assert config.save_delimiter_enabled(False) is True
+
+    saved = json.loads(cfg_path.read_text())
+    assert saved["delimiter"]["enabled"] is False
+
+
+def test_save_delimiter_enabled_preserves_existing_fields(monkeypatch, tmp_path):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({"alsaDevice": "hw:AUDIO"}))
+    monkeypatch.setattr(config, "CONFIG_PATH", cfg_path)
+
+    assert config.save_delimiter_enabled(True) is True
+
+    saved = json.loads(cfg_path.read_text())
+    assert saved["alsaDevice"] == "hw:AUDIO"
+    assert saved["delimiter"]["enabled"] is True


### PR DESCRIPTION
## Summary
- persist De-limiter enable/disable to config so restart keeps OFF
- force SIGKILL fallback when restart button stops hung daemon
- add tests for toggle persistence

Closes #1161

## Testing
- uv run pytest web/tests/test_config_delimiter.py web/tests/test_delimiter_router.py