### PR TITLE
#1146 Vulkan streaming: linear phase switch

### DIFF
--- a/include/vulkan/vulkan_streaming_upsampler.h
+++ b/include/vulkan/vulkan_streaming_upsampler.h
@@ -13,7 +13,12 @@ namespace vulkan_backend {
 class VulkanStreamingUpsampler : public ConvolutionEngine::IAudioUpsampler {
    public:
     struct InitParams {
+        // Legacy: 旧実装との互換のため残す（Minimum 用として扱う）
         std::string filterPath;
+        // 新実装: phase 切替のため Minimum/Linear を両方指定できる
+        std::string filterPathMinimum;
+        std::string filterPathLinear;
+        PhaseType initialPhase = PhaseType::Minimum;
         uint32_t upsampleRatio = 0;
         uint32_t blockSize = 0;
         uint32_t inputRate = 0;
@@ -41,9 +46,7 @@ class VulkanStreamingUpsampler : public ConvolutionEngine::IAudioUpsampler {
     }
     int getCurrentInputRate() const override;
     bool switchToInputRate(int inputSampleRate) override;
-    PhaseType getPhaseType() const override {
-        return PhaseType::Minimum;
-    }
+    PhaseType getPhaseType() const override;
     bool switchPhaseType(PhaseType targetPhase) override;
     size_t getFilterFftSize() const override;
     size_t getFullFftSize() const override;


### PR DESCRIPTION
## Summary
- Vulkan streaming upsamplerでminimum/linear両フィルタをロードし、phase切替を実装
- ControlPlane経由のPHASE_TYPE_SETでlinear指定がエラーにならないようエラー/ログ整備
- EQ再適用が行えるようphase切替時に元スペクトルを更新し、テストを追加

## Testing
- cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_VULKAN=ON && cmake --build build -j8
- /usr/bin/ctest --test-dir build --output-on-failure
- uv run pre-commit run --hook-stage pre-push --show-diff-on-failure