### PR TITLE
#1057 Public repo export: FastAPI web app

### DIFF
--- a/.github/workflows/uiux-sync-public.yml
+++ b/.github/workflows/uiux-sync-public.yml
@@ -36,14 +36,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Prepare UI/UX export (templates/static)
+      - name: Prepare Web export (FastAPI + templates/static)
         if: env.TOKEN != ''
         run: |
           set -euo pipefail
           rm -rf "${EXPORT_DIR}"
-          mkdir -p "${EXPORT_DIR}/web/templates" "${EXPORT_DIR}/web/static"
-          rsync -a --delete "web/templates/" "${EXPORT_DIR}/web/templates/"
-          rsync -a --delete "web/static/" "${EXPORT_DIR}/web/static/"
+          mkdir -p "${EXPORT_DIR}/web"
+          rsync -a --delete "web/" "${EXPORT_DIR}/web/"
 
           # Delimiter page is not published yet (Issue #1057)
           rm -f "${EXPORT_DIR}/web/templates/pages/delimiter.html"
@@ -79,9 +78,8 @@ jobs:
           cd "${CLONE_DIR}"
           git switch -c "sync/uiux-${GITHUB_REF_NAME:-manual}-${GITHUB_SHA:0:7}"
 
-          mkdir -p web/templates web/static
-          rsync -a --delete --exclude ".git" "${EXPORT_DIR}/web/templates/" "web/templates/"
-          rsync -a --delete --exclude ".git" "${EXPORT_DIR}/web/static/" "web/static/"
+          mkdir -p web
+          rsync -a --delete --exclude ".git" "${EXPORT_DIR}/web/" "web/"
 
           git add -A
           if git diff --cached --quiet; then

--- a/web/main.py
+++ b/web/main.py
@@ -33,6 +33,7 @@ from .templates.pages import (
     render_dashboard,
     render_eq_settings,
     render_delimiter,
+    is_delimiter_ui_available,
     render_pi_settings,
     render_system,
 )
@@ -254,13 +255,15 @@ async def system_page(request: Request, lang: str | None = None):
     )
 
 
-@app.get("/delimiter", response_class=HTMLResponse)
-async def delimiter_page(request: Request, lang: str | None = None):
-    """Serve the De-limiter page."""
-    resolved_lang = _resolve_lang(request, lang)
-    return _render_with_lang(
-        content=render_delimiter(lang=resolved_lang), lang=resolved_lang
-    )
+if is_delimiter_ui_available():
+
+    @app.get("/delimiter", response_class=HTMLResponse)
+    async def delimiter_page(request: Request, lang: str | None = None):
+        """Serve the De-limiter page."""
+        resolved_lang = _resolve_lang(request, lang)
+        return _render_with_lang(
+            content=render_delimiter(lang=resolved_lang), lang=resolved_lang
+        )
 
 
 @app.get("/pi", response_class=HTMLResponse)

--- a/web/templates/components/sidebar.html
+++ b/web/templates/components/sidebar.html
@@ -23,14 +23,16 @@
     >
         <span style="margin-right: 8px;">🎚️</span> {{ t.get('nav.eq') }}
     </a>
-    <a
-        href="/delimiter{{ lang_query }}"
-        class="nav-item {% if current_page == 'delimiter' %}active{% endif %}"
-        aria-current="{% if current_page == 'delimiter' %}page{% else %}false{% endif %}"
-        @click="closeMenu()"
-    >
-        <span style="margin-right: 8px;">🧊</span> {{ t.get('nav.delimiter') }}
-    </a>
+    {% if enable_delimiter_ui | default(true) %}
+        <a
+            href="/delimiter{{ lang_query }}"
+            class="nav-item {% if current_page == 'delimiter' %}active{% endif %}"
+            aria-current="{% if current_page == 'delimiter' %}page{% else %}false{% endif %}"
+            @click="closeMenu()"
+        >
+            <span style="margin-right: 8px;">🧊</span> {{ t.get('nav.delimiter') }}
+        </a>
+    {% endif %}
     <a
         href="/system{{ lang_query }}"
         class="nav-item {% if current_page == 'system' %}active{% endif %}"

--- a/web/templates/pages.py
+++ b/web/templates/pages.py
@@ -12,6 +12,8 @@ from ..i18n import get_translations, normalize_lang
 
 # Initialize Jinja2 environment
 template_dir = Path(__file__).parent
+_delimiter_template_path = template_dir / "pages" / "delimiter.html"
+_delimiter_ui_available = _delimiter_template_path.exists()
 env = Environment(
     loader=FileSystemLoader(str(template_dir)),
     autoescape=select_autoescape(["html", "xml"]),
@@ -37,6 +39,7 @@ def render_dashboard(lang: str = "en", current_page: str = "dashboard") -> str:
         t=get_translations(normalized_lang),
         current_page=current_page,
         lang=normalized_lang,
+        enable_delimiter_ui=_delimiter_ui_available,
     )
 
 
@@ -57,6 +60,7 @@ def render_eq_settings(lang: str = "en", current_page: str = "eq") -> str:
         t=get_translations(normalized_lang),
         current_page=current_page,
         lang=normalized_lang,
+        enable_delimiter_ui=_delimiter_ui_available,
     )
 
 
@@ -77,7 +81,13 @@ def render_system(lang: str = "en", current_page: str = "system") -> str:
         t=get_translations(normalized_lang),
         current_page=current_page,
         lang=normalized_lang,
+        enable_delimiter_ui=_delimiter_ui_available,
     )
+
+
+def is_delimiter_ui_available() -> bool:
+    """delimiter UIテンプレが利用可能か（public exportで削除される場合がある）."""
+    return _delimiter_ui_available
 
 
 def render_delimiter(lang: str = "en", current_page: str = "delimiter") -> str:
@@ -91,12 +101,15 @@ def render_delimiter(lang: str = "en", current_page: str = "delimiter") -> str:
     Returns:
         Rendered HTML string
     """
+    if not _delimiter_ui_available:
+        raise FileNotFoundError("delimiter.html is not available")
     normalized_lang = normalize_lang(lang)
     template = env.get_template("pages/delimiter.html")
     return template.render(
         t=get_translations(normalized_lang),
         current_page=current_page,
         lang=normalized_lang,
+        enable_delimiter_ui=_delimiter_ui_available,
     )
 
 
@@ -117,4 +130,5 @@ def render_pi_settings(lang: str = "en", current_page: str = "pi") -> str:
         t=get_translations(normalized_lang),
         current_page=current_page,
         lang=normalized_lang,
+        enable_delimiter_ui=_delimiter_ui_available,
     )


### PR DESCRIPTION
Issue: #1057

## 目的
Public repo で「UIが起動できる状態」にするため、templates/static だけでなく FastAPI の `web/` 一式も同期対象に含める。

## 変更
- Public repo 同期workflow（`.github/workflows/uiux-sync-public.yml`）を `web/` 一式のexportに拡張
- delimiter UIページ（`web/templates/pages/delimiter.html`）は引き続き除外
- delimiter UIテンプレが存在しない環境でもUIが起動できるようにガード
  - サイドバーのdelimiterリンクを非表示
  - `/delimiter` ページルートを登録しない

## メモ
- API自体（router）は引き続き含める（UIページのみ未公開）。
- `PUBLIC_REPO_TOKEN` が無い場合はworkflowはskip。
