### PR TITLE
Fix ZeroMQ IPC path mismatch between Python and C++

### DIFF
--- a/web/constants.py
+++ b/web/constants.py
@@ -28,7 +28,7 @@ LINEAR_PHASE_WARNING = f"線形位相: {LINEAR_PHASE_DESCRIPTION}。約0.45秒�
 # ZeroMQ
 # ============================================================================
 
-ZEROMQ_IPC_PATH = "ipc:///tmp/totton_audio.sock"
+ZEROMQ_IPC_PATH = "ipc:///tmp/gpu_os.sock"
 
 # ============================================================================
 # Daemon


### PR DESCRIPTION
Python (Web UI) was trying to connect to ipc:///tmp/totton_audio.sock while C++ daemon binds to ipc:///tmp/gpu_os.sock.

This caused all ZeroMQ commands (crossfeed/status, daemon/phase-type, etc.) to timeout with 504 Gateway Timeout.

Changed: web/constants.py ZEROMQ_IPC_PATH
- Before: ipc:///tmp/totton_audio.sock
- After:  ipc:///tmp/gpu_os.sock (matches C++ daemon_constants.h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)