### PR TITLE
#1256 ローカル絶対パスの除去

### DIFF
--- a/docs/setup/build.md
+++ b/docs/setup/build.md
@@ -220,7 +220,7 @@ De-Limiter（AI Loudness Care）機能を使用する場合、ONNX Runtimeをソ
 
 ```bash
 # ビルドディレクトリをクリーン
-rm -rf /home/michihito/Working/onnxruntime/build
+rm -rf "${HOME}/onnxruntime/build"
 
 # シンプルなビルド（disable_contrib_ops を外す）
 ./build.sh --config Release --update --build --parallel 1 \
@@ -253,7 +253,7 @@ rm -rf /home/michihito/Working/onnxruntime/build
 cmake -B build \
   -DCMAKE_BUILD_TYPE=Release \
   -DDELIMITER_ENABLE_ORT=ON \
-  -DONNXRUNTIME_ROOT=/home/michihito/Working/onnxruntime/build/Release
+  -DONNXRUNTIME_ROOT=${HOME}/onnxruntime/build/Release
 
 cmake --build build -j$(nproc)
 ```

--- a/scripts/testing/test_eq_effect.py
+++ b/scripts/testing/test_eq_effect.py
@@ -191,7 +191,9 @@ def main():
 
     eq_file = project_dir / "data" / "EQ" / "Sample_EQ.txt"
     if not eq_file.exists():
-        eq_file = Path("/home/michihito/Working/gpu_os/data/EQ/Sample_EQ.txt")
+        raise FileNotFoundError(
+            f"EQ profile not found at {eq_file}. Place Sample_EQ.txt under data/EQ."
+        )
 
     fs = 44100
 

--- a/src/daemon/audio_pipeline/switch_actions.cpp
+++ b/src/daemon/audio_pipeline/switch_actions.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <mutex>
@@ -21,7 +22,8 @@ namespace audio_pipeline {
 // #region agent log
 static void agent_debug_log(const char* location, const char* message, const std::string& dataJson,
                             const char* hypothesisId) {
-    std::ofstream ofs("/home/michihito/Working/gpu_os/.cursor/debug.log", std::ios::app);
+    const auto logPath = std::filesystem::temp_directory_path() / "gpu_os_agent_debug.log";
+    std::ofstream ofs(logPath, std::ios::app);
     if (!ofs.is_open()) {
         return;
     }

--- a/src/test_eq.cpp
+++ b/src/test_eq.cpp
@@ -92,7 +92,7 @@ int main(int argc, char* argv[]) {
     std::cout << "========================================" << '\n';
 
     std::string filterPath = "data/coefficients/filter_44k_16x_2m_linear_phase.bin";
-    std::string eqPath = "/home/michihito/Working/gpu_os/data/EQ/Sample_EQ.txt";
+    std::string eqPath = "data/EQ/Sample_EQ.txt";
 
     if (argc > 1) {
         eqPath = argv[1];


### PR DESCRIPTION
## Summary
- Fixes #1256
- EQテスト用のデフォルトパスをリポジトリ内の相対パスに統一
- agentデバッグログの出力先を一時ディレクトリに変更し環境依存を排除
- ONNX Runtimeビルド手順のパス指定を/home/michihito参照に置き換え

## Testing
- uv run pre-commit run --hook-stage pre-push