### PR TITLE
#1174 Vulkan FourChannelFIR を CUDA 非依存に

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ if(NOT ENABLE_CUDA AND NOT ENABLE_VULKAN)
     message(FATAL_ERROR "At least one backend must be enabled: ENABLE_CUDA or ENABLE_VULKAN")
 endif()
 
+if(ENABLE_CUDA)
+    add_compile_definitions(HAVE_CUDA_BACKEND)
+endif()
+
 if(ENABLE_VULKAN)
     add_compile_definitions(HAVE_VULKAN_BACKEND)
 endif()
@@ -758,15 +762,17 @@ if(ENABLE_VULKAN)
     gtest_discover_tests(gpu_backend_vulkan_tests)
 endif()
 
-if(ENABLE_VULKAN AND ENABLE_CUDA)
+if(ENABLE_VULKAN)
     add_executable(vulkan_four_channel_tests
         tests/cpp/vulkan/test_vulkan_four_channel_fir.cpp
     )
     target_link_libraries(vulkan_four_channel_tests
         GTest::gtest_main
         vulkan_streaming
-        gpu_upsampler_core
     )
+    if(ENABLE_CUDA)
+        target_link_libraries(vulkan_four_channel_tests gpu_upsampler_core)
+    endif()
     target_include_directories(vulkan_four_channel_tests PRIVATE
         ${CMAKE_SOURCE_DIR}/include
     )

--- a/include/daemon/audio_pipeline/audio_pipeline.h
+++ b/include/daemon/audio_pipeline/audio_pipeline.h
@@ -11,8 +11,6 @@
 #include "io/audio_ring_buffer.h"
 #include "logging/logger.h"
 
-#include <cuda_runtime_api.h>
-
 #include <algorithm>
 #include <atomic>
 #include <chrono>
@@ -40,12 +38,12 @@ struct BufferResources {
 struct Upsampler {
     using ProcessFn = std::function<bool(
         const float* inputData, size_t inputFrames,
-        ConvolutionEngine::StreamFloatVector& outputData, cudaStream_t stream,
+        ConvolutionEngine::StreamFloatVector& outputData, ConvolutionEngine::DeviceStream stream,
         ConvolutionEngine::StreamFloatVector& streamInputBuffer, size_t& streamInputAccumulated)>;
 
     ProcessFn process;
-    cudaStream_t streamLeft = nullptr;
-    cudaStream_t streamRight = nullptr;
+    ConvolutionEngine::DeviceStream streamLeft = nullptr;
+    ConvolutionEngine::DeviceStream streamRight = nullptr;
     bool available = false;
 };
 

--- a/include/vulkan/vulkan_four_channel_fir.h
+++ b/include/vulkan/vulkan_four_channel_fir.h
@@ -28,7 +28,8 @@ class VulkanFourChannelFIR : public ConvolutionEngine::IFourChannelFIR {
 
     bool processStreamBlock(const float* inputL, const float* inputR, size_t inputFrames,
                             ConvolutionEngine::StreamFloatVector& outputL,
-                            ConvolutionEngine::StreamFloatVector& outputR, cudaStream_t stream,
+                            ConvolutionEngine::StreamFloatVector& outputR,
+                            ConvolutionEngine::DeviceStream stream,
                             ConvolutionEngine::StreamFloatVector& streamInputBufferL,
                             ConvolutionEngine::StreamFloatVector& streamInputBufferR,
                             size_t& streamInputAccumulatedL,

--- a/include/vulkan/vulkan_streaming_upsampler.h
+++ b/include/vulkan/vulkan_streaming_upsampler.h
@@ -56,7 +56,8 @@ class VulkanStreamingUpsampler : public ConvolutionEngine::IAudioUpsampler {
     bool applyEqMagnitude(const std::vector<double>& eqMagnitude) override;
 
     bool processStreamBlock(const float* inputData, size_t inputFrames,
-                            ConvolutionEngine::StreamFloatVector& outputData, cudaStream_t stream,
+                            ConvolutionEngine::StreamFloatVector& outputData,
+                            ConvolutionEngine::DeviceStream stream,
                             ConvolutionEngine::StreamFloatVector& streamInputBuffer,
                             size_t& streamInputAccumulated) override;
 

--- a/src/vulkan/vulkan_four_channel_fir.cpp
+++ b/src/vulkan/vulkan_four_channel_fir.cpp
@@ -390,7 +390,8 @@ bool VulkanFourChannelFIR::switchRateFamily(ConvolutionEngine::RateFamily target
 bool VulkanFourChannelFIR::processStreamBlock(
     const float* inputL, const float* inputR, size_t inputFrames,
     ConvolutionEngine::StreamFloatVector& outputL, ConvolutionEngine::StreamFloatVector& outputR,
-    cudaStream_t /*stream*/, ConvolutionEngine::StreamFloatVector& streamInputBufferL,
+    ConvolutionEngine::DeviceStream /*stream*/,
+    ConvolutionEngine::StreamFloatVector& streamInputBufferL,
     ConvolutionEngine::StreamFloatVector& streamInputBufferR, size_t& streamInputAccumulatedL,
     size_t& streamInputAccumulatedR) {
     if (!initialized_ || !streamInitialized_) {

--- a/src/vulkan/vulkan_streaming_upsampler.cpp
+++ b/src/vulkan/vulkan_streaming_upsampler.cpp
@@ -1164,8 +1164,8 @@ bool VulkanStreamingUpsampler::applyEqMagnitude(const std::vector<double>& eqMag
 
 bool VulkanStreamingUpsampler::processStreamBlock(
     const float* inputData, size_t inputFrames, ConvolutionEngine::StreamFloatVector& outputData,
-    cudaStream_t /*stream*/, ConvolutionEngine::StreamFloatVector& streamInputBuffer,
-    size_t& streamInputAccumulated) {
+    ConvolutionEngine::DeviceStream /*stream*/,
+    ConvolutionEngine::StreamFloatVector& streamInputBuffer, size_t& streamInputAccumulated) {
     if (!impl_ || !impl_->initialized) {
         return false;
     }


### PR DESCRIPTION
## Summary
- DeviceStream/CudaPinnedVector をコンパイル時に切り替えて CUDA なしでもヘッダが使えるようにし、CUDA 実装は HAVE_CUDA_BACKEND でガード
- Vulkan FourChannelFIR/upsampler のシグネチャを CUDA 依存でない型に揃え、CMake で Vulkan 単独ビルド時もテストを生成
- 非 CUDA 環境向けに test_vulkan_four_channel_fir を条件分岐させ、CUDA 環境では従来比較を維持

## Testing
- cmake -B build-vk -DCMAKE_BUILD_TYPE=Release -DENABLE_CUDA=OFF -DENABLE_VULKAN=ON
- cmake --build build-vk --target vulkan_four_channel_tests
- git push (pre-push hooks: clang-format, clang-tidy, diff-based-tests)