### PR TITLE
#1265 CODE_OF_CONDUCT.md 追加

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -65,7 +65,7 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the project maintainers:
 
 - GitHub: https://github.com/michihitoTakami
-- Repository Issues: https://github.com/michihitoTakami/michy_os/issues
+- GitHub Discussions: https://github.com/michihitoTakami/michy_os/discussions
 
 All complaints will be reviewed and investigated promptly and fairly.
 
@@ -142,7 +142,7 @@ available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.ht
 嫌がらせや不適切な行為を見聞きした場合は、以下へ報告してください:
 
 - GitHub: https://github.com/michihitoTakami
-- リポジトリのIssue: https://github.com/michihitoTakami/michy_os/issues
+- GitHub Discussions: https://github.com/michihitoTakami/michy_os/discussions
 
 すべての報告は速やかに、かつ公平に確認・調査します。
 


### PR DESCRIPTION
Fixes #1265\n\n- 行動規範（Contributor Covenant 2.1）を追加\n- 報告先（GitHub / Issues）を明記