### PR TITLE
#1221 線形/最小位相のゲイン差調査: headroom/effective gain 計測ログ追加

### DIFF
--- a/src/daemon/audio_pipeline/headroom_controller.cpp
+++ b/src/daemon/audio_pipeline/headroom_controller.cpp
@@ -2,9 +2,42 @@
 
 #include "logging/logger.h"
 
+#include <chrono>
+#include <cstdlib>
+#include <fstream>
+#include <nlohmann/json.hpp>
 #include <utility>
 
 namespace audio_pipeline {
+namespace {
+inline int64_t debug_now_ms() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
+inline const char* debug_run_id() {
+    const char* v = std::getenv("MAGICBOX_DEBUG_RUN_ID");
+    return (v && *v) ? v : "pre-fix";
+}
+
+inline void debug_ndjson(const char* location, const char* message, const char* hypothesisId,
+                         const nlohmann::json& data) {
+    nlohmann::json payload;
+    payload["sessionId"] = "debug-session";
+    payload["runId"] = debug_run_id();
+    payload["hypothesisId"] = hypothesisId;
+    payload["location"] = location;
+    payload["message"] = message;
+    payload["data"] = data;
+    payload["timestamp"] = debug_now_ms();
+    std::ofstream ofs("/home/michihito/Working/gpu_os/.cursor/debug.log", std::ios::app);
+    if (!ofs) {
+        return;
+    }
+    ofs << payload.dump() << "\n";
+}
+}  // namespace
 
 HeadroomController::HeadroomController(HeadroomControllerDependencies deps)
     : deps_(std::move(deps)) {}
@@ -78,12 +111,27 @@ void HeadroomController::updateEffectiveGain(float headroomGain, const std::stri
     if (deps_.outputGain) {
         deps_.outputGain->store(effective, std::memory_order_relaxed);
     }
+    // #region agent log
+    debug_ndjson("src/daemon/audio_pipeline/headroom_controller.cpp:updateEffectiveGain",
+                 "Updated effective gain", "H1",
+                 {{"reason", reason},
+                  {"userGain", userGain},
+                  {"headroomGain", headroomGain},
+                  {"effectiveGain", effective}});
+    // #endregion
     LOG_INFO("Gain [{}]: user {:.4f} * headroom {:.4f} = {:.4f}", reason, userGain, headroomGain,
              effective);
 }
 
 void HeadroomController::applyHeadroomForPath(const std::string& path,
                                               const std::string& reason) const {
+    // #region agent log
+    debug_ndjson("src/daemon/audio_pipeline/headroom_controller.cpp:applyHeadroomForPath",
+                 "Applying headroom for filter path", "H3",
+                 {{"reason", reason},
+                  {"path", path},
+                  {"userGain", (deps_.config) ? deps_.config->gain : 1.0f}});
+    // #endregion
     if (path.empty()) {
         LOG_WARN("Headroom [{}]: empty filter path, falling back to unity gain", reason);
         updateEffectiveGain(1.0f, reason);
@@ -97,6 +145,17 @@ void HeadroomController::applyHeadroomForPath(const std::string& path,
     }
 
     FilterHeadroomInfo info = deps_.headroomCache->get(path);
+    // #region agent log
+    debug_ndjson("src/daemon/audio_pipeline/headroom_controller.cpp:applyHeadroomForPath",
+                 "Headroom cache result", "H1",
+                 {{"reason", reason},
+                  {"path", path},
+                  {"metadataFound", info.metadataFound},
+                  {"maxCoefficient", info.maxCoefficient},
+                  {"l1Norm", info.l1Norm},
+                  {"safeGain", info.safeGain},
+                  {"targetPeak", info.targetPeak}});
+    // #endregion
     updateEffectiveGain(info.safeGain, reason);
 
     if (!info.metadataFound) {


### PR DESCRIPTION
Fixes #1221

## 目的
線形位相/最小位相で音量が変わる現象を、実行ログ（NDJSON）で切り分け可能にする。

## 変更点
- フェーズ切替要求（ZMQ）をログ
- headroom適用開始（path/reason）をログ
- フィルタ係数メタデータ読込（maxCoefficient等）をログ
- safeGain算出結果をログ
- effective gain更新（userGain×headroomGain）をログ

ログ出力先: `/home/michihito/Working/gpu_os/.cursor/debug.log`
runId: 環境変数 `MAGICBOX_DEBUG_RUN_ID` があればそれを使用（なければ `pre-fix`）

## 確認手順
1) daemon起動
2) minimum→linear→minimum と切替
3) `debug.log` の `maxCoefficient/safeGain/effectiveGain` を比較
