### PR TITLE
Fix #1212: ラウドネスケアOFFクラッシュ修正

### DIFF
--- a/include/daemon/audio_pipeline/audio_pipeline.h
+++ b/include/daemon/audio_pipeline/audio_pipeline.h
@@ -177,7 +177,7 @@ class AudioPipeline {
     std::vector<float> workRight_;
 
     // High-latency worker path (Fix #1010 / Epic #1006)
-    bool highLatencyEnabled_ = false;
+    std::atomic<bool> highLatencyEnabled_{false};
     std::unique_ptr<delimiter::InferenceBackend> delimiterBackend_;
     std::unique_ptr<delimiter::SafetyController> delimiterSafety_;
     std::thread workerThread_;


### PR DESCRIPTION
## Summary\n- highLatencyEnabled_ を atomic 化して RT/制御間の競合を解消\n- デリミタ停止時の状態リセットを atomic load/store で一貫化\n- Loudness Care OFF 時の安全性を確認する回帰テストを追加\n\n## Testing\n- cmake --build build -j8\n- /usr/bin/ctest -C Release -R AudioPipelineHighLatency.DisableWhileWorkerRunningIsSafe -VV