### PR TITLE
#1194 GHCR公開確認: 公開pullとダイジェストpin整理

### DIFF
--- a/.github/workflows/private-release-build-ghcr.yml
+++ b/.github/workflows/private-release-build-ghcr.yml
@@ -181,6 +181,40 @@ jobs:
           docker push "${image}:${VERSION}"
           docker push "${image}:latest"
 
+      - name: Ensure GHCR package is public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          package="${IMAGE_NAME}"
+          # Package owner is the current user (not org)
+          gh api --method PUT "/user/packages/container/${package}/visibility" -f visibility=public
+
+      - name: Collect GHCR digests (RepoDigests)
+        run: |
+          set -euo pipefail
+          VERSION_RAW="${{ steps.vars.outputs.version_raw }}"
+          VERSION="${{ steps.vars.outputs.version }}"
+          owner_lower="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          image="ghcr.io/${owner_lower}/${IMAGE_NAME}"
+
+          out_dir="dist/digests"
+          mkdir -p "${out_dir}"
+
+          # Pull to make sure RepoDigests is populated locally
+          docker pull "${image}:${VERSION_RAW}"
+
+          docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "${image}:${VERSION_RAW}" \
+            > "${out_dir}/ghcr-digests-${VERSION}-${PLATFORM}.txt"
+          cat "${out_dir}/ghcr-digests-${VERSION}-${PLATFORM}.txt"
+
+      - name: Upload GHCR digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ghcr-digests-${{ steps.vars.outputs.version_raw }}-${{ env.PLATFORM }}
+          path: dist/digests/ghcr-digests-${{ steps.vars.outputs.version }}-${{ env.PLATFORM }}.txt
+          if-no-files-found: error
+
   publish-release-assets:
     name: Publish Release assets (.sha256 / SHA256SUMS / SBOM)
     needs: [build-jetson-arm64]
@@ -203,6 +237,12 @@ jobs:
         with:
           name: magicbox-update-${{ steps.vars.outputs.version_raw }}-${{ env.PLATFORM }}
           path: dist
+
+      - name: Download GHCR digest artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ghcr-digests-${{ steps.vars.outputs.version_raw }}-${{ env.PLATFORM }}
+          path: dist/digests
 
       - name: Generate SBOM (CycloneDX JSON) from tarball content
         run: |
@@ -250,3 +290,4 @@ jobs:
             dist/sbom-${{ steps.vars.outputs.version }}-${{ env.PLATFORM }}.cdx.json.sha256
             dist/SHA256SUMS
             dist/checksums.sha256
+            dist/digests/ghcr-digests-${{ steps.vars.outputs.version }}-${{ env.PLATFORM }}.txt

--- a/docker/README.evaluator.md
+++ b/docker/README.evaluator.md
@@ -4,6 +4,31 @@
 
 ---
 
+## GHCRイメージ（公開 / アーキ別タグ / ダイジェスト固定）
+
+- パッケージ: `ghcr.io/michihitotakami/totton-audio-system`（公開、認証不要で pull 可能）
+- サポートプラットフォーム:
+  - `linux/arm64`（Jetson Orin 系）: `MAGICBOX_IMAGE` / `USB_I2S_BRIDGE_IMAGE` / `RASPI_CONTROL_API_IMAGE`
+  - `linux/amd64`（開発PC/NVIDIA GPU）: amd64 イメージが発行されたリリースでは、`--platform=linux/amd64` を明示して pull 可能
+- タグ運用:
+  - リリースタグ: `vX.Y.Z`（推奨） / `X.Y.Z`
+  - 評価用ダイジェスト: Release アセットの `ghcr-digests-<X.Y.Z>.txt` を参照し、`@sha256:...` で pin
+  - `latest`: スモーク向け。評価時は使わず、必ずバージョンまたはダイジェストを指定
+- 例（Jetsonで digest pin する場合）:
+
+```bash
+export MAGICBOX_IMAGE=ghcr.io/michihitotakami/totton-audio-system@sha256:<jetson-digest>
+docker compose -f jetson/docker-compose.jetson.runtime.yml up -d
+```
+
+例（PC/amd64で pull できることを確認する場合。実行には NVIDIA GPU + CUDA ドライバが必要）:
+
+```bash
+docker pull --platform=linux/amd64 ghcr.io/michihitotakami/totton-audio-system@sha256:<amd64-digest>
+```
+
+---
+
 ## Jetson: runtime-only（image-based）
 
 詳細な前提・ログ取得・既知トラブル・ロールバックは、まずこちら:

--- a/docker/jetson/docker-compose.jetson.runtime.yml
+++ b/docker/jetson/docker-compose.jetson.runtime.yml
@@ -14,7 +14,10 @@
 services:
   magicbox:
     # Runtime-only distribution (GHCR)
+    # 評価時は release note 掲載の digest で pin することを推奨。
+    # 例: MAGICBOX_IMAGE=ghcr.io/michihitotakami/totton-audio-system@sha256:<digest>
     image: ${MAGICBOX_IMAGE:-ghcr.io/michihitotakami/totton-audio-system:latest}
+    platform: linux/arm64
     container_name: magicbox
     command: all
     restart: always

--- a/docs/jetson/evaluator_guide_docker.md
+++ b/docs/jetson/evaluator_guide_docker.md
@@ -13,6 +13,7 @@ Issue: #1060（Epic: #1051）
 - **NVIDIA Container Runtime が有効**
 - **音声デバイスをコンテナに渡せる**こと（`/dev/snd` が存在する）
 - インターネット接続（GHCR から image を pull するため）
+- GHCR の image は **認証不要**で pull 可能。評価では Release アセットの `ghcr-digests-<VERSION>.txt` に記載のダイジェストで **pin することを推奨**（`latest` はスモーク用）
 
 確認コマンド（例）:
 
@@ -170,6 +171,6 @@ docker compose -f jetson/docker-compose.jetson.runtime.yml down -v
 cd docker
 
 # 例: 既知のタグへ固定して起動
-MAGICBOX_IMAGE=ghcr.io/michihitotakami/totton-audio-system:<tag> \
+MAGICBOX_IMAGE=ghcr.io/michihitotakami/totton-audio-system@sha256:<digest> \
   docker compose -f jetson/docker-compose.jetson.runtime.yml up -d
 ```

--- a/docs/releases/ghcr_public.md
+++ b/docs/releases/ghcr_public.md
@@ -1,0 +1,66 @@
+# GHCR 公開確認 / タグ・ダイジェスト運用
+
+Issue: #1194（Epic: #1051）
+
+## 目的
+
+- 評価者が **認証なし**で GHCR からイメージを pull できることを確認する
+- `linux/arm64`（Jetson）と `linux/amd64`（開発PC/NVIDIA GPU, 発行済みの場合）で **同じタグ**を使えるようにし、リリースごとにダイジェストで再現性を担保する
+- Compose は `image:` 前提とし、Release アセットに含めるダイジェストで pin できるようにする
+
+## 対象パッケージ（GHCR）
+
+- `ghcr.io/michihitotakami/totton-audio-system`
+  - `magicbox` runtime（Jetson/PC 共通タグ、`linux/arm64`。`linux/amd64` は発行されたリリースで同タグを共有予定）
+  - Raspberry Pi 付帯サービス（同パッケージ内のタグで分岐）
+    - `raspi-usb-i2s-bridge-*`（`linux/arm64`）
+    - `raspi-control-api-*`（`linux/arm64`）
+
+## 公開（認証なし）確認手順
+
+以下はいずれも **docker login なし**で成功することを確認する:
+
+```bash
+# Jetson/arm64 イメージの pull（digest pin）
+docker pull --platform=linux/arm64 ghcr.io/michihitotakami/totton-audio-system@sha256:<jetson-digest>
+
+# PC/amd64 イメージの pull（digest pin、amd64 イメージを発行しているリリースのみ）
+docker pull --platform=linux/amd64 ghcr.io/michihitotakami/totton-audio-system@sha256:<amd64-digest>
+
+# Raspberry Pi 付帯サービス（arm64）
+docker pull ghcr.io/michihitotakami/totton-audio-system@sha256:<raspi-bridge-digest>
+docker pull ghcr.io/michihitotakami/totton-audio-system@sha256:<raspi-control-digest>
+```
+
+> いずれかが 401/404 になる場合、GHCR パッケージの可視性を `public` に設定する（`gh api --method PUT /user/packages/container/totton-audio-system/visibility -f visibility=public`）。
+
+## タグ / ダイジェストの運用ルール
+
+- タグ（共通）
+  - **推奨**: `vX.Y.Z`（リリースタグ） / `X.Y.Z`
+  - **スモークのみ**: `latest`（評価用には使用しない）
+- ダイジェスト
+  - リリースごとに `ghcr-digests-<X.Y.Z>.txt` を Release assets に添付する
+  - **必須**: Jetson/arm64 runtime の `RepoDigests`
+  - **あれば追記**: PC/amd64 runtime・Raspberry Pi 付帯サービスの `RepoDigests`
+- マルチアーチ
+  - 同じタグで `linux/arm64` を必須提供し、`linux/amd64` は発行済みの場合に同タグへ追加する（`docker pull --platform=...` で取得可）
+
+## Compose での固定例（ダイジェスト pin）
+
+Jetson runtime:
+
+```bash
+MAGICBOX_IMAGE=ghcr.io/michihitotakami/totton-audio-system@sha256:<jetson-digest> \
+  docker compose -f docker/jetson/docker-compose.jetson.runtime.yml up -d
+```
+
+Raspberry Pi 付帯サービス:
+
+```bash
+USB_I2S_BRIDGE_IMAGE=ghcr.io/michihitotakami/totton-audio-system@sha256:<raspi-bridge-digest> \
+RASPI_CONTROL_API_IMAGE=ghcr.io/michihitotakami/totton-audio-system@sha256:<raspi-control-digest> \
+  docker compose -f raspberry_pi/docker-compose.raspberry_pi.runtime.yml up -d
+```
+
+> `latest` は動作確認用に残すが、評価版の配布では **必ずタグまたはダイジェスト** を指定する。

--- a/docs/releases/public_repo.md
+++ b/docs/releases/public_repo.md
@@ -140,3 +140,7 @@ Private Repo の GitHub Actions で以下を行う：
 - [ ] `docs/api/openapi.json` と `docs/api/raspi_openapi.json` が最新
 - [ ] `LICENSE*` が Public に含まれている
 - [ ] OPRA 等の外部データは **データ本体ではなく** 帰属/利用条件/取得手段が明記されている
+
+## GHCR 公開確認
+
+- GHCR で配布するコンテナは `ghcr_public.md` の手順で **認証なし pull 可 / タグ・ダイジェストの運用が明確** であることを確認する

--- a/raspberry_pi/README.md
+++ b/raspberry_pi/README.md
@@ -15,11 +15,13 @@ Raspberry Pi 側の評価者導入を一本道化するためのガイドです�
 ## 起動（評価者向け / ソース不要: runtime-only）
 
 Pi では GHCR image を pull して起動します（**ソースコード不要**）。
+必ず Release アセットの `ghcr-digests-<VERSION>.txt` に記載のダイジェストで pin してください（`latest` はスモーク用途のみ）。
 
 ```bash
 #
 # NOTE: 配布された Release Notes の指定がある場合は、image を環境変数で固定してください。
-#   USB_I2S_BRIDGE_IMAGE=ghcr.io/...:<tag> RASPI_CONTROL_API_IMAGE=ghcr.io/...:<tag> \
+#   USB_I2S_BRIDGE_IMAGE=ghcr.io/...@sha256:<digest> \
+#   RASPI_CONTROL_API_IMAGE=ghcr.io/...@sha256:<digest> \
 #
 docker compose -f raspberry_pi/docker-compose.raspberry_pi.runtime.yml up -d
 docker compose -f raspberry_pi/docker-compose.raspberry_pi.runtime.yml logs -f

--- a/raspberry_pi/docker-compose.raspberry_pi.runtime.yml
+++ b/raspberry_pi/docker-compose.raspberry_pi.runtime.yml
@@ -14,7 +14,9 @@ services:
     # Runtime-only distribution (GHCR)
     # NOTE: GHCR の "package" を増やさず、既存の `totton-audio-system` をタグで分岐する想定。
     # 実際のタグは Release Notes / 配布物に合わせて上書きしてください。
+    # 例: USB_I2S_BRIDGE_IMAGE=ghcr.io/michihitotakami/totton-audio-system@sha256:<digest>
     image: ${USB_I2S_BRIDGE_IMAGE:-ghcr.io/michihitotakami/totton-audio-system:raspi-usb-i2s-bridge-latest}
+    platform: linux/arm64
     container_name: rpi-usb-i2s-bridge
     network_mode: "host"
     cap_add:
@@ -42,7 +44,9 @@ services:
       - usb-i2s-bridge-config:/var/lib/usb-i2s-bridge
 
   raspi-control-api:
+    # 例: RASPI_CONTROL_API_IMAGE=ghcr.io/michihitotakami/totton-audio-system@sha256:<digest>
     image: ${RASPI_CONTROL_API_IMAGE:-ghcr.io/michihitotakami/totton-audio-system:raspi-control-api-latest}
+    platform: linux/arm64
     container_name: rpi-control-api
     network_mode: "host"
     depends_on:


### PR DESCRIPTION
## Summary\n- GHCR 公開確認用の手順と digest pin 方針を docs/releases/ghcr_public.md に追加し、評価者向け README へ反映\n- runtime compose に platform 指定と digest 指定例を追記し、Jetson/Pi ガイドで release ダイジェストの利用を明示\n- release GHCR ビルドワークフローでパッケージを public 化し、RepoDigest を Release アセットとして公開する処理を追加\n\n## Testing\n- not run (docs/workflow only)