### PR TITLE
#1229 De-Limiterチャンク長を4秒に合わせる

### DIFF
--- a/config.json
+++ b/config.json
@@ -39,7 +39,7 @@
   "delimiter": {
     "enabled": false,
     "backend": "ort",
-    "chunkSec": 6.0,
+    "chunkSec": 4.0,
     "overlapSec": 0.25,
     "expectedSampleRate": 44100,
     "ort": {

--- a/config_samples/delimiter/delimiter_44k.json
+++ b/config_samples/delimiter/delimiter_44k.json
@@ -40,7 +40,7 @@
   "delimiter": {
     "enabled": true,
     "backend": "ort",
-    "chunkSec": 6.0,
+    "chunkSec": 4.0,
     "overlapSec": 0.25,
     "expectedSampleRate": 44100,
     "ort": {

--- a/config_samples/delimiter/delimiter_48k_resample.json
+++ b/config_samples/delimiter/delimiter_48k_resample.json
@@ -40,7 +40,7 @@
   "delimiter": {
     "enabled": true,
     "backend": "ort",
-    "chunkSec": 6.0,
+    "chunkSec": 4.0,
     "overlapSec": 0.25,
     "expectedSampleRate": 44100,
     "ort": {

--- a/docs/releases/delimiter_assets_1098.md
+++ b/docs/releases/delimiter_assets_1098.md
@@ -47,7 +47,7 @@ uv run python scripts/delimiter/offline_wav_to_wav.py \
   --output /tmp/output.wav \
   --backend delimiter \
   --expected-sample-rate 44100 \
-  --chunk-sec 6.0 \
+  --chunk-sec 4.0 \
   --overlap-sec 0.25 \
   --resample-back \
   --debug-dir /tmp/delimiter_debug \
@@ -67,7 +67,7 @@ uv run python scripts/delimiter/onnx_wav_to_wav.py \
   --model data/delimiter/weights/jeonchangbin49-de-limiter/44100/delimiter.onnx \
   --provider cpu \
   --expected-sample-rate 44100 \
-  --chunk-sec 6.0 \
+  --chunk-sec 4.0 \
   --overlap-sec 0.25 \
   --resample-back \
   --report /tmp/delimiter_report_ort.json

--- a/include/core/config_loader.h
+++ b/include/core/config_loader.h
@@ -120,7 +120,7 @@ struct AppConfig {
         std::string backend = "bypass";
 
         // High-latency worker chunking parameters (Fix #1009 / #1010)
-        float chunkSec = 6.0f;
+        float chunkSec = 4.0f;
         float overlapSec = 0.25f;
 
         struct OrtConfig {

--- a/scripts/delimiter/benchmark_streaming.py
+++ b/scripts/delimiter/benchmark_streaming.py
@@ -453,7 +453,7 @@ def parse_args() -> argparse.Namespace:
         "--model", type=Path, required=True, help="Path to delimiter ONNX model"
     )
     p.add_argument("--provider", choices=["cpu", "cuda", "tensorrt"], default="cpu")
-    p.add_argument("--chunk-sec", type=float, default=6.0, help="Chunk size in seconds")
+    p.add_argument("--chunk-sec", type=float, default=4.0, help="Chunk size in seconds")
     p.add_argument(
         "--overlap-sec", type=float, default=0.25, help="Crossfade overlap seconds"
     )

--- a/scripts/delimiter/offline_wav_to_wav.py
+++ b/scripts/delimiter/offline_wav_to_wav.py
@@ -408,7 +408,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--chunk-sec",
         type=float,
-        default=6.0,
+        default=4.0,
         help="Chunk size in seconds (0 to disable chunking)",
     )
     p.add_argument("--overlap-sec", type=float, default=0.25, help="Crossfade overlap")

--- a/scripts/delimiter/onnx_wav_to_wav.py
+++ b/scripts/delimiter/onnx_wav_to_wav.py
@@ -198,7 +198,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--chunk-sec",
         type=float,
-        default=6.0,
+        default=4.0,
         help="Chunk size in seconds (0 to disable chunking)",
     )
     p.add_argument("--overlap-sec", type=float, default=0.25, help="Crossfade overlap")

--- a/src/delimiter_wav_to_wav.cpp
+++ b/src/delimiter_wav_to_wav.cpp
@@ -30,7 +30,7 @@ struct Args {
     std::string outputPath;
     std::string modelPath;
     std::string provider = "cuda";
-    float chunkSec = 6.0f;
+    float chunkSec = 4.0f;
     float overlapSec = 0.25f;
     int expectedSampleRate = 44100;
     int intraOpThreads = 0;
@@ -44,7 +44,7 @@ void printUsage(const char* prog) {
               << "  --output <path>      Output WAV file (required)\n"
               << "  --model <path>       ONNX model path (required)\n"
               << "  --provider <name>    ORT provider: cpu, cuda, tensorrt (default: cuda)\n"
-              << "  --chunk-sec <float>  Chunk size in seconds (default: 6.0)\n"
+              << "  --chunk-sec <float>  Chunk size in seconds (default: 4.0)\n"
               << "  --overlap-sec <float> Overlap size in seconds (default: 0.25)\n"
               << "  --sample-rate <int>  Expected sample rate (default: 44100)\n"
               << "  --threads <int>      Intra-op threads (default: 0 = auto)\n"

--- a/tests/python/test_delimiter_offline_poc.py
+++ b/tests/python/test_delimiter_offline_poc.py
@@ -41,7 +41,7 @@ def test_delimiter_offline_poc_bypass_smoke(
             "--backend",
             "bypass",
             "--chunk-sec",
-            "6.0",
+            "4.0",
             "--overlap-sec",
             "0.25",
             "--resample-back",


### PR DESCRIPTION
## Summary
- De-LimiterのchunkSecデフォルトを4.0秒に統一（C++ CLI/ORT/PyTorchオフラインツール/ベンチ）
- config.jsonとサンプル、ドキュメントの記述を公式4秒チャンクに合わせて更新
- offline PoCテストの引数を4秒に変更し、公式仕様に整合

## Testing
- cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
- git push（pre-push hooks: clang-tidy, diff-based-tests, Vulkan build など）