### PR TITLE
Fix #1208: De-limiter ORT入力をchannel-firstに修正

### DIFF
--- a/src/delimiter/inference_backend.cpp
+++ b/src/delimiter/inference_backend.cpp
@@ -107,10 +107,10 @@ class OrtInferenceBackend final : public InferenceBackend {
         }
 
         inputBuffer_.resize(input.frames * 2);
-        for (std::size_t i = 0; i < input.frames; ++i) {
-            inputBuffer_[i * 2] = input.left[i];
-            inputBuffer_[i * 2 + 1] = input.right[i];
-        }
+        // ORT model expects channel-first layout: [1, 2, frames]
+        // i.e. [L0..L(N-1), R0..R(N-1)].
+        std::copy(input.left, input.left + input.frames, inputBuffer_.begin());
+        std::copy(input.right, input.right + input.frames, inputBuffer_.begin() + input.frames);
 
         std::array<int64_t, 3> shape{1, 2, static_cast<int64_t>(input.frames)};
         Ort::Value inputTensor = Ort::Value::CreateTensor<float>(


### PR DESCRIPTION
## 概要
ORT(CUDA provider)で推論自体は成功するが、音がスロー再生/歪む問題を修正します。

## 原因
入力tensorのshapeを `[1, 2, frames]` (channel-first) と宣言しているのに、実データを `[L0,R0,L1,R1,...]` (interleaved) で詰めていたため、モデルが意図しないチャンネル解釈になっていました。

## 修正内容
`src/delimiter/inference_backend.cpp` で入力バッファを `[L0..L(N-1), R0..R(N-1)]` に詰め替えて、shape宣言と整合させました。

## 影響範囲
De-limiter ORTバックエンドのみ。Bypass/他経路に変更はありません。

## テスト
- /usr/bin/ctest で delimiter 関連含む絞り込みテストを実行しpass
