### PR TITLE
#1180 ORT provider options for delimiter

### DIFF
--- a/src/delimiter/inference_backend.cpp
+++ b/src/delimiter/inference_backend.cpp
@@ -394,10 +394,11 @@ class OrtInferenceBackend final : public InferenceBackend {
 
 std::unique_ptr<InferenceBackend> createDelimiterInferenceBackend(
     const AppConfig::DelimiterConfig& config) {
+    if (!config.enabled) {
+        return std::make_unique<BypassInferenceBackend>(config.expectedSampleRate);
+    }
+
     std::string backend = toLower(config.backend);
-    // Note: config.enabled check removed - caller controls when to create backend.
-    // Startup checks config->delimiter.enabled before calling startDelimiterBackend().
-    // API-triggered enable always wants to create the configured backend.
 
     if (backend == "bypass") {
         return std::make_unique<BypassInferenceBackend>(config.expectedSampleRate);


### PR DESCRIPTION
## Summary
- CUDA/TensorRT プロバイダ追加時に ORT 1.17+ のオプション構造体を渡し、旧 API と両対応にして GPU モードのセグフォを防止
- delimiter が disabled の場合は常に bypass backend を返し、期待挙動とテストを一致

## Testing
- cmake --build build -j8
- /usr/bin/ctest --output-on-failure (ConvolutionEngineTest.* はビルド条件により skip)
